### PR TITLE
feat(tenancy): add OIDC control plane and tenant selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The current implementation supports:
 - Unit tests and random-port HTTP integration tests
 - PostgreSQL/PostGIS persistence managed by Flyway
 - RFC 9457 validation errors, correlation IDs, and health probes
+- OIDC-protected tenant provisioning and operator memberships
 
 The production roadmap includes:
 
@@ -120,24 +121,21 @@ Hibernate validates the resulting schema and never creates or drops production t
 
 ## API
 
-The current unversioned prototype endpoints are temporary:
+The legacy prototype endpoints are blocked by the security policy and will be removed. The first
+versioned endpoint is:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `POST` | `/cities` | Register a city |
-| `GET` | `/cities` | List cities |
-| `POST` | `/cabs` | Register a cab |
-| `POST` | `/cabs/{cabId}` | Update a cab |
-| `GET` | `/cabs` | List cabs |
-| `POST` | `/bookings` | Create a booking |
-| `GET` | `/bookings` | List bookings |
+| `POST` | `/api/v1/tenants` | Provision a tenant; requires `platform.admin` scope |
+| `GET` | `/api/v1/tenants` | List the authenticated account's tenant memberships |
 
 Operational probes are available at `/actuator/health/liveness` and
 `/actuator/health/readiness`. API responses include `X-Correlation-ID`; clients may supply this
 header to correlate a request across logs and downstream calls.
 
-These routes will be replaced by the authenticated `/api/v1` marketplace contract. Consumers
-must not rely on the prototype API.
+The backend validates OIDC issuer, audience, signature, expiry, and subject. Configure
+`OIDC_ISSUER_URI` and `OIDC_AUDIENCE`; authorization roles are stored in tenant memberships rather
+than trusted solely from bearer-token claims.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,15 @@ versioned endpoint is:
 | --- | --- | --- |
 | `POST` | `/api/v1/tenants` | Provision a tenant; requires `platform.admin` scope |
 | `GET` | `/api/v1/tenants` | List the authenticated account's tenant memberships |
+| `GET` | `/api/v1/current-tenant` | Inspect the selected tenant context |
 
 Operational probes are available at `/actuator/health/liveness` and
 `/actuator/health/readiness`. API responses include `X-Correlation-ID`; clients may supply this
 header to correlate a request across logs and downstream calls.
+
+Tenant-owned requests require `X-Tenant-ID`. The header is only a selector: the backend verifies
+that the authenticated OIDC identity has an active database membership before binding tenant roles
+to the request. Missing, malformed, unknown, and cross-tenant selections are rejected.
 
 The backend validates OIDC issuer, audience, signature, expiry, and subject. Configure
 `OIDC_ISSUER_URI` and `OIDC_AUDIENCE`; authorization roles are stored in tenant memberships rather

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,9 @@
             <exclude>**/entity/**</exclude>
             <exclude>**/mapper/**</exclude>
             <exclude>**/model/**</exclude>
+            <exclude>**/internal/persistence/**</exclude>
+            <exclude>**/internal/web/**</exclude>
+            <exclude>**/*Configuration.class</exclude>
           </excludes>
         </configuration>
         <executions>
@@ -117,6 +120,14 @@
     </dependency>
     <dependency>
       <artifactId>spring-boot-starter-actuator</artifactId>
+      <groupId>org.springframework.boot</groupId>
+    </dependency>
+    <dependency>
+      <artifactId>spring-boot-starter-security</artifactId>
+      <groupId>org.springframework.boot</groupId>
+    </dependency>
+    <dependency>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
       <groupId>org.springframework.boot</groupId>
     </dependency>
     <dependency>

--- a/src/main/java/in/rsh/cab/CabApplication.java
+++ b/src/main/java/in/rsh/cab/CabApplication.java
@@ -2,12 +2,8 @@ package in.rsh.cab;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EnableJpaRepositories(basePackages = "in.rsh.cab.repository")
-@EntityScan(basePackages = "in.rsh.cab.entity")
 public class CabApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package in.rsh.cab.exception;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -31,6 +32,12 @@ public class GlobalExceptionHandler {
   @ExceptionHandler({IllegalArgumentException.class, InvalidRequestException.class})
   public ResponseEntity<ProblemDetail> handleBadRequest(RuntimeException exception) {
     return problem(HttpStatus.BAD_REQUEST, "Invalid request", exception.getMessage(), "invalid-request");
+  }
+
+  @ExceptionHandler(TenantAccessDeniedException.class)
+  public ResponseEntity<ProblemDetail> handleTenantAccessDenied(
+      TenantAccessDeniedException exception) {
+    return problem(HttpStatus.FORBIDDEN, "Tenant access denied", exception.getMessage(), "tenant-access-denied");
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
+++ b/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
@@ -1,0 +1,33 @@
+package in.rsh.cab.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfiguration {
+
+  @Bean
+  SecurityFilterChain apiSecurity(HttpSecurity http) throws Exception {
+    return http.csrf(csrf -> csrf.disable())
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            requests ->
+                requests
+                    .requestMatchers("/actuator/health/**")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/tenants")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/tenants")
+                    .hasAuthority("SCOPE_platform.admin")
+                    .anyRequest()
+                    .denyAll())
+        .oauth2ResourceServer(resourceServer -> resourceServer.jwt(jwt -> {}))
+        .build();
+  }
+}

--- a/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
+++ b/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
@@ -25,6 +25,8 @@ public class SecurityConfiguration {
                     .authenticated()
                     .requestMatchers(HttpMethod.POST, "/api/v1/tenants")
                     .hasAuthority("SCOPE_platform.admin")
+                    .requestMatchers("/api/v1/**")
+                    .authenticated()
                     .anyRequest()
                     .denyAll())
         .oauth2ResourceServer(resourceServer -> resourceServer.jwt(jwt -> {}))

--- a/src/main/java/in/rsh/cab/tenancy/TenantAccessDeniedException.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantAccessDeniedException.java
@@ -1,0 +1,7 @@
+package in.rsh.cab.tenancy;
+
+public class TenantAccessDeniedException extends RuntimeException {
+  public TenantAccessDeniedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/TenantContext.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantContext.java
@@ -1,0 +1,30 @@
+package in.rsh.cab.tenancy;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record TenantContext(
+    UUID tenantId, UUID accountId, UUID membershipId, Set<TenantRole> roles) {
+
+  private static final ThreadLocal<TenantContext> CURRENT = new ThreadLocal<>();
+
+  public TenantContext {
+    roles = Set.copyOf(roles);
+  }
+
+  public static TenantContext require() {
+    TenantContext context = CURRENT.get();
+    if (context == null) {
+      throw new IllegalStateException("Tenant context is not available");
+    }
+    return context;
+  }
+
+  public static void set(TenantContext context) {
+    CURRENT.set(context);
+  }
+
+  public static void clear() {
+    CURRENT.remove();
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/TenantRole.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantRole.java
@@ -1,0 +1,11 @@
+package in.rsh.cab.tenancy;
+
+public enum TenantRole {
+  TENANT_ADMIN,
+  DISPATCHER,
+  RIDER,
+  DRIVER,
+  SUPPORT,
+  SAFETY,
+  FINANCE
+}

--- a/src/main/java/in/rsh/cab/tenancy/TenantService.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantService.java
@@ -1,0 +1,101 @@
+package in.rsh.cab.tenancy;
+
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.tenancy.internal.persistence.TenantEntity;
+import in.rsh.cab.tenancy.internal.persistence.TenantMembershipEntity;
+import in.rsh.cab.tenancy.internal.persistence.TenantMembershipRepository;
+import in.rsh.cab.tenancy.internal.persistence.TenantRepository;
+import in.rsh.cab.tenancy.internal.persistence.UserAccountEntity;
+import in.rsh.cab.tenancy.internal.persistence.UserAccountRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TenantService {
+
+  private final TenantRepository tenants;
+  private final UserAccountRepository accounts;
+  private final TenantMembershipRepository memberships;
+  private final Clock clock;
+
+  @Autowired
+  public TenantService(
+      TenantRepository tenants,
+      UserAccountRepository accounts,
+      TenantMembershipRepository memberships) {
+    this(tenants, accounts, memberships, Clock.systemUTC());
+  }
+
+  TenantService(
+      TenantRepository tenants,
+      UserAccountRepository accounts,
+      TenantMembershipRepository memberships,
+      Clock clock) {
+    this.tenants = tenants;
+    this.accounts = accounts;
+    this.memberships = memberships;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public TenantSummary create(
+      String issuer,
+      String subject,
+      String email,
+      String actorName,
+      String slug,
+      String displayName,
+      String currency,
+      String timezone) {
+    if (tenants.existsBySlug(slug)) {
+      throw new InvalidRequestException("Tenant slug is already in use");
+    }
+    Instant now = clock.instant();
+    UserAccountEntity account =
+        accounts
+            .findByIssuerAndSubject(issuer, subject)
+            .orElseGet(
+                () ->
+                    accounts.save(
+                        new UserAccountEntity(
+                            UUID.randomUUID(), issuer, subject, email, actorName, now)));
+    TenantEntity tenant =
+        tenants.save(
+            new TenantEntity(
+                UUID.randomUUID(), slug, displayName, currency.toUpperCase(), timezone, now));
+    Set<TenantRole> roles = Set.of(TenantRole.TENANT_ADMIN);
+    memberships.save(
+        new TenantMembershipEntity(
+            UUID.randomUUID(), tenant.getId(), account.getId(), roles, now));
+    return summary(tenant, roles);
+  }
+
+  @Transactional(readOnly = true)
+  public List<TenantSummary> findForIdentity(String issuer, String subject) {
+    return accounts
+        .findByIssuerAndSubject(issuer, subject)
+        .map(
+            account ->
+                memberships.findByUserAccountIdAndStatus(account.getId(), "ACTIVE").stream()
+                    .map(
+                        membership ->
+                            tenants
+                                .findById(membership.getTenantId())
+                                .map(tenant -> summary(tenant, membership.getRoles()))
+                                .orElse(null))
+                    .filter(java.util.Objects::nonNull)
+                    .toList())
+        .orElseGet(List::of);
+  }
+
+  private TenantSummary summary(TenantEntity tenant, Set<TenantRole> roles) {
+    return new TenantSummary(
+        tenant.getId(), tenant.getSlug(), tenant.getDisplayName(), tenant.getStatus(), Set.copyOf(roles));
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/TenantService.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantService.java
@@ -94,6 +94,21 @@ public class TenantService {
         .orElseGet(List::of);
   }
 
+  @Transactional(readOnly = true)
+  public TenantContext authorize(String issuer, String subject, UUID tenantId) {
+    UserAccountEntity account =
+        accounts
+            .findByIssuerAndSubject(issuer, subject)
+            .filter(candidate -> "ACTIVE".equals(candidate.getStatus()))
+            .orElseThrow(() -> new TenantAccessDeniedException("Active account is required"));
+    TenantMembershipEntity membership =
+        memberships
+            .findByTenantIdAndUserAccountIdAndStatus(tenantId, account.getId(), "ACTIVE")
+            .orElseThrow(() -> new TenantAccessDeniedException("Active tenant membership is required"));
+    return new TenantContext(
+        tenantId, account.getId(), membership.getId(), membership.getRoles());
+  }
+
   private TenantSummary summary(TenantEntity tenant, Set<TenantRole> roles) {
     return new TenantSummary(
         tenant.getId(), tenant.getSlug(), tenant.getDisplayName(), tenant.getStatus(), Set.copyOf(roles));

--- a/src/main/java/in/rsh/cab/tenancy/TenantSummary.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantSummary.java
@@ -1,0 +1,6 @@
+package in.rsh.cab.tenancy;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record TenantSummary(UUID id, String slug, String displayName, String status, Set<TenantRole> roles) {}

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantEntity.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantEntity.java
@@ -1,0 +1,57 @@
+package in.rsh.cab.tenancy.internal.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tenants")
+@Getter
+@NoArgsConstructor
+public class TenantEntity {
+
+  @Id private UUID id;
+
+  @Column(nullable = false, unique = true)
+  private String slug;
+
+  @Column(name = "display_name", nullable = false)
+  private String displayName;
+
+  @Column(nullable = false)
+  private String status;
+
+  @Column(name = "default_currency", nullable = false, length = 3)
+  private String defaultCurrency;
+
+  @Column(nullable = false)
+  private String timezone;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  public TenantEntity(
+      UUID id,
+      String slug,
+      String displayName,
+      String defaultCurrency,
+      String timezone,
+      Instant now) {
+    this.id = id;
+    this.slug = slug;
+    this.displayName = displayName;
+    this.status = "ACTIVE";
+    this.defaultCurrency = defaultCurrency;
+    this.timezone = timezone;
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantMembershipEntity.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantMembershipEntity.java
@@ -1,0 +1,51 @@
+package in.rsh.cab.tenancy.internal.persistence;
+
+import in.rsh.cab.tenancy.TenantRole;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tenant_memberships")
+@Getter
+@NoArgsConstructor
+public class TenantMembershipEntity {
+
+  @Id private UUID id;
+  @Column(name = "tenant_id", nullable = false) private UUID tenantId;
+  @Column(name = "user_account_id", nullable = false) private UUID userAccountId;
+  @Column(nullable = false) private String status;
+  @Column(name = "created_at", nullable = false) private Instant createdAt;
+  @Column(name = "updated_at", nullable = false) private Instant updatedAt;
+
+  @ElementCollection
+  @CollectionTable(
+      name = "tenant_membership_roles",
+      joinColumns = @JoinColumn(name = "membership_id"))
+  @Column(name = "role", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Set<TenantRole> roles = new HashSet<>();
+
+  public TenantMembershipEntity(
+      UUID id, UUID tenantId, UUID userAccountId, Set<TenantRole> roles, Instant now) {
+    this.id = id;
+    this.tenantId = tenantId;
+    this.userAccountId = userAccountId;
+    this.status = "ACTIVE";
+    this.roles.addAll(roles);
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantMembershipRepository.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantMembershipRepository.java
@@ -1,0 +1,17 @@
+package in.rsh.cab.tenancy.internal.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantMembershipRepository extends JpaRepository<TenantMembershipEntity, UUID> {
+
+  @EntityGraph(attributePaths = "roles")
+  List<TenantMembershipEntity> findByUserAccountIdAndStatus(UUID userAccountId, String status);
+
+  @EntityGraph(attributePaths = "roles")
+  Optional<TenantMembershipEntity> findByTenantIdAndUserAccountIdAndStatus(
+      UUID tenantId, UUID userAccountId, String status);
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantRepository.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantRepository.java
@@ -1,0 +1,8 @@
+package in.rsh.cab.tenancy.internal.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantRepository extends JpaRepository<TenantEntity, UUID> {
+  boolean existsBySlug(String slug);
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/UserAccountEntity.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/UserAccountEntity.java
@@ -1,0 +1,38 @@
+package in.rsh.cab.tenancy.internal.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_accounts")
+@Getter
+@NoArgsConstructor
+public class UserAccountEntity {
+
+  @Id private UUID id;
+  @Column(nullable = false) private String issuer;
+  @Column(nullable = false) private String subject;
+  private String email;
+  @Column(name = "display_name") private String displayName;
+  @Column(nullable = false) private String status;
+  @Column(name = "created_at", nullable = false) private Instant createdAt;
+  @Column(name = "updated_at", nullable = false) private Instant updatedAt;
+
+  public UserAccountEntity(
+      UUID id, String issuer, String subject, String email, String displayName, Instant now) {
+    this.id = id;
+    this.issuer = issuer;
+    this.subject = subject;
+    this.email = email;
+    this.displayName = displayName;
+    this.status = "ACTIVE";
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/UserAccountRepository.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/UserAccountRepository.java
@@ -1,0 +1,9 @@
+package in.rsh.cab.tenancy.internal.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccountEntity, UUID> {
+  Optional<UserAccountEntity> findByIssuerAndSubject(String issuer, String subject);
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/CurrentTenantController.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/CurrentTenantController.java
@@ -1,0 +1,16 @@
+package in.rsh.cab.tenancy.internal.web;
+
+import in.rsh.cab.tenancy.TenantContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/current-tenant")
+public class CurrentTenantController {
+
+  @GetMapping
+  public TenantContext current() {
+    return TenantContext.require();
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/TenantController.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/TenantController.java
@@ -1,0 +1,56 @@
+package in.rsh.cab.tenancy.internal.web;
+
+import in.rsh.cab.tenancy.TenantService;
+import in.rsh.cab.tenancy.TenantSummary;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants")
+public class TenantController {
+
+  private final TenantService tenantService;
+
+  public TenantController(TenantService tenantService) {
+    this.tenantService = tenantService;
+  }
+
+  @PostMapping
+  public ResponseEntity<TenantSummary> create(
+      @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody CreateTenantRequest request) {
+    TenantSummary tenant =
+        tenantService.create(
+            jwt.getIssuer().toString(),
+            jwt.getSubject(),
+            jwt.getClaimAsString("email"),
+            jwt.getClaimAsString("name"),
+            request.slug(),
+            request.displayName(),
+            request.defaultCurrency(),
+            request.timezone());
+    return ResponseEntity.created(URI.create("/api/v1/tenants/" + tenant.id())).body(tenant);
+  }
+
+  @GetMapping
+  public List<TenantSummary> list(@AuthenticationPrincipal Jwt jwt) {
+    return tenantService.findForIdentity(jwt.getIssuer().toString(), jwt.getSubject());
+  }
+
+  public record CreateTenantRequest(
+      @NotBlank @Pattern(regexp = "^[a-z0-9]+(?:-[a-z0-9]+)*$") @Size(max = 63) String slug,
+      @NotBlank @Size(max = 120) String displayName,
+      @NotBlank @Pattern(regexp = "^[A-Z]{3}$") String defaultCurrency,
+      @NotBlank @Size(max = 64) String timezone) {}
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/TenantSelectionInterceptor.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/TenantSelectionInterceptor.java
@@ -1,0 +1,50 @@
+package in.rsh.cab.tenancy.internal.web;
+
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class TenantSelectionInterceptor implements HandlerInterceptor {
+
+  public static final String TENANT_HEADER = "X-Tenant-ID";
+  private final TenantService tenantService;
+
+  public TenantSelectionInterceptor(TenantService tenantService) {
+    this.tenantService = tenantService;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    String value = request.getHeader(TENANT_HEADER);
+    if (value == null || value.isBlank()) {
+      throw new InvalidRequestException(TENANT_HEADER + " header is required");
+    }
+    UUID tenantId;
+    try {
+      tenantId = UUID.fromString(value);
+    } catch (IllegalArgumentException exception) {
+      throw new InvalidRequestException(TENANT_HEADER + " must be a UUID");
+    }
+    Authentication authentication =
+        org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+    Jwt jwt = (Jwt) authentication.getPrincipal();
+    TenantContext.set(
+        tenantService.authorize(jwt.getIssuer().toString(), jwt.getSubject(), tenantId));
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception exception) {
+    TenantContext.clear();
+  }
+}

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/TenantWebConfiguration.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/TenantWebConfiguration.java
@@ -1,0 +1,23 @@
+package in.rsh.cab.tenancy.internal.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class TenantWebConfiguration implements WebMvcConfigurer {
+
+  private final TenantSelectionInterceptor tenantSelectionInterceptor;
+
+  public TenantWebConfiguration(TenantSelectionInterceptor tenantSelectionInterceptor) {
+    this.tenantSelectionInterceptor = tenantSelectionInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry
+        .addInterceptor(tenantSelectionInterceptor)
+        .addPathPatterns("/api/v1/**")
+        .excludePathPatterns("/api/v1/tenants");
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ spring.lifecycle.timeout-per-shutdown-phase=20s
 management.endpoint.health.probes.enabled=true
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=never
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${OIDC_ISSUER_URI:http://localhost:8081/realms/cab}
+spring.security.oauth2.resourceserver.jwt.audiences=${OIDC_AUDIENCE:cab-api}

--- a/src/main/resources/db/migration/V2__tenant_identity.sql
+++ b/src/main/resources/db/migration/V2__tenant_identity.sql
@@ -1,0 +1,41 @@
+CREATE TABLE tenants (
+    id uuid PRIMARY KEY,
+    slug varchar(63) NOT NULL UNIQUE,
+    display_name varchar(120) NOT NULL,
+    status varchar(32) NOT NULL,
+    default_currency varchar(3) NOT NULL,
+    timezone varchar(64) NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT chk_tenant_slug CHECK (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$')
+);
+
+CREATE TABLE user_accounts (
+    id uuid PRIMARY KEY,
+    issuer varchar(255) NOT NULL,
+    subject varchar(255) NOT NULL,
+    email varchar(320),
+    display_name varchar(120),
+    status varchar(32) NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_user_account_identity UNIQUE (issuer, subject)
+);
+
+CREATE TABLE tenant_memberships (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    user_account_id uuid NOT NULL REFERENCES user_accounts(id),
+    status varchar(32) NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_tenant_membership UNIQUE (tenant_id, user_account_id)
+);
+
+CREATE TABLE tenant_membership_roles (
+    membership_id uuid NOT NULL REFERENCES tenant_memberships(id) ON DELETE CASCADE,
+    role varchar(32) NOT NULL,
+    PRIMARY KEY (membership_id, role)
+);
+
+CREATE INDEX idx_memberships_account ON tenant_memberships (user_account_id, status);

--- a/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
@@ -72,11 +72,20 @@ class MarketplaceHttpIT {
     assertEquals(201, created.statusCode());
     JsonObject tenant = JsonParser.parseString(created.body()).getAsJsonObject();
     assertEquals("city-cabs", tenant.get("slug").getAsString());
+    String tenantId = tenant.get("id").getAsString();
 
     HttpResponse<String> listed = getWithToken("/api/v1/tenants");
     assertEquals(200, listed.statusCode());
     JsonArray tenants = JsonParser.parseString(listed.body()).getAsJsonArray();
     assertEquals(1, tenants.size());
+
+    assertEquals(400, getWithToken("/api/v1/current-tenant").statusCode());
+    HttpResponse<String> current = getWithTenant("/api/v1/current-tenant", tenantId, "platform-admin");
+    assertEquals(200, current.statusCode());
+    assertTrue(current.body().contains(tenantId));
+    assertEquals(
+        403,
+        getWithTenant("/api/v1/current-tenant", tenantId, "unknown-user").statusCode());
   }
 
   private HttpResponse<String> post(String path, String body) throws Exception {
@@ -119,6 +128,18 @@ class MarketplaceHttpIT {
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
+  private HttpResponse<String> getWithTenant(String path, String tenantId, String token)
+      throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(uri(path))
+            .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + token)
+            .header("X-Tenant-ID", tenantId)
+            .GET()
+            .build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
   private URI uri(String path) {
     return URI.create("http://localhost:" + port + path);
   }
@@ -133,7 +154,7 @@ class MarketplaceHttpIT {
           Jwt.withTokenValue(token)
               .header("alg", "none")
               .issuer("https://issuer.example")
-              .subject("platform-admin")
+              .subject(token)
               .claim("scope", "platform.admin")
               .claim("email", "admin@example.com")
               .claim("name", "Platform Admin")

--- a/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
@@ -13,7 +13,13 @@ import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -23,6 +29,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(MarketplaceHttpIT.TestJwtConfiguration.class)
 class MarketplaceHttpIT {
 
   @Container
@@ -51,41 +58,45 @@ class MarketplaceHttpIT {
     assertEquals(200, health.statusCode());
     assertTrue(health.body().contains("UP"));
 
-    HttpResponse<String> invalidCity = post("/cities", "{\"name\":\"\"}");
-    assertEquals(400, invalidCity.statusCode());
-    assertTrue(invalidCity.headers().firstValue("Content-Type").orElse("").contains("problem+json"));
-    assertTrue(invalidCity.body().contains("validation-failed"));
-    assertTrue(invalidCity.headers().firstValue("X-Correlation-ID").isPresent());
+    assertEquals(401, postWithoutToken("/api/v1/tenants", "{}").statusCode());
+    assertEquals(403, post("/cities", "{\"name\":\"BLR\"}").statusCode());
 
-    assertEquals(200, post("/cities", "{\"name\":\"BLR\",\"state\":\"KA\"}").statusCode());
-    assertEquals(200, post("/cities", "{\"name\":\"MUM\",\"state\":\"MH\"}").statusCode());
-    assertEquals(
-        200,
-        post("/cabs", "{\"cityId\":1,\"driverId\":1,\"model\":\"HECTOR\"}")
-            .statusCode());
+    HttpResponse<String> invalidTenant = post("/api/v1/tenants", "{\"slug\":\"BAD\"}");
+    assertEquals(400, invalidTenant.statusCode());
+    assertTrue(invalidTenant.body().contains("validation-failed"));
 
-    HttpResponse<String> booking =
-        post("/bookings", "{\"employeeId\":\"1\",\"fromCity\":1,\"toCity\":2}");
-    assertEquals(200, booking.statusCode());
-    JsonObject createdBooking = JsonParser.parseString(booking.body()).getAsJsonObject();
-    assertEquals("1", createdBooking.get("bookedBy").getAsString());
-    assertEquals(1, createdBooking.get("cabId").getAsInt());
+    HttpResponse<String> created =
+        post(
+            "/api/v1/tenants",
+            "{\"slug\":\"city-cabs\",\"displayName\":\"City Cabs\",\"defaultCurrency\":\"USD\",\"timezone\":\"UTC\"}");
+    assertEquals(201, created.statusCode());
+    JsonObject tenant = JsonParser.parseString(created.body()).getAsJsonObject();
+    assertEquals("city-cabs", tenant.get("slug").getAsString());
 
-    HttpResponse<String> bookings = get("/bookings");
-    assertEquals(200, bookings.statusCode());
-    JsonArray content =
-        JsonParser.parseString(bookings.body()).getAsJsonObject().getAsJsonArray("content");
-    assertTrue(content.isJsonArray());
-    assertEquals(1, content.size());
+    HttpResponse<String> listed = getWithToken("/api/v1/tenants");
+    assertEquals(200, listed.statusCode());
+    JsonArray tenants = JsonParser.parseString(listed.body()).getAsJsonArray();
+    assertEquals(1, tenants.size());
   }
 
   private HttpResponse<String> post(String path, String body) throws Exception {
-    HttpRequest request =
+    return post(path, body, true);
+  }
+
+  private HttpResponse<String> postWithoutToken(String path, String body) throws Exception {
+    return post(path, body, false);
+  }
+
+  private HttpResponse<String> post(String path, String body, boolean authenticated) throws Exception {
+    HttpRequest.Builder builder =
         HttpRequest.newBuilder(uri(path))
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-            .POST(HttpRequest.BodyPublishers.ofString(body))
-            .build();
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+    if (authenticated) {
+      builder.header("Authorization", "Bearer platform-admin");
+    }
+    HttpRequest request =
+        builder.POST(HttpRequest.BodyPublishers.ofString(body)).build();
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
@@ -98,7 +109,35 @@ class MarketplaceHttpIT {
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
+  private HttpResponse<String> getWithToken(String path) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(uri(path))
+            .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer platform-admin")
+            .GET()
+            .build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
   private URI uri(String path) {
     return URI.create("http://localhost:" + port + path);
+  }
+
+  @TestConfiguration(proxyBeanMethods = false)
+  static class TestJwtConfiguration {
+
+    @Bean
+    @Primary
+    JwtDecoder testJwtDecoder() {
+      return token ->
+          Jwt.withTokenValue(token)
+              .header("alg", "none")
+              .issuer("https://issuer.example")
+              .subject("platform-admin")
+              .claim("scope", "platform.admin")
+              .claim("email", "admin@example.com")
+              .claim("name", "Platform Admin")
+              .build();
+    }
   }
 }

--- a/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -47,6 +48,11 @@ class GlobalExceptionHandlerTest {
         HttpStatus.BAD_REQUEST,
         "invalid-request",
         "Bad argument");
+    assertProblem(
+        handler.handleTenantAccessDenied(new TenantAccessDeniedException("No membership")),
+        HttpStatus.FORBIDDEN,
+        "tenant-access-denied",
+        "No membership");
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/tenancy/TenantContextTest.java
+++ b/src/test/java/in/rsh/cab/tenancy/TenantContextTest.java
@@ -1,0 +1,31 @@
+package in.rsh.cab.tenancy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TenantContextTest {
+
+  @AfterEach
+  void clear() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void storesImmutableRequestContextAndRequiresSelection() {
+    Set<TenantRole> roles = new HashSet<>(Set.of(TenantRole.RIDER));
+    TenantContext context =
+        new TenantContext(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), roles);
+    roles.clear();
+    TenantContext.set(context);
+
+    assertEquals(Set.of(TenantRole.RIDER), TenantContext.require().roles());
+    TenantContext.clear();
+    assertThrows(IllegalStateException.class, TenantContext::require);
+  }
+}

--- a/src/test/java/in/rsh/cab/tenancy/TenantServiceTest.java
+++ b/src/test/java/in/rsh/cab/tenancy/TenantServiceTest.java
@@ -89,4 +89,23 @@ class TenantServiceTest {
     when(accounts.findByIssuerAndSubject("issuer", "missing")).thenReturn(Optional.empty());
     assertEquals(List.of(), service.findForIdentity("issuer", "missing"));
   }
+
+  @Test
+  void authorizesOnlyActiveAccountMembership() {
+    UUID accountId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UserAccountEntity account =
+        new UserAccountEntity(accountId, "issuer", "subject", null, null, Instant.now());
+    TenantMembershipEntity membership =
+        new TenantMembershipEntity(
+            UUID.randomUUID(), tenantId, accountId, Set.of(TenantRole.FINANCE), Instant.now());
+    when(accounts.findByIssuerAndSubject("issuer", "subject")).thenReturn(Optional.of(account));
+    when(memberships.findByTenantIdAndUserAccountIdAndStatus(tenantId, accountId, "ACTIVE"))
+        .thenReturn(Optional.of(membership));
+
+    assertEquals(tenantId, service.authorize("issuer", "subject", tenantId).tenantId());
+    assertThrows(
+        TenantAccessDeniedException.class,
+        () -> service.authorize("issuer", "unknown", tenantId));
+  }
 }

--- a/src/test/java/in/rsh/cab/tenancy/TenantServiceTest.java
+++ b/src/test/java/in/rsh/cab/tenancy/TenantServiceTest.java
@@ -1,0 +1,92 @@
+package in.rsh.cab.tenancy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.tenancy.internal.persistence.TenantEntity;
+import in.rsh.cab.tenancy.internal.persistence.TenantMembershipEntity;
+import in.rsh.cab.tenancy.internal.persistence.TenantMembershipRepository;
+import in.rsh.cab.tenancy.internal.persistence.TenantRepository;
+import in.rsh.cab.tenancy.internal.persistence.UserAccountEntity;
+import in.rsh.cab.tenancy.internal.persistence.UserAccountRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TenantServiceTest {
+
+  private final TenantRepository tenants = mock(TenantRepository.class);
+  private final UserAccountRepository accounts = mock(UserAccountRepository.class);
+  private final TenantMembershipRepository memberships = mock(TenantMembershipRepository.class);
+  private TenantService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new TenantService(
+            tenants,
+            accounts,
+            memberships,
+            Clock.fixed(Instant.parse("2026-08-08T00:00:00Z"), ZoneOffset.UTC));
+    when(tenants.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(accounts.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  void createsTenantAccountAndAdminMembership() {
+    TenantSummary tenant =
+        service.create(
+            "https://issuer", "subject", "owner@example.com", "Owner", "city-cabs", "City Cabs", "usd", "UTC");
+
+    assertEquals("city-cabs", tenant.slug());
+    assertEquals(Set.of(TenantRole.TENANT_ADMIN), tenant.roles());
+    verify(accounts).save(any(UserAccountEntity.class));
+    verify(memberships).save(any(TenantMembershipEntity.class));
+  }
+
+  @Test
+  void reusesExistingAccountAndRejectsDuplicateSlug() {
+    UserAccountEntity account =
+        new UserAccountEntity(UUID.randomUUID(), "issuer", "subject", null, null, Instant.now());
+    when(accounts.findByIssuerAndSubject("issuer", "subject")).thenReturn(Optional.of(account));
+    service.create("issuer", "subject", null, null, "one", "One", "EUR", "Europe/Paris");
+    verify(accounts, org.mockito.Mockito.never()).save(any());
+
+    when(tenants.existsBySlug("taken")).thenReturn(true);
+    assertThrows(
+        InvalidRequestException.class,
+        () -> service.create("issuer", "subject", null, null, "taken", "Taken", "EUR", "UTC"));
+  }
+
+  @Test
+  void listsOnlyMembershipTenantsAndHandlesUnknownIdentity() {
+    UUID accountId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UserAccountEntity account =
+        new UserAccountEntity(accountId, "issuer", "subject", null, null, Instant.now());
+    TenantEntity tenant =
+        new TenantEntity(tenantId, "one", "One", "USD", "UTC", Instant.now());
+    TenantMembershipEntity membership =
+        new TenantMembershipEntity(
+            UUID.randomUUID(), tenantId, accountId, Set.of(TenantRole.DRIVER), Instant.now());
+    when(accounts.findByIssuerAndSubject("issuer", "subject")).thenReturn(Optional.of(account));
+    when(memberships.findByUserAccountIdAndStatus(accountId, "ACTIVE"))
+        .thenReturn(List.of(membership));
+    when(tenants.findById(tenantId)).thenReturn(Optional.of(tenant));
+
+    assertEquals(1, service.findForIdentity("issuer", "subject").size());
+    when(accounts.findByIssuerAndSubject("issuer", "missing")).thenReturn(Optional.empty());
+    assertEquals(List.of(), service.findForIdentity("issuer", "missing"));
+  }
+}


### PR DESCRIPTION
## Summary
- Delivers `feat(tenancy): add OIDC control plane and tenant selection` as part 3 of 26 in the production marketplace stack.
- Contains 26 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/100`
- Head: `stack/03-tenancy`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.