### PR TITLE
feat(fleet): add marketplace profiles and driver shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ The current implementation supports:
 - OIDC-protected tenant provisioning and operator memberships
 - Tenant-owned PostGIS service areas
 - OSRM-backed route distance and duration estimates
+- Tenant-scoped rider and driver profiles, driver approval, vehicles, and driver shifts
 
 The production roadmap includes:
 
 - Strict tenant isolation and broader role-based access
-- Rider, driver, vehicle, and compliance management
+- Driver document upload and verification workflows
 - Fare quotes, dispatch offers, and complete trip lifecycle
 - Provider-neutral payments, notifications, refunds, and settlements
 - Auditing, webhooks, ratings, support, and safety workflows
@@ -136,6 +137,16 @@ versioned endpoint is:
 | `POST` | `/api/v1/service-areas` | Create a tenant service area; requires `TENANT_ADMIN` |
 | `GET` | `/api/v1/service-areas` | List the selected tenant's service areas |
 | `POST` | `/api/v1/routes/estimate` | Estimate driving distance and duration through OSRM |
+| `POST`, `GET`, `PUT` | `/api/v1/rider/profile` | Create, read, or update the authenticated rider profile |
+| `POST`, `GET` | `/api/v1/drivers` | Onboard or list drivers; requires `TENANT_ADMIN` |
+| `POST` | `/api/v1/drivers/{id}/approve` | Approve a pending driver; requires `TENANT_ADMIN` |
+| `GET`, `PUT` | `/api/v1/drivers/me` | Read or update the authenticated driver profile |
+| `POST`, `GET` | `/api/v1/vehicles` | Create or list vehicles; requires `TENANT_ADMIN` |
+| `PUT` | `/api/v1/vehicles/{id}` | Versioned vehicle update; requires `TENANT_ADMIN` |
+| `POST`, `GET` | `/api/v1/driver/shifts` | Create or list the authenticated driver's shifts |
+| `POST` | `/api/v1/driver/shifts/{id}/go-online` | Move an `OFFLINE` shift to `AVAILABLE` |
+| `POST` | `/api/v1/driver/shifts/{id}/go-offline` | Move an `AVAILABLE` shift to `OFFLINE` |
+| `POST` | `/api/v1/current-tenant/roles/{role}` | Admin self-grant of `RIDER` or `DRIVER` for operations/testing |
 
 Operational probes are available at `/actuator/health/liveness` and
 `/actuator/health/readiness`. API responses include `X-Correlation-ID`; clients may supply this
@@ -147,6 +158,13 @@ to the request. Missing, malformed, unknown, and cross-tenant selections are rej
 boundaries accept GeoJSON `Polygon` or `MultiPolygon` values as either JSON objects or JSON strings;
 tenant IDs are never accepted in request bodies. Route coordinates use latitude/longitude decimal
 degrees and responses report meters and seconds.
+
+Driver onboarding accepts an account UUID only after proving that account has an active membership
+in the selected tenant, and grants its persisted membership the `DRIVER` role. Driver and rider
+operations resolve the account from the authenticated tenant context. Vehicle and shift mutations
+use optimistic versions and return stable `409 resource-conflict` errors for stale or invalid
+transitions. Driver document storage is metadata-only; document bytes and raw secrets are never
+stored in the marketplace database.
 
 The backend validates OIDC issuer, audience, signature, expiry, and subject. Configure
 `OIDC_ISSUER_URI` and `OIDC_AUDIENCE`; authorization roles are stored in tenant memberships rather

--- a/src/main/java/in/rsh/cab/config/TimeConfiguration.java
+++ b/src/main/java/in/rsh/cab/config/TimeConfiguration.java
@@ -1,0 +1,14 @@
+package in.rsh.cab.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfiguration {
+
+  @Bean
+  Clock clock() {
+    return Clock.systemUTC();
+  }
+}

--- a/src/main/java/in/rsh/cab/driver/DriverProfile.java
+++ b/src/main/java/in/rsh/cab/driver/DriverProfile.java
@@ -1,0 +1,31 @@
+package in.rsh.cab.driver;
+
+import in.rsh.cab.exception.ConflictException;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DriverProfile(
+    UUID id,
+    UUID accountId,
+    String legalName,
+    String phoneNumber,
+    DriverStatus status,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public DriverProfile approve(Instant now) {
+    if (status != DriverStatus.PENDING) {
+      throw new ConflictException("Only a pending driver can be approved");
+    }
+    return new DriverProfile(
+        id, accountId, legalName, phoneNumber, DriverStatus.APPROVED, createdAt, now);
+  }
+
+  public DriverProfile suspend(Instant now) {
+    if (status != DriverStatus.APPROVED) {
+      throw new ConflictException("Only an approved driver can be suspended");
+    }
+    return new DriverProfile(
+        id, accountId, legalName, phoneNumber, DriverStatus.SUSPENDED, createdAt, now);
+  }
+}

--- a/src/main/java/in/rsh/cab/driver/DriverService.java
+++ b/src/main/java/in/rsh/cab/driver/DriverService.java
@@ -1,0 +1,106 @@
+package in.rsh.cab.driver;
+
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import in.rsh.cab.tenancy.TenantService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DriverService {
+
+  private final DriverProfileRepository drivers;
+  private final TenantService tenants;
+  private final Clock clock;
+
+  public DriverService(DriverProfileRepository drivers, TenantService tenants, Clock clock) {
+    this.drivers = drivers;
+    this.tenants = tenants;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public DriverProfile create(UUID accountId, String legalName, String phoneNumber) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    tenants.grantRoleForActiveAccount(accountId, TenantRole.DRIVER);
+    Instant now = clock.instant();
+    DriverProfile profile =
+        new DriverProfile(
+            UUID.randomUUID(), accountId, legalName, phoneNumber, DriverStatus.PENDING, now, now);
+    try {
+      drivers.insert(context.tenantId(), profile);
+    } catch (DataIntegrityViolationException exception) {
+      throw new ConflictException("Driver profile already exists for account");
+    }
+    return profile;
+  }
+
+  @Transactional(readOnly = true)
+  public List<DriverProfile> list() {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    return drivers.findAllByTenantId(context.tenantId());
+  }
+
+  @Transactional
+  public DriverProfile approve(UUID id) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    DriverProfile current = find(context.tenantId(), id);
+    DriverProfile approved = current.approve(clock.instant());
+    if (!drivers.updateStatus(
+        context.tenantId(), id, current.status(), approved.status(), approved.updatedAt())) {
+      throw new ConflictException("Driver status changed concurrently");
+    }
+    return approved;
+  }
+
+  @Transactional
+  public DriverProfile suspend(UUID id) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    DriverProfile current = find(context.tenantId(), id);
+    DriverProfile suspended = current.suspend(clock.instant());
+    if (!drivers.updateStatus(
+        context.tenantId(), id, current.status(), suspended.status(), suspended.updatedAt())) {
+      throw new ConflictException("Driver status changed concurrently");
+    }
+    return suspended;
+  }
+
+  @Transactional(readOnly = true)
+  public DriverProfile getOwn() {
+    TenantContext context = require(TenantRole.DRIVER);
+    return drivers.findByTenantIdAndAccountId(context.tenantId(), context.accountId())
+        .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+  }
+
+  @Transactional
+  public DriverProfile updateOwn(String legalName, String phoneNumber) {
+    TenantContext context = require(TenantRole.DRIVER);
+    if (!drivers.updateOwn(
+        context.tenantId(), context.accountId(), legalName, phoneNumber, clock.instant())) {
+      throw new NotFoundException("Driver profile not found");
+    }
+    return getOwn();
+  }
+
+  private DriverProfile find(UUID tenantId, UUID id) {
+    return drivers.findByTenantIdAndId(tenantId, id)
+        .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+  }
+
+  private TenantContext require(TenantRole role) {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(role)) {
+      throw new TenantAccessDeniedException(role + " role is required");
+    }
+    return context;
+  }
+}

--- a/src/main/java/in/rsh/cab/driver/DriverStatus.java
+++ b/src/main/java/in/rsh/cab/driver/DriverStatus.java
@@ -1,0 +1,7 @@
+package in.rsh.cab.driver;
+
+public enum DriverStatus {
+  PENDING,
+  APPROVED,
+  SUSPENDED
+}

--- a/src/main/java/in/rsh/cab/driver/internal/persistence/DriverProfileRepository.java
+++ b/src/main/java/in/rsh/cab/driver/internal/persistence/DriverProfileRepository.java
@@ -1,0 +1,25 @@
+package in.rsh.cab.driver.internal.persistence;
+
+import in.rsh.cab.driver.DriverProfile;
+import in.rsh.cab.driver.DriverStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DriverProfileRepository {
+
+  void insert(UUID tenantId, DriverProfile profile);
+
+  Optional<DriverProfile> findByTenantIdAndId(UUID tenantId, UUID id);
+
+  Optional<DriverProfile> findByTenantIdAndAccountId(UUID tenantId, UUID accountId);
+
+  List<DriverProfile> findAllByTenantId(UUID tenantId);
+
+  boolean updateStatus(UUID tenantId, UUID id, DriverStatus expected, DriverStatus status,
+      Instant updatedAt);
+
+  boolean updateOwn(UUID tenantId, UUID accountId, String legalName, String phoneNumber,
+      Instant updatedAt);
+}

--- a/src/main/java/in/rsh/cab/driver/internal/persistence/JdbcDriverProfileRepository.java
+++ b/src/main/java/in/rsh/cab/driver/internal/persistence/JdbcDriverProfileRepository.java
@@ -1,0 +1,100 @@
+package in.rsh.cab.driver.internal.persistence;
+
+import in.rsh.cab.driver.DriverProfile;
+import in.rsh.cab.driver.DriverStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcDriverProfileRepository implements DriverProfileRepository {
+
+  private static final String SELECT = """
+      SELECT id, account_id, legal_name, phone_number, status, created_at, updated_at
+      FROM driver_profiles
+      """;
+  private final JdbcClient jdbc;
+
+  public JdbcDriverProfileRepository(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public void insert(UUID tenantId, DriverProfile profile) {
+    jdbc.sql("""
+            INSERT INTO driver_profiles
+              (id, tenant_id, account_id, legal_name, phone_number, status, created_at, updated_at)
+            VALUES
+              (:id, :tenantId, :accountId, :legalName, :phoneNumber, :status, :createdAt, :updatedAt)
+            """)
+        .param("id", profile.id())
+        .param("tenantId", tenantId)
+        .param("accountId", profile.accountId())
+        .param("legalName", profile.legalName())
+        .param("phoneNumber", profile.phoneNumber())
+        .param("status", profile.status().name())
+        .param("createdAt", Timestamp.from(profile.createdAt()))
+        .param("updatedAt", Timestamp.from(profile.updatedAt()))
+        .update();
+  }
+
+  @Override
+  public Optional<DriverProfile> findByTenantIdAndId(UUID tenantId, UUID id) {
+    return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId AND id = :id")
+        .param("tenantId", tenantId).param("id", id).query(this::map).optional();
+  }
+
+  @Override
+  public Optional<DriverProfile> findByTenantIdAndAccountId(UUID tenantId, UUID accountId) {
+    return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId AND account_id = :accountId")
+        .param("tenantId", tenantId).param("accountId", accountId).query(this::map).optional();
+  }
+
+  @Override
+  public List<DriverProfile> findAllByTenantId(UUID tenantId) {
+    return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId ORDER BY created_at, id")
+        .param("tenantId", tenantId).query(this::map).list();
+  }
+
+  @Override
+  public boolean updateStatus(
+      UUID tenantId, UUID id, DriverStatus expected, DriverStatus status, Instant updatedAt) {
+    return jdbc.sql("""
+            UPDATE driver_profiles SET status = :status, updated_at = :updatedAt
+            WHERE tenant_id = :tenantId AND id = :id AND status = :expected
+            """)
+        .param("tenantId", tenantId).param("id", id)
+        .param("expected", expected.name()).param("status", status.name())
+        .param("updatedAt", Timestamp.from(updatedAt)).update() == 1;
+  }
+
+  @Override
+  public boolean updateOwn(
+      UUID tenantId, UUID accountId, String legalName, String phoneNumber, Instant updatedAt) {
+    return jdbc.sql("""
+            UPDATE driver_profiles
+            SET legal_name = :legalName, phone_number = :phoneNumber, updated_at = :updatedAt
+            WHERE tenant_id = :tenantId AND account_id = :accountId
+            """)
+        .param("tenantId", tenantId).param("accountId", accountId)
+        .param("legalName", legalName).param("phoneNumber", phoneNumber)
+        .param("updatedAt", Timestamp.from(updatedAt)).update() == 1;
+  }
+
+  private DriverProfile map(ResultSet resultSet, int rowNumber) throws SQLException {
+    return new DriverProfile(
+        resultSet.getObject("id", UUID.class),
+        resultSet.getObject("account_id", UUID.class),
+        resultSet.getString("legal_name"),
+        resultSet.getString("phone_number"),
+        DriverStatus.valueOf(resultSet.getString("status")),
+        resultSet.getTimestamp("created_at").toInstant(),
+        resultSet.getTimestamp("updated_at").toInstant());
+  }
+}

--- a/src/main/java/in/rsh/cab/driver/internal/web/DriverController.java
+++ b/src/main/java/in/rsh/cab/driver/internal/web/DriverController.java
@@ -1,0 +1,72 @@
+package in.rsh.cab.driver.internal.web;
+
+import in.rsh.cab.driver.DriverProfile;
+import in.rsh.cab.driver.DriverService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/drivers")
+public class DriverController {
+
+  private final DriverService drivers;
+
+  public DriverController(DriverService drivers) {
+    this.drivers = drivers;
+  }
+
+  @PostMapping
+  public ResponseEntity<DriverProfile> create(@Valid @RequestBody CreateDriverRequest request) {
+    DriverProfile driver =
+        drivers.create(request.accountId(), request.legalName(), request.phoneNumber());
+    return ResponseEntity.created(URI.create("/api/v1/drivers/" + driver.id())).body(driver);
+  }
+
+  @GetMapping
+  public List<DriverProfile> list() {
+    return drivers.list();
+  }
+
+  @PostMapping("/{id}/approve")
+  public DriverProfile approve(@PathVariable UUID id) {
+    return drivers.approve(id);
+  }
+
+  @PostMapping("/{id}/suspend")
+  public DriverProfile suspend(@PathVariable UUID id) {
+    return drivers.suspend(id);
+  }
+
+  @GetMapping("/me")
+  public DriverProfile getOwn() {
+    return drivers.getOwn();
+  }
+
+  @PutMapping("/me")
+  public DriverProfile updateOwn(@Valid @RequestBody UpdateDriverRequest request) {
+    return drivers.updateOwn(request.legalName(), request.phoneNumber());
+  }
+
+  public record CreateDriverRequest(
+      @NotNull UUID accountId,
+      @NotBlank @Size(max = 120) String legalName,
+      @Pattern(regexp = "^\\+?[0-9 -]{7,32}$") String phoneNumber) {}
+
+  public record UpdateDriverRequest(
+      @NotBlank @Size(max = 120) String legalName,
+      @Pattern(regexp = "^\\+?[0-9 -]{7,32}$") String phoneNumber) {}
+}

--- a/src/main/java/in/rsh/cab/exception/ConflictException.java
+++ b/src/main/java/in/rsh/cab/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package in.rsh.cab.exception;
+
+public class ConflictException extends RuntimeException {
+
+  public ConflictException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
@@ -30,6 +30,11 @@ public class GlobalExceptionHandler {
     return problem(HttpStatus.CONFLICT, "Cab unavailable", exception.getMessage(), "cab-unavailable");
   }
 
+  @ExceptionHandler(ConflictException.class)
+  public ResponseEntity<ProblemDetail> handleConflict(ConflictException exception) {
+    return problem(HttpStatus.CONFLICT, "Conflict", exception.getMessage(), "resource-conflict");
+  }
+
   @ExceptionHandler({IllegalArgumentException.class, InvalidRequestException.class})
   public ResponseEntity<ProblemDetail> handleBadRequest(RuntimeException exception) {
     return problem(HttpStatus.BAD_REQUEST, "Invalid request", exception.getMessage(), "invalid-request");

--- a/src/main/java/in/rsh/cab/fleet/DriverShift.java
+++ b/src/main/java/in/rsh/cab/fleet/DriverShift.java
@@ -1,0 +1,44 @@
+package in.rsh.cab.fleet;
+
+import in.rsh.cab.exception.ConflictException;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DriverShift(
+    UUID id,
+    UUID driverId,
+    UUID vehicleId,
+    ShiftStatus status,
+    long version,
+    Instant createdAt,
+    Instant updatedAt,
+    Instant availableAt,
+    Instant closedAt) {
+
+  public DriverShift goOnline(Instant now) {
+    require(ShiftStatus.OFFLINE, "Only an offline shift can go online");
+    return transition(ShiftStatus.AVAILABLE, now, now, null);
+  }
+
+  public DriverShift goOffline(Instant now) {
+    require(ShiftStatus.AVAILABLE, "Only an available shift can go offline");
+    return transition(ShiftStatus.OFFLINE, now, availableAt, null);
+  }
+
+  public DriverShift close(Instant now) {
+    require(ShiftStatus.OFFLINE, "Only an offline shift can be closed");
+    return transition(ShiftStatus.CLOSED, now, availableAt, now);
+  }
+
+  private void require(ShiftStatus expected, String message) {
+    if (status != expected) {
+      throw new ConflictException(message);
+    }
+  }
+
+  private DriverShift transition(
+      ShiftStatus next, Instant now, Instant nextAvailableAt, Instant nextClosedAt) {
+    return new DriverShift(
+        id, driverId, vehicleId, next, version + 1, createdAt, now, nextAvailableAt, nextClosedAt);
+  }
+}

--- a/src/main/java/in/rsh/cab/fleet/FleetService.java
+++ b/src/main/java/in/rsh/cab/fleet/FleetService.java
@@ -1,0 +1,149 @@
+package in.rsh.cab.fleet;
+
+import in.rsh.cab.driver.DriverStatus;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.fleet.internal.persistence.FleetRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FleetService {
+
+  private final FleetRepository fleet;
+  private final Clock clock;
+
+  public FleetService(FleetRepository fleet, Clock clock) {
+    this.fleet = fleet;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public Vehicle createVehicle(String registration, String serviceClass, int capacity) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    Instant now = clock.instant();
+    Vehicle vehicle =
+        new Vehicle(
+            UUID.randomUUID(), normalize(registration), serviceClass, capacity,
+            VehicleStatus.ACTIVE, 0, now, now);
+    try {
+      fleet.insertVehicle(context.tenantId(), vehicle);
+    } catch (DataIntegrityViolationException exception) {
+      throw new ConflictException("Vehicle registration is already in use");
+    }
+    return vehicle;
+  }
+
+  @Transactional(readOnly = true)
+  public List<Vehicle> listVehicles() {
+    return fleet.findVehicles(require(TenantRole.TENANT_ADMIN).tenantId());
+  }
+
+  @Transactional
+  public Vehicle updateVehicle(
+      UUID id, String registration, String serviceClass, int capacity, VehicleStatus status,
+      long version) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    Vehicle current = fleet.findVehicle(context.tenantId(), id)
+        .orElseThrow(() -> new NotFoundException("Vehicle not found"));
+    if (current.version() != version) {
+      throw new ConflictException("Vehicle version is stale");
+    }
+    Vehicle updated = current.update(normalize(registration), serviceClass, capacity, status, clock.instant());
+    try {
+      if (!fleet.updateVehicle(context.tenantId(), updated, version)) {
+        throw new ConflictException("Vehicle changed concurrently");
+      }
+    } catch (DataIntegrityViolationException exception) {
+      throw new ConflictException("Vehicle registration is already in use");
+    }
+    return updated;
+  }
+
+  @Transactional
+  public DriverShift createShift(UUID driverId, UUID vehicleId) {
+    TenantContext context = require(TenantRole.DRIVER);
+    DriverStatus driverStatus =
+        fleet.findDriverStatus(context.tenantId(), driverId, context.accountId())
+            .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+    if (driverStatus != DriverStatus.APPROVED) {
+      throw new ConflictException("Driver must be approved to start a shift");
+    }
+    Vehicle vehicle = fleet.findVehicle(context.tenantId(), vehicleId)
+        .orElseThrow(() -> new NotFoundException("Vehicle not found"));
+    if (vehicle.status() != VehicleStatus.ACTIVE) {
+      throw new ConflictException("Vehicle must be active to start a shift");
+    }
+    Instant now = clock.instant();
+    DriverShift shift =
+        new DriverShift(
+            UUID.randomUUID(), driverId, vehicleId, ShiftStatus.OFFLINE, 0, now, now, null, null);
+    try {
+      fleet.insertShift(context.tenantId(), shift);
+    } catch (DataIntegrityViolationException exception) {
+      throw new ConflictException("Driver or vehicle already has an open shift");
+    }
+    return shift;
+  }
+
+  @Transactional(readOnly = true)
+  public List<DriverShift> listOwnShifts() {
+    TenantContext context = require(TenantRole.DRIVER);
+    return fleet.findShifts(context.tenantId(), context.accountId());
+  }
+
+  @Transactional
+  public DriverShift goOnline(UUID shiftId, long version) {
+    return transition(shiftId, version, Transition.ONLINE);
+  }
+
+  @Transactional
+  public DriverShift goOffline(UUID shiftId, long version) {
+    return transition(shiftId, version, Transition.OFFLINE);
+  }
+
+  @Transactional
+  public DriverShift closeShift(UUID shiftId, long version) {
+    return transition(shiftId, version, Transition.CLOSE);
+  }
+
+  private DriverShift transition(UUID shiftId, long version, Transition transition) {
+    TenantContext context = require(TenantRole.DRIVER);
+    DriverShift current = fleet.findShift(context.tenantId(), shiftId, context.accountId())
+        .orElseThrow(() -> new NotFoundException("Driver shift not found"));
+    if (current.version() != version) {
+      throw new ConflictException("Driver shift version is stale");
+    }
+    DriverShift updated = switch (transition) {
+      case ONLINE -> current.goOnline(clock.instant());
+      case OFFLINE -> current.goOffline(clock.instant());
+      case CLOSE -> current.close(clock.instant());
+    };
+    if (!fleet.updateShift(context.tenantId(), updated, version)) {
+      throw new ConflictException("Driver shift changed concurrently");
+    }
+    return updated;
+  }
+
+  private TenantContext require(TenantRole role) {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(role)) {
+      throw new TenantAccessDeniedException(role + " role is required");
+    }
+    return context;
+  }
+
+  private String normalize(String registration) {
+    return registration.replaceAll("\\s+", "").toUpperCase();
+  }
+
+  private enum Transition { ONLINE, OFFLINE, CLOSE }
+}

--- a/src/main/java/in/rsh/cab/fleet/ShiftStatus.java
+++ b/src/main/java/in/rsh/cab/fleet/ShiftStatus.java
@@ -1,0 +1,9 @@
+package in.rsh.cab.fleet;
+
+public enum ShiftStatus {
+  OFFLINE,
+  AVAILABLE,
+  RESERVED,
+  ON_TRIP,
+  CLOSED
+}

--- a/src/main/java/in/rsh/cab/fleet/Vehicle.java
+++ b/src/main/java/in/rsh/cab/fleet/Vehicle.java
@@ -1,0 +1,28 @@
+package in.rsh.cab.fleet;
+
+import in.rsh.cab.exception.InvalidRequestException;
+import java.time.Instant;
+import java.util.UUID;
+
+public record Vehicle(
+    UUID id,
+    String registration,
+    String serviceClass,
+    int capacity,
+    VehicleStatus status,
+    long version,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public Vehicle {
+    if (capacity < 1 || capacity > 20) {
+      throw new InvalidRequestException("Vehicle capacity must be between 1 and 20");
+    }
+  }
+
+  public Vehicle update(
+      String registration, String serviceClass, int capacity, VehicleStatus status, Instant now) {
+    return new Vehicle(
+        id, registration, serviceClass, capacity, status, version + 1, createdAt, now);
+  }
+}

--- a/src/main/java/in/rsh/cab/fleet/VehicleStatus.java
+++ b/src/main/java/in/rsh/cab/fleet/VehicleStatus.java
@@ -1,0 +1,6 @@
+package in.rsh.cab.fleet;
+
+public enum VehicleStatus {
+  ACTIVE,
+  INACTIVE
+}

--- a/src/main/java/in/rsh/cab/fleet/internal/persistence/FleetRepository.java
+++ b/src/main/java/in/rsh/cab/fleet/internal/persistence/FleetRepository.java
@@ -1,0 +1,30 @@
+package in.rsh.cab.fleet.internal.persistence;
+
+import in.rsh.cab.driver.DriverStatus;
+import in.rsh.cab.fleet.DriverShift;
+import in.rsh.cab.fleet.Vehicle;
+import in.rsh.cab.fleet.VehicleStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FleetRepository {
+
+  void insertVehicle(UUID tenantId, Vehicle vehicle);
+
+  Optional<Vehicle> findVehicle(UUID tenantId, UUID id);
+
+  List<Vehicle> findVehicles(UUID tenantId);
+
+  boolean updateVehicle(UUID tenantId, Vehicle vehicle, long expectedVersion);
+
+  Optional<DriverStatus> findDriverStatus(UUID tenantId, UUID driverId, UUID accountId);
+
+  void insertShift(UUID tenantId, DriverShift shift);
+
+  Optional<DriverShift> findShift(UUID tenantId, UUID shiftId, UUID accountId);
+
+  List<DriverShift> findShifts(UUID tenantId, UUID accountId);
+
+  boolean updateShift(UUID tenantId, DriverShift shift, long expectedVersion);
+}

--- a/src/main/java/in/rsh/cab/fleet/internal/persistence/JdbcFleetRepository.java
+++ b/src/main/java/in/rsh/cab/fleet/internal/persistence/JdbcFleetRepository.java
@@ -1,0 +1,161 @@
+package in.rsh.cab.fleet.internal.persistence;
+
+import in.rsh.cab.driver.DriverStatus;
+import in.rsh.cab.fleet.DriverShift;
+import in.rsh.cab.fleet.ShiftStatus;
+import in.rsh.cab.fleet.Vehicle;
+import in.rsh.cab.fleet.VehicleStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcFleetRepository implements FleetRepository {
+
+  private static final String VEHICLE_SELECT = """
+      SELECT id, registration, service_class, capacity, status, version, created_at, updated_at
+      FROM vehicles
+      """;
+  private static final String SHIFT_SELECT = """
+      SELECT s.id, s.driver_id, s.vehicle_id, s.status, s.version, s.created_at,
+             s.updated_at, s.available_at, s.closed_at
+      FROM driver_shifts s
+      JOIN driver_profiles d ON d.tenant_id = s.tenant_id AND d.id = s.driver_id
+      """;
+  private final JdbcClient jdbc;
+
+  public JdbcFleetRepository(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public void insertVehicle(UUID tenantId, Vehicle vehicle) {
+    jdbc.sql("""
+            INSERT INTO vehicles
+              (id, tenant_id, registration, service_class, capacity, status, version,
+               created_at, updated_at)
+            VALUES
+              (:id, :tenantId, :registration, :serviceClass, :capacity, :status, :version,
+               :createdAt, :updatedAt)
+            """)
+        .param("id", vehicle.id()).param("tenantId", tenantId)
+        .param("registration", vehicle.registration()).param("serviceClass", vehicle.serviceClass())
+        .param("capacity", vehicle.capacity()).param("status", vehicle.status().name())
+        .param("version", vehicle.version()).param("createdAt", Timestamp.from(vehicle.createdAt()))
+        .param("updatedAt", Timestamp.from(vehicle.updatedAt())).update();
+  }
+
+  @Override
+  public Optional<Vehicle> findVehicle(UUID tenantId, UUID id) {
+    return jdbc.sql(VEHICLE_SELECT + " WHERE tenant_id = :tenantId AND id = :id")
+        .param("tenantId", tenantId).param("id", id).query(this::mapVehicle).optional();
+  }
+
+  @Override
+  public List<Vehicle> findVehicles(UUID tenantId) {
+    return jdbc.sql(VEHICLE_SELECT + " WHERE tenant_id = :tenantId ORDER BY registration, id")
+        .param("tenantId", tenantId).query(this::mapVehicle).list();
+  }
+
+  @Override
+  public boolean updateVehicle(UUID tenantId, Vehicle vehicle, long expectedVersion) {
+    return jdbc.sql("""
+            UPDATE vehicles
+            SET registration = :registration, service_class = :serviceClass,
+                capacity = :capacity, status = :status, version = :version, updated_at = :updatedAt
+            WHERE tenant_id = :tenantId AND id = :id AND version = :expectedVersion
+            """)
+        .param("tenantId", tenantId).param("id", vehicle.id())
+        .param("registration", vehicle.registration()).param("serviceClass", vehicle.serviceClass())
+        .param("capacity", vehicle.capacity()).param("status", vehicle.status().name())
+        .param("version", vehicle.version()).param("updatedAt", Timestamp.from(vehicle.updatedAt()))
+        .param("expectedVersion", expectedVersion).update() == 1;
+  }
+
+  @Override
+  public Optional<DriverStatus> findDriverStatus(UUID tenantId, UUID driverId, UUID accountId) {
+    return jdbc.sql("""
+            SELECT status FROM driver_profiles
+            WHERE tenant_id = :tenantId AND id = :driverId AND account_id = :accountId
+            """)
+        .param("tenantId", tenantId).param("driverId", driverId).param("accountId", accountId)
+        .query(String.class).optional().map(DriverStatus::valueOf);
+  }
+
+  @Override
+  public void insertShift(UUID tenantId, DriverShift shift) {
+    jdbc.sql("""
+            INSERT INTO driver_shifts
+              (id, tenant_id, driver_id, vehicle_id, status, version, created_at, updated_at)
+            VALUES
+              (:id, :tenantId, :driverId, :vehicleId, :status, :version, :createdAt, :updatedAt)
+            """)
+        .param("id", shift.id()).param("tenantId", tenantId).param("driverId", shift.driverId())
+        .param("vehicleId", shift.vehicleId()).param("status", shift.status().name())
+        .param("version", shift.version()).param("createdAt", Timestamp.from(shift.createdAt()))
+        .param("updatedAt", Timestamp.from(shift.updatedAt())).update();
+  }
+
+  @Override
+  public Optional<DriverShift> findShift(UUID tenantId, UUID shiftId, UUID accountId) {
+    return jdbc.sql(SHIFT_SELECT + """
+            WHERE s.tenant_id = :tenantId AND s.id = :shiftId AND d.account_id = :accountId
+            """)
+        .param("tenantId", tenantId).param("shiftId", shiftId).param("accountId", accountId)
+        .query(this::mapShift).optional();
+  }
+
+  @Override
+  public List<DriverShift> findShifts(UUID tenantId, UUID accountId) {
+    return jdbc.sql(SHIFT_SELECT + """
+            WHERE s.tenant_id = :tenantId AND d.account_id = :accountId
+            ORDER BY s.created_at DESC, s.id
+            """)
+        .param("tenantId", tenantId).param("accountId", accountId).query(this::mapShift).list();
+  }
+
+  @Override
+  public boolean updateShift(UUID tenantId, DriverShift shift, long expectedVersion) {
+    return jdbc.sql("""
+            UPDATE driver_shifts
+            SET status = :status, version = :version, updated_at = :updatedAt,
+                available_at = :availableAt, closed_at = :closedAt
+            WHERE tenant_id = :tenantId AND id = :id AND version = :expectedVersion
+            """)
+        .param("tenantId", tenantId).param("id", shift.id()).param("status", shift.status().name())
+        .param("version", shift.version()).param("updatedAt", Timestamp.from(shift.updatedAt()))
+        .param("availableAt", timestamp(shift.availableAt())).param("closedAt", timestamp(shift.closedAt()))
+        .param("expectedVersion", expectedVersion).update() == 1;
+  }
+
+  private Vehicle mapVehicle(ResultSet resultSet, int rowNumber) throws SQLException {
+    return new Vehicle(
+        resultSet.getObject("id", UUID.class), resultSet.getString("registration"),
+        resultSet.getString("service_class"), resultSet.getInt("capacity"),
+        VehicleStatus.valueOf(resultSet.getString("status")), resultSet.getLong("version"),
+        resultSet.getTimestamp("created_at").toInstant(), resultSet.getTimestamp("updated_at").toInstant());
+  }
+
+  private DriverShift mapShift(ResultSet resultSet, int rowNumber) throws SQLException {
+    return new DriverShift(
+        resultSet.getObject("id", UUID.class), resultSet.getObject("driver_id", UUID.class),
+        resultSet.getObject("vehicle_id", UUID.class), ShiftStatus.valueOf(resultSet.getString("status")),
+        resultSet.getLong("version"), resultSet.getTimestamp("created_at").toInstant(),
+        resultSet.getTimestamp("updated_at").toInstant(), instant(resultSet, "available_at"),
+        instant(resultSet, "closed_at"));
+  }
+
+  private Timestamp timestamp(java.time.Instant instant) {
+    return instant == null ? null : Timestamp.from(instant);
+  }
+
+  private java.time.Instant instant(ResultSet resultSet, String name) throws SQLException {
+    Timestamp timestamp = resultSet.getTimestamp(name);
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+}

--- a/src/main/java/in/rsh/cab/fleet/internal/web/DriverShiftController.java
+++ b/src/main/java/in/rsh/cab/fleet/internal/web/DriverShiftController.java
@@ -1,0 +1,58 @@
+package in.rsh.cab.fleet.internal.web;
+
+import in.rsh.cab.fleet.DriverShift;
+import in.rsh.cab.fleet.FleetService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/driver/shifts")
+public class DriverShiftController {
+
+  private final FleetService fleet;
+
+  public DriverShiftController(FleetService fleet) {
+    this.fleet = fleet;
+  }
+
+  @PostMapping
+  public ResponseEntity<DriverShift> create(@Valid @RequestBody CreateShiftRequest request) {
+    DriverShift shift = fleet.createShift(request.driverId(), request.vehicleId());
+    return ResponseEntity.created(URI.create("/api/v1/driver/shifts/" + shift.id())).body(shift);
+  }
+
+  @GetMapping
+  public List<DriverShift> listOwn() {
+    return fleet.listOwnShifts();
+  }
+
+  @PostMapping("/{id}/go-online")
+  public DriverShift goOnline(@PathVariable UUID id, @Valid @RequestBody VersionRequest request) {
+    return fleet.goOnline(id, request.version());
+  }
+
+  @PostMapping("/{id}/go-offline")
+  public DriverShift goOffline(@PathVariable UUID id, @Valid @RequestBody VersionRequest request) {
+    return fleet.goOffline(id, request.version());
+  }
+
+  @PostMapping("/{id}/close")
+  public DriverShift close(@PathVariable UUID id, @Valid @RequestBody VersionRequest request) {
+    return fleet.closeShift(id, request.version());
+  }
+
+  public record CreateShiftRequest(@NotNull UUID driverId, @NotNull UUID vehicleId) {}
+
+  public record VersionRequest(@PositiveOrZero long version) {}
+}

--- a/src/main/java/in/rsh/cab/fleet/internal/web/VehicleController.java
+++ b/src/main/java/in/rsh/cab/fleet/internal/web/VehicleController.java
@@ -1,0 +1,65 @@
+package in.rsh.cab.fleet.internal.web;
+
+import in.rsh.cab.fleet.FleetService;
+import in.rsh.cab.fleet.Vehicle;
+import in.rsh.cab.fleet.VehicleStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/vehicles")
+public class VehicleController {
+
+  private final FleetService fleet;
+
+  public VehicleController(FleetService fleet) {
+    this.fleet = fleet;
+  }
+
+  @PostMapping
+  public ResponseEntity<Vehicle> create(@Valid @RequestBody CreateVehicleRequest request) {
+    Vehicle vehicle = fleet.createVehicle(request.registration(), request.serviceClass(), request.capacity());
+    return ResponseEntity.created(URI.create("/api/v1/vehicles/" + vehicle.id())).body(vehicle);
+  }
+
+  @GetMapping
+  public List<Vehicle> list() {
+    return fleet.listVehicles();
+  }
+
+  @PutMapping("/{id}")
+  public Vehicle update(@PathVariable UUID id, @Valid @RequestBody UpdateVehicleRequest request) {
+    return fleet.updateVehicle(
+        id, request.registration(), request.serviceClass(), request.capacity(), request.status(),
+        request.version());
+  }
+
+  public record CreateVehicleRequest(
+      @NotBlank @Pattern(regexp = "^[A-Za-z0-9 -]+$") @Size(max = 32) String registration,
+      @NotBlank @Size(max = 32) String serviceClass,
+      @Min(1) @Max(20) int capacity) {}
+
+  public record UpdateVehicleRequest(
+      @NotBlank @Pattern(regexp = "^[A-Za-z0-9 -]+$") @Size(max = 32) String registration,
+      @NotBlank @Size(max = 32) String serviceClass,
+      @Min(1) @Max(20) int capacity,
+      @NotNull VehicleStatus status,
+      @PositiveOrZero long version) {}
+}

--- a/src/main/java/in/rsh/cab/geography/ServiceAreaService.java
+++ b/src/main/java/in/rsh/cab/geography/ServiceAreaService.java
@@ -11,7 +11,6 @@ import java.time.ZoneId;
 import java.time.zone.ZoneRulesException;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
@@ -27,12 +26,7 @@ public class ServiceAreaService {
   private final ObjectMapper objectMapper;
   private final Clock clock;
 
-  @Autowired
-  public ServiceAreaService(ServiceAreaRepository serviceAreas, ObjectMapper objectMapper) {
-    this(serviceAreas, objectMapper, Clock.systemUTC());
-  }
-
-  ServiceAreaService(ServiceAreaRepository serviceAreas, ObjectMapper objectMapper, Clock clock) {
+  public ServiceAreaService(ServiceAreaRepository serviceAreas, ObjectMapper objectMapper, Clock clock) {
     this.serviceAreas = serviceAreas;
     this.objectMapper = objectMapper;
     this.clock = clock;

--- a/src/main/java/in/rsh/cab/rider/RiderProfile.java
+++ b/src/main/java/in/rsh/cab/rider/RiderProfile.java
@@ -1,0 +1,11 @@
+package in.rsh.cab.rider;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record RiderProfile(
+    UUID id,
+    String displayName,
+    String phoneNumber,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/src/main/java/in/rsh/cab/rider/RiderProfileService.java
+++ b/src/main/java/in/rsh/cab/rider/RiderProfileService.java
@@ -1,0 +1,64 @@
+package in.rsh.cab.rider;
+
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.rider.internal.persistence.RiderProfileRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RiderProfileService {
+
+  private final RiderProfileRepository profiles;
+  private final Clock clock;
+
+  public RiderProfileService(RiderProfileRepository profiles, Clock clock) {
+    this.profiles = profiles;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public RiderProfile create(String displayName, String phoneNumber) {
+    TenantContext context = requireRider();
+    Instant now = clock.instant();
+    RiderProfile profile = new RiderProfile(UUID.randomUUID(), displayName, phoneNumber, now, now);
+    try {
+      profiles.insert(context.tenantId(), context.accountId(), profile);
+    } catch (DataIntegrityViolationException exception) {
+      throw new ConflictException("Rider profile already exists");
+    }
+    return profile;
+  }
+
+  @Transactional(readOnly = true)
+  public RiderProfile getOwn() {
+    TenantContext context = requireRider();
+    return profiles.findByTenantIdAndAccountId(context.tenantId(), context.accountId())
+        .orElseThrow(() -> new NotFoundException("Rider profile not found"));
+  }
+
+  @Transactional
+  public RiderProfile updateOwn(String displayName, String phoneNumber) {
+    TenantContext context = requireRider();
+    if (!profiles.update(
+        context.tenantId(), context.accountId(), displayName, phoneNumber, clock.instant())) {
+      throw new NotFoundException("Rider profile not found");
+    }
+    return getOwn();
+  }
+
+  private TenantContext requireRider() {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(TenantRole.RIDER)) {
+      throw new TenantAccessDeniedException("RIDER role is required");
+    }
+    return context;
+  }
+}

--- a/src/main/java/in/rsh/cab/rider/internal/persistence/JdbcRiderProfileRepository.java
+++ b/src/main/java/in/rsh/cab/rider/internal/persistence/JdbcRiderProfileRepository.java
@@ -1,0 +1,76 @@
+package in.rsh.cab.rider.internal.persistence;
+
+import in.rsh.cab.rider.RiderProfile;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcRiderProfileRepository implements RiderProfileRepository {
+
+  private final JdbcClient jdbc;
+
+  public JdbcRiderProfileRepository(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public Optional<RiderProfile> findByTenantIdAndAccountId(UUID tenantId, UUID accountId) {
+    return jdbc.sql("""
+            SELECT id, display_name, phone_number, created_at, updated_at
+            FROM rider_profiles
+            WHERE tenant_id = :tenantId AND account_id = :accountId
+            """)
+        .param("tenantId", tenantId)
+        .param("accountId", accountId)
+        .query(this::map)
+        .optional();
+  }
+
+  @Override
+  public void insert(UUID tenantId, UUID accountId, RiderProfile profile) {
+    jdbc.sql("""
+            INSERT INTO rider_profiles
+              (id, tenant_id, account_id, display_name, phone_number, created_at, updated_at)
+            VALUES (:id, :tenantId, :accountId, :displayName, :phoneNumber, :createdAt, :updatedAt)
+            """)
+        .param("id", profile.id())
+        .param("tenantId", tenantId)
+        .param("accountId", accountId)
+        .param("displayName", profile.displayName())
+        .param("phoneNumber", profile.phoneNumber())
+        .param("createdAt", Timestamp.from(profile.createdAt()))
+        .param("updatedAt", Timestamp.from(profile.updatedAt()))
+        .update();
+  }
+
+  @Override
+  public boolean update(
+      UUID tenantId, UUID accountId, String displayName, String phoneNumber, Instant updatedAt) {
+    return jdbc.sql("""
+            UPDATE rider_profiles
+            SET display_name = :displayName, phone_number = :phoneNumber, updated_at = :updatedAt
+            WHERE tenant_id = :tenantId AND account_id = :accountId
+            """)
+        .param("tenantId", tenantId)
+        .param("accountId", accountId)
+        .param("displayName", displayName)
+        .param("phoneNumber", phoneNumber)
+        .param("updatedAt", Timestamp.from(updatedAt))
+        .update() == 1;
+  }
+
+  private RiderProfile map(ResultSet resultSet, int rowNumber) throws SQLException {
+    return new RiderProfile(
+        resultSet.getObject("id", UUID.class),
+        resultSet.getString("display_name"),
+        resultSet.getString("phone_number"),
+        resultSet.getTimestamp("created_at").toInstant(),
+        resultSet.getTimestamp("updated_at").toInstant());
+  }
+}

--- a/src/main/java/in/rsh/cab/rider/internal/persistence/RiderProfileRepository.java
+++ b/src/main/java/in/rsh/cab/rider/internal/persistence/RiderProfileRepository.java
@@ -1,0 +1,15 @@
+package in.rsh.cab.rider.internal.persistence;
+
+import in.rsh.cab.rider.RiderProfile;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RiderProfileRepository {
+
+  Optional<RiderProfile> findByTenantIdAndAccountId(UUID tenantId, UUID accountId);
+
+  void insert(UUID tenantId, UUID accountId, RiderProfile profile);
+
+  boolean update(UUID tenantId, UUID accountId, String displayName, String phoneNumber,
+      java.time.Instant updatedAt);
+}

--- a/src/main/java/in/rsh/cab/rider/internal/web/RiderProfileController.java
+++ b/src/main/java/in/rsh/cab/rider/internal/web/RiderProfileController.java
@@ -1,0 +1,47 @@
+package in.rsh.cab.rider.internal.web;
+
+import in.rsh.cab.rider.RiderProfile;
+import in.rsh.cab.rider.RiderProfileService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rider/profile")
+public class RiderProfileController {
+
+  private final RiderProfileService profiles;
+
+  public RiderProfileController(RiderProfileService profiles) {
+    this.profiles = profiles;
+  }
+
+  @PostMapping
+  public ResponseEntity<RiderProfile> create(@Valid @RequestBody ProfileRequest request) {
+    RiderProfile profile = profiles.create(request.displayName(), request.phoneNumber());
+    return ResponseEntity.created(URI.create("/api/v1/rider/profile")).body(profile);
+  }
+
+  @GetMapping
+  public RiderProfile getOwn() {
+    return profiles.getOwn();
+  }
+
+  @PutMapping
+  public RiderProfile update(@Valid @RequestBody ProfileRequest request) {
+    return profiles.updateOwn(request.displayName(), request.phoneNumber());
+  }
+
+  public record ProfileRequest(
+      @NotBlank @Size(max = 120) String displayName,
+      @Pattern(regexp = "^\\+?[0-9 -]{7,32}$") String phoneNumber) {}
+}

--- a/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
+++ b/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
@@ -25,11 +25,14 @@ public class SecurityConfiguration {
                     .authenticated()
                     .requestMatchers(HttpMethod.POST, "/api/v1/tenants")
                     .hasAuthority("SCOPE_platform.admin")
-                    .requestMatchers(HttpMethod.GET, "/api/v1/service-areas")
-                    .authenticated()
-                    .requestMatchers(HttpMethod.POST, "/api/v1/service-areas")
-                    .authenticated()
-                    .requestMatchers(HttpMethod.POST, "/api/v1/routes/estimate")
+                    .requestMatchers(
+                        "/api/v1/current-tenant",
+                        "/api/v1/service-areas/**",
+                        "/api/v1/routes/**",
+                        "/api/v1/rider/**",
+                        "/api/v1/drivers/**",
+                        "/api/v1/vehicles/**",
+                        "/api/v1/driver/shifts/**")
                     .authenticated()
                     .requestMatchers("/api/v1/**")
                     .authenticated()

--- a/src/main/java/in/rsh/cab/tenancy/TenantService.java
+++ b/src/main/java/in/rsh/cab/tenancy/TenantService.java
@@ -12,7 +12,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,15 +23,7 @@ public class TenantService {
   private final TenantMembershipRepository memberships;
   private final Clock clock;
 
-  @Autowired
   public TenantService(
-      TenantRepository tenants,
-      UserAccountRepository accounts,
-      TenantMembershipRepository memberships) {
-    this(tenants, accounts, memberships, Clock.systemUTC());
-  }
-
-  TenantService(
       TenantRepository tenants,
       UserAccountRepository accounts,
       TenantMembershipRepository memberships,
@@ -107,6 +98,28 @@ public class TenantService {
             .orElseThrow(() -> new TenantAccessDeniedException("Active tenant membership is required"));
     return new TenantContext(
         tenantId, account.getId(), membership.getId(), membership.getRoles());
+  }
+
+  @Transactional
+  public void grantRoleForActiveAccount(UUID accountId, TenantRole role) {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(TenantRole.TENANT_ADMIN)) {
+      throw new TenantAccessDeniedException("TENANT_ADMIN role is required");
+    }
+    TenantMembershipEntity membership =
+        memberships
+            .findByTenantIdAndUserAccountIdAndStatus(context.tenantId(), accountId, "ACTIVE")
+            .orElseThrow(
+                () -> new InvalidRequestException("Account must have an active tenant membership"));
+    membership.addRole(role, clock.instant());
+  }
+
+  @Transactional
+  public void grantSelfServiceRole(TenantRole role) {
+    if (role != TenantRole.RIDER && role != TenantRole.DRIVER) {
+      throw new InvalidRequestException("Only RIDER or DRIVER can be granted here");
+    }
+    grantRoleForActiveAccount(TenantContext.require().accountId(), role);
   }
 
   private TenantSummary summary(TenantEntity tenant, Set<TenantRole> roles) {

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantMembershipEntity.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantMembershipEntity.java
@@ -48,4 +48,10 @@ public class TenantMembershipEntity {
     this.createdAt = now;
     this.updatedAt = now;
   }
+
+  public void addRole(TenantRole role, Instant now) {
+    if (roles.add(role)) {
+      updatedAt = now;
+    }
+  }
 }

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/CurrentTenantController.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/CurrentTenantController.java
@@ -1,6 +1,11 @@
 package in.rsh.cab.tenancy.internal.web;
 
 import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import in.rsh.cab.tenancy.TenantService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,8 +14,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/current-tenant")
 public class CurrentTenantController {
 
+  private final TenantService tenantService;
+
+  public CurrentTenantController(TenantService tenantService) {
+    this.tenantService = tenantService;
+  }
+
   @GetMapping
   public TenantContext current() {
     return TenantContext.require();
+  }
+
+  @PostMapping("/roles/{role}")
+  public ResponseEntity<Void> grantSelfServiceRole(@PathVariable TenantRole role) {
+    tenantService.grantSelfServiceRole(role);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/resources/db/migration/V4__riders_drivers_and_fleet.sql
+++ b/src/main/resources/db/migration/V4__riders_drivers_and_fleet.sql
@@ -1,0 +1,104 @@
+CREATE TABLE rider_profiles (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    account_id uuid NOT NULL,
+    display_name varchar(120) NOT NULL,
+    phone_number varchar(32),
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_rider_profile_tenant_account UNIQUE (tenant_id, account_id),
+    CONSTRAINT uq_rider_profile_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_rider_profile_membership
+        FOREIGN KEY (tenant_id, account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id)
+);
+
+CREATE TABLE driver_profiles (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    account_id uuid NOT NULL,
+    legal_name varchar(120) NOT NULL,
+    phone_number varchar(32),
+    status varchar(32) NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_driver_profile_tenant_account UNIQUE (tenant_id, account_id),
+    CONSTRAINT uq_driver_profile_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_driver_profile_membership
+        FOREIGN KEY (tenant_id, account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_driver_profile_status
+        CHECK (status IN ('PENDING', 'APPROVED', 'SUSPENDED'))
+);
+
+CREATE TABLE driver_documents (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    driver_id uuid NOT NULL,
+    document_type varchar(64) NOT NULL,
+    document_reference varchar(255) NOT NULL,
+    object_key varchar(512),
+    expires_on date,
+    verification_status varchar(32) NOT NULL,
+    verified_at timestamptz,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_driver_document_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_driver_document_profile
+        FOREIGN KEY (tenant_id, driver_id)
+        REFERENCES driver_profiles (tenant_id, id) ON DELETE CASCADE,
+    CONSTRAINT chk_driver_document_verification
+        CHECK (verification_status IN ('PENDING', 'VERIFIED', 'REJECTED'))
+);
+
+CREATE TABLE vehicles (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    registration varchar(32) NOT NULL,
+    service_class varchar(32) NOT NULL,
+    capacity integer NOT NULL,
+    status varchar(32) NOT NULL,
+    version bigint NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_vehicle_tenant_registration UNIQUE (tenant_id, registration),
+    CONSTRAINT uq_vehicle_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT chk_vehicle_capacity CHECK (capacity BETWEEN 1 AND 20),
+    CONSTRAINT chk_vehicle_status CHECK (status IN ('ACTIVE', 'INACTIVE'))
+);
+
+CREATE TABLE driver_shifts (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    driver_id uuid NOT NULL,
+    vehicle_id uuid NOT NULL,
+    status varchar(32) NOT NULL,
+    version bigint NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    available_at timestamptz,
+    closed_at timestamptz,
+    CONSTRAINT uq_driver_shift_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_driver_shift_driver
+        FOREIGN KEY (tenant_id, driver_id)
+        REFERENCES driver_profiles (tenant_id, id),
+    CONSTRAINT fk_driver_shift_vehicle
+        FOREIGN KEY (tenant_id, vehicle_id)
+        REFERENCES vehicles (tenant_id, id),
+    CONSTRAINT chk_driver_shift_status
+        CHECK (status IN ('OFFLINE', 'AVAILABLE', 'RESERVED', 'ON_TRIP', 'CLOSED'))
+);
+
+CREATE INDEX idx_rider_profiles_tenant ON rider_profiles (tenant_id);
+CREATE INDEX idx_driver_profiles_tenant_status ON driver_profiles (tenant_id, status);
+CREATE INDEX idx_driver_documents_tenant_driver ON driver_documents (tenant_id, driver_id);
+CREATE INDEX idx_vehicles_tenant_status ON vehicles (tenant_id, status);
+CREATE INDEX idx_driver_shifts_tenant_status ON driver_shifts (tenant_id, status);
+
+CREATE UNIQUE INDEX uq_driver_open_shift
+    ON driver_shifts (tenant_id, driver_id)
+    WHERE status <> 'CLOSED';
+
+CREATE UNIQUE INDEX uq_vehicle_open_shift
+    ON driver_shifts (tenant_id, vehicle_id)
+    WHERE status <> 'CLOSED';

--- a/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
@@ -98,9 +98,76 @@ class MarketplaceHttpIT {
     HttpResponse<String> current = getWithTenant("/api/v1/current-tenant", tenantId, "platform-admin");
     assertEquals(200, current.statusCode());
     assertTrue(current.body().contains(tenantId));
+    String accountId =
+        JsonParser.parseString(current.body()).getAsJsonObject().get("accountId").getAsString();
     assertEquals(
         403,
         getWithTenant("/api/v1/current-tenant", tenantId, "unknown-user").statusCode());
+
+    assertEquals(
+        204,
+        postWithTenant("/api/v1/current-tenant/roles/RIDER", tenantId, "").statusCode());
+    HttpResponse<String> riderCreated =
+        postWithTenant(
+            "/api/v1/rider/profile",
+            tenantId,
+            "{\"displayName\":\"Admin Rider\",\"phoneNumber\":\"+1 555 0100\"}");
+    assertEquals(201, riderCreated.statusCode());
+    assertEquals(
+        "Admin Rider",
+        JsonParser.parseString(riderCreated.body()).getAsJsonObject().get("displayName").getAsString());
+    assertEquals(200, getWithTenant("/api/v1/rider/profile", tenantId, "platform-admin").statusCode());
+
+    HttpResponse<String> vehicleCreated =
+        postWithTenant(
+            "/api/v1/vehicles",
+            tenantId,
+            "{\"registration\":\"KA 01 AB 1234\",\"serviceClass\":\"STANDARD\",\"capacity\":4}");
+    assertEquals(201, vehicleCreated.statusCode());
+    JsonObject vehicle = JsonParser.parseString(vehicleCreated.body()).getAsJsonObject();
+    String vehicleId = vehicle.get("id").getAsString();
+    assertEquals("KA01AB1234", vehicle.get("registration").getAsString());
+    assertEquals(1, JsonParser.parseString(
+        getWithTenant("/api/v1/vehicles", tenantId, "platform-admin").body()).getAsJsonArray().size());
+
+    HttpResponse<String> driverCreated =
+        postWithTenant(
+            "/api/v1/drivers",
+            tenantId,
+            "{\"accountId\":\"" + accountId
+                + "\",\"legalName\":\"Admin Driver\",\"phoneNumber\":\"+1 555 0101\"}");
+    assertEquals(201, driverCreated.statusCode());
+    String driverId =
+        JsonParser.parseString(driverCreated.body()).getAsJsonObject().get("id").getAsString();
+    assertEquals(
+        200,
+        postWithTenant("/api/v1/drivers/" + driverId + "/approve", tenantId, "").statusCode());
+    assertEquals(1, JsonParser.parseString(
+        getWithTenant("/api/v1/drivers", tenantId, "platform-admin").body()).getAsJsonArray().size());
+
+    HttpResponse<String> shiftCreated =
+        postWithTenant(
+            "/api/v1/driver/shifts",
+            tenantId,
+            "{\"driverId\":\"" + driverId + "\",\"vehicleId\":\"" + vehicleId + "\"}");
+    assertEquals(201, shiftCreated.statusCode());
+    JsonObject shift = JsonParser.parseString(shiftCreated.body()).getAsJsonObject();
+    String shiftId = shift.get("id").getAsString();
+    assertEquals("OFFLINE", shift.get("status").getAsString());
+    HttpResponse<String> online = postWithTenant(
+        "/api/v1/driver/shifts/" + shiftId + "/go-online", tenantId, "{\"version\":0}");
+    assertEquals(200, online.statusCode());
+    assertEquals("AVAILABLE",
+        JsonParser.parseString(online.body()).getAsJsonObject().get("status").getAsString());
+    HttpResponse<String> staleOnline = postWithTenant(
+        "/api/v1/driver/shifts/" + shiftId + "/go-online", tenantId, "{\"version\":0}");
+    assertEquals(409, staleOnline.statusCode());
+    assertTrue(staleOnline.body().contains("resource-conflict"));
+    HttpResponse<String> offline = postWithTenant(
+        "/api/v1/driver/shifts/" + shiftId + "/go-offline", tenantId, "{\"version\":1}");
+    assertEquals(200, offline.statusCode());
+    assertEquals("OFFLINE",
+        JsonParser.parseString(offline.body()).getAsJsonObject().get("status").getAsString());
 
     String boundary =
         "{\"type\":\"Polygon\",\"coordinates\":[[[77.5,12.9],[77.7,12.9],[77.7,13.1],[77.5,12.9]]]}";

--- a/src/test/java/in/rsh/cab/driver/DriverServiceTest.java
+++ b/src/test/java/in/rsh/cab/driver/DriverServiceTest.java
@@ -1,0 +1,122 @@
+package in.rsh.cab.driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import in.rsh.cab.tenancy.TenantService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class DriverServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID ACCOUNT_ID = UUID.randomUUID();
+  private final DriverProfileRepository repository = mock(DriverProfileRepository.class);
+  private final TenantService tenants = mock(TenantService.class);
+  private DriverService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new DriverService(
+        repository, tenants,
+        Clock.fixed(Instant.parse("2026-08-08T10:00:00Z"), ZoneOffset.UTC));
+    admin();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void adminOnboardsListsAndApprovesMember() {
+    DriverProfile pending = service.create(ACCOUNT_ID, "Driver One", "+1 555 0100");
+    assertEquals(DriverStatus.PENDING, pending.status());
+    verify(tenants).grantRoleForActiveAccount(ACCOUNT_ID, TenantRole.DRIVER);
+    verify(repository).insert(TENANT_ID, pending);
+
+    when(repository.findAllByTenantId(TENANT_ID)).thenReturn(List.of(pending));
+    assertEquals(List.of(pending), service.list());
+    when(repository.findByTenantIdAndId(TENANT_ID, pending.id())).thenReturn(Optional.of(pending));
+    when(repository.updateStatus(any(), any(), any(), any(), any())).thenReturn(true);
+    assertEquals(DriverStatus.APPROVED, service.approve(pending.id()).status());
+  }
+
+  @Test
+  void adminSuspendsApprovedDriverAndRejectsInvalidOrConcurrentTransitions() {
+    DriverProfile approved = profile(DriverStatus.APPROVED);
+    when(repository.findByTenantIdAndId(TENANT_ID, approved.id())).thenReturn(Optional.of(approved));
+    when(repository.updateStatus(any(), any(), any(), any(), any())).thenReturn(true);
+    assertEquals(DriverStatus.SUSPENDED, service.suspend(approved.id()).status());
+
+    DriverProfile pending = profile(DriverStatus.PENDING);
+    when(repository.findByTenantIdAndId(TENANT_ID, pending.id())).thenReturn(Optional.of(pending));
+    assertThrows(ConflictException.class, () -> service.suspend(pending.id()));
+
+    when(repository.findByTenantIdAndId(TENANT_ID, approved.id())).thenReturn(Optional.of(approved));
+    when(repository.updateStatus(any(), any(), any(), any(), any())).thenReturn(false);
+    assertThrows(ConflictException.class, () -> service.suspend(approved.id()));
+    assertThrows(NotFoundException.class, () -> service.approve(UUID.randomUUID()));
+  }
+
+  @Test
+  void driverReadsAndUpdatesOwnProfile() {
+    driver();
+    DriverProfile profile = profile(DriverStatus.APPROVED);
+    when(repository.findByTenantIdAndAccountId(TENANT_ID, ACCOUNT_ID))
+        .thenReturn(Optional.of(profile));
+    assertEquals(profile, service.getOwn());
+    when(repository.updateOwn(any(), any(), any(), any(), any())).thenReturn(true);
+    assertEquals(profile, service.updateOwn("Driver One", null));
+
+    when(repository.updateOwn(any(), any(), any(), any(), any())).thenReturn(false);
+    assertThrows(NotFoundException.class, () -> service.updateOwn("Missing", null));
+    when(repository.findByTenantIdAndAccountId(TENANT_ID, ACCOUNT_ID)).thenReturn(Optional.empty());
+    assertThrows(NotFoundException.class, service::getOwn);
+  }
+
+  @Test
+  void rejectsWrongRoleAndDuplicateProfile() {
+    driver();
+    assertThrows(TenantAccessDeniedException.class, service::list);
+    admin();
+    doThrow(new DataIntegrityViolationException("constraint"))
+        .when(repository).insert(any(), any());
+    assertThrows(ConflictException.class, () -> service.create(ACCOUNT_ID, "Driver", null));
+  }
+
+  private DriverProfile profile(DriverStatus status) {
+    return new DriverProfile(
+        UUID.randomUUID(), ACCOUNT_ID, "Driver One", null, status, Instant.EPOCH, Instant.EPOCH);
+  }
+
+  private void admin() {
+    TenantContext.set(new TenantContext(
+        TENANT_ID, ACCOUNT_ID, UUID.randomUUID(), Set.of(TenantRole.TENANT_ADMIN)));
+  }
+
+  private void driver() {
+    TenantContext.set(new TenantContext(
+        TENANT_ID, ACCOUNT_ID, UUID.randomUUID(), Set.of(TenantRole.DRIVER)));
+  }
+}

--- a/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
@@ -40,6 +40,11 @@ class GlobalExceptionHandlerTest {
         "cab-unavailable",
         "No cabs available");
     assertProblem(
+        handler.handleConflict(new ConflictException("Version is stale")),
+        HttpStatus.CONFLICT,
+        "resource-conflict",
+        "Version is stale");
+    assertProblem(
         handler.handleBadRequest(new InvalidRequestException("Invalid request")),
         HttpStatus.BAD_REQUEST,
         "invalid-request",

--- a/src/test/java/in/rsh/cab/fleet/FleetServiceTest.java
+++ b/src/test/java/in/rsh/cab/fleet/FleetServiceTest.java
@@ -1,0 +1,179 @@
+package in.rsh.cab.fleet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.driver.DriverStatus;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.fleet.internal.persistence.FleetRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class FleetServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID ACCOUNT_ID = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
+  private final FleetRepository repository = mock(FleetRepository.class);
+  private FleetService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new FleetService(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+    admin();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void adminCreatesListsAndVersionUpdatesVehicle() {
+    Vehicle created = service.createVehicle("ab 12 cd", "STANDARD", 4);
+    assertEquals("AB12CD", created.registration());
+    verify(repository).insertVehicle(TENANT_ID, created);
+    when(repository.findVehicles(TENANT_ID)).thenReturn(List.of(created));
+    assertEquals(List.of(created), service.listVehicles());
+
+    when(repository.findVehicle(TENANT_ID, created.id())).thenReturn(Optional.of(created));
+    when(repository.updateVehicle(any(), any(), any(Long.class))).thenReturn(true);
+    Vehicle updated = service.updateVehicle(
+        created.id(), "xy 99", "XL", 6, VehicleStatus.INACTIVE, 0);
+    assertEquals(1, updated.version());
+    assertEquals(VehicleStatus.INACTIVE, updated.status());
+  }
+
+  @Test
+  void vehicleValidatesCapacityRoleDuplicatesAndOptimisticConflicts() {
+    assertThrows(InvalidRequestException.class,
+        () -> service.createVehicle("A", "STANDARD", 0));
+    doThrow(new DataIntegrityViolationException("constraint"))
+        .when(repository).insertVehicle(any(), any());
+    assertThrows(ConflictException.class,
+        () -> service.createVehicle("A", "STANDARD", 4));
+
+    Vehicle vehicle = vehicle(VehicleStatus.ACTIVE, 2);
+    when(repository.findVehicle(TENANT_ID, vehicle.id())).thenReturn(Optional.of(vehicle));
+    assertThrows(ConflictException.class,
+        () -> service.updateVehicle(vehicle.id(), "A", "STANDARD", 4, VehicleStatus.ACTIVE, 1));
+    when(repository.updateVehicle(any(), any(), any(Long.class))).thenReturn(false);
+    assertThrows(ConflictException.class,
+        () -> service.updateVehicle(vehicle.id(), "A", "STANDARD", 4, VehicleStatus.ACTIVE, 2));
+    assertThrows(NotFoundException.class,
+        () -> service.updateVehicle(UUID.randomUUID(), "A", "STANDARD", 4, VehicleStatus.ACTIVE, 0));
+
+    driver();
+    assertThrows(TenantAccessDeniedException.class, service::listVehicles);
+  }
+
+  @Test
+  void approvedDriverCreatesAndTransitionsOwnShift() {
+    driver();
+    UUID driverId = UUID.randomUUID();
+    Vehicle vehicle = vehicle(VehicleStatus.ACTIVE, 0);
+    when(repository.findDriverStatus(TENANT_ID, driverId, ACCOUNT_ID))
+        .thenReturn(Optional.of(DriverStatus.APPROVED));
+    when(repository.findVehicle(TENANT_ID, vehicle.id())).thenReturn(Optional.of(vehicle));
+    DriverShift shift = service.createShift(driverId, vehicle.id());
+    assertEquals(ShiftStatus.OFFLINE, shift.status());
+    verify(repository).insertShift(TENANT_ID, shift);
+
+    when(repository.findShift(TENANT_ID, shift.id(), ACCOUNT_ID)).thenReturn(Optional.of(shift));
+    when(repository.updateShift(any(), any(), any(Long.class))).thenReturn(true);
+    DriverShift online = service.goOnline(shift.id(), 0);
+    assertEquals(ShiftStatus.AVAILABLE, online.status());
+    assertNotNull(online.availableAt());
+
+    when(repository.findShift(TENANT_ID, shift.id(), ACCOUNT_ID)).thenReturn(Optional.of(online));
+    DriverShift offline = service.goOffline(shift.id(), 1);
+    assertEquals(ShiftStatus.OFFLINE, offline.status());
+    when(repository.findShift(TENANT_ID, shift.id(), ACCOUNT_ID)).thenReturn(Optional.of(offline));
+    DriverShift closed = service.closeShift(shift.id(), 2);
+    assertEquals(ShiftStatus.CLOSED, closed.status());
+    assertNotNull(closed.closedAt());
+  }
+
+  @Test
+  void shiftRejectsIneligibleResourcesDuplicatesAndStaleTransitions() {
+    driver();
+    UUID driverId = UUID.randomUUID();
+    UUID vehicleId = UUID.randomUUID();
+    when(repository.findDriverStatus(TENANT_ID, driverId, ACCOUNT_ID))
+        .thenReturn(Optional.of(DriverStatus.PENDING));
+    assertThrows(ConflictException.class, () -> service.createShift(driverId, vehicleId));
+    when(repository.findDriverStatus(TENANT_ID, driverId, ACCOUNT_ID))
+        .thenReturn(Optional.of(DriverStatus.APPROVED));
+    when(repository.findVehicle(TENANT_ID, vehicleId))
+        .thenReturn(Optional.of(vehicle(VehicleStatus.INACTIVE, 0)));
+    assertThrows(ConflictException.class, () -> service.createShift(driverId, vehicleId));
+    when(repository.findVehicle(TENANT_ID, vehicleId)).thenReturn(Optional.empty());
+    assertThrows(NotFoundException.class, () -> service.createShift(driverId, vehicleId));
+    when(repository.findDriverStatus(TENANT_ID, driverId, ACCOUNT_ID)).thenReturn(Optional.empty());
+    assertThrows(NotFoundException.class, () -> service.createShift(driverId, vehicleId));
+
+    DriverShift shift = shift(ShiftStatus.OFFLINE, 1);
+    when(repository.findShift(TENANT_ID, shift.id(), ACCOUNT_ID)).thenReturn(Optional.of(shift));
+    assertThrows(ConflictException.class, () -> service.goOnline(shift.id(), 0));
+    assertThrows(ConflictException.class, () -> service.goOffline(shift.id(), 1));
+    when(repository.updateShift(any(), any(), any(Long.class))).thenReturn(false);
+    assertThrows(ConflictException.class, () -> service.goOnline(shift.id(), 1));
+    assertThrows(NotFoundException.class, () -> service.goOnline(UUID.randomUUID(), 0));
+  }
+
+  @Test
+  void listsOnlyOwnShiftsAndMapsOpenShiftConstraint() {
+    driver();
+    DriverShift shift = shift(ShiftStatus.OFFLINE, 0);
+    when(repository.findShifts(TENANT_ID, ACCOUNT_ID)).thenReturn(List.of(shift));
+    assertEquals(List.of(shift), service.listOwnShifts());
+
+    when(repository.findDriverStatus(TENANT_ID, shift.driverId(), ACCOUNT_ID))
+        .thenReturn(Optional.of(DriverStatus.APPROVED));
+    when(repository.findVehicle(TENANT_ID, shift.vehicleId()))
+        .thenReturn(Optional.of(vehicle(VehicleStatus.ACTIVE, 0)));
+    doThrow(new DataIntegrityViolationException("constraint"))
+        .when(repository).insertShift(any(), any());
+    assertThrows(ConflictException.class,
+        () -> service.createShift(shift.driverId(), shift.vehicleId()));
+  }
+
+  private Vehicle vehicle(VehicleStatus status, long version) {
+    return new Vehicle(UUID.randomUUID(), "AB12", "STANDARD", 4, status, version, NOW, NOW);
+  }
+
+  private DriverShift shift(ShiftStatus status, long version) {
+    return new DriverShift(
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), status, version, NOW, NOW, null, null);
+  }
+
+  private void admin() {
+    TenantContext.set(new TenantContext(
+        TENANT_ID, ACCOUNT_ID, UUID.randomUUID(), Set.of(TenantRole.TENANT_ADMIN)));
+  }
+
+  private void driver() {
+    TenantContext.set(new TenantContext(
+        TENANT_ID, ACCOUNT_ID, UUID.randomUUID(), Set.of(TenantRole.DRIVER)));
+  }
+}

--- a/src/test/java/in/rsh/cab/rider/RiderProfileServiceTest.java
+++ b/src/test/java/in/rsh/cab/rider/RiderProfileServiceTest.java
@@ -1,0 +1,85 @@
+package in.rsh.cab.rider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.rider.internal.persistence.RiderProfileRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class RiderProfileServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID ACCOUNT_ID = UUID.randomUUID();
+  private final RiderProfileRepository repository = mock(RiderProfileRepository.class);
+  private RiderProfileService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new RiderProfileService(
+        repository, Clock.fixed(Instant.parse("2026-08-08T10:00:00Z"), ZoneOffset.UTC));
+    TenantContext.set(new TenantContext(
+        TENANT_ID, ACCOUNT_ID, UUID.randomUUID(), Set.of(TenantRole.RIDER)));
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void createsAndReadsProfileForContextAccount() {
+    RiderProfile created = service.create("Rider One", "+1 555 0100");
+    when(repository.findByTenantIdAndAccountId(TENANT_ID, ACCOUNT_ID))
+        .thenReturn(Optional.of(created));
+
+    assertEquals(Instant.parse("2026-08-08T10:00:00Z"), created.createdAt());
+    assertEquals(created, service.getOwn());
+    verify(repository).insert(TENANT_ID, ACCOUNT_ID, created);
+  }
+
+  @Test
+  void updatesOnlyContextAccountAndReportsMissingProfile() {
+    RiderProfile updated = new RiderProfile(
+        UUID.randomUUID(), "New Name", null, Instant.EPOCH, Instant.EPOCH);
+    when(repository.update(TENANT_ID, ACCOUNT_ID, "New Name", null,
+        Instant.parse("2026-08-08T10:00:00Z"))).thenReturn(true);
+    when(repository.findByTenantIdAndAccountId(TENANT_ID, ACCOUNT_ID))
+        .thenReturn(Optional.of(updated));
+    assertEquals(updated, service.updateOwn("New Name", null));
+
+    when(repository.update(any(), any(), any(), any(), any())).thenReturn(false);
+    assertThrows(NotFoundException.class, () -> service.updateOwn("Missing", null));
+    when(repository.findByTenantIdAndAccountId(TENANT_ID, ACCOUNT_ID)).thenReturn(Optional.empty());
+    assertThrows(NotFoundException.class, service::getOwn);
+  }
+
+  @Test
+  void requiresRiderAndMapsDuplicateToConflict() {
+    doThrow(new DataIntegrityViolationException("constraint"))
+        .when(repository).insert(any(), any(), any());
+    assertThrows(ConflictException.class, () -> service.create("Rider", null));
+
+    TenantContext.set(new TenantContext(
+        TENANT_ID, ACCOUNT_ID, UUID.randomUUID(), Set.of(TenantRole.TENANT_ADMIN)));
+    assertThrows(TenantAccessDeniedException.class, service::getOwn);
+  }
+}

--- a/src/test/java/in/rsh/cab/tenancy/TenantServiceTest.java
+++ b/src/test/java/in/rsh/cab/tenancy/TenantServiceTest.java
@@ -108,4 +108,36 @@ class TenantServiceTest {
         TenantAccessDeniedException.class,
         () -> service.authorize("issuer", "unknown", tenantId));
   }
+
+  @Test
+  void tenantAdminGrantsOnlySelfServiceRolesToActiveMembership() {
+    UUID tenantId = UUID.randomUUID();
+    UUID accountId = UUID.randomUUID();
+    TenantMembershipEntity membership = new TenantMembershipEntity(
+        UUID.randomUUID(), tenantId, accountId, Set.of(TenantRole.TENANT_ADMIN), Instant.EPOCH);
+    TenantContext.set(new TenantContext(
+        tenantId, accountId, membership.getId(), Set.of(TenantRole.TENANT_ADMIN)));
+    when(memberships.findByTenantIdAndUserAccountIdAndStatus(tenantId, accountId, "ACTIVE"))
+        .thenReturn(Optional.of(membership));
+
+    service.grantSelfServiceRole(TenantRole.RIDER);
+    assertEquals(Set.of(TenantRole.TENANT_ADMIN, TenantRole.RIDER), membership.getRoles());
+    assertThrows(InvalidRequestException.class,
+        () -> service.grantSelfServiceRole(TenantRole.FINANCE));
+
+    when(memberships.findByTenantIdAndUserAccountIdAndStatus(tenantId, UUID.randomUUID(), "ACTIVE"))
+        .thenReturn(Optional.empty());
+    assertThrows(InvalidRequestException.class,
+        () -> service.grantRoleForActiveAccount(UUID.randomUUID(), TenantRole.DRIVER));
+    TenantContext.clear();
+  }
+
+  @Test
+  void nonAdminCannotGrantTenantRole() {
+    TenantContext.set(new TenantContext(
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), Set.of(TenantRole.DRIVER)));
+    assertThrows(TenantAccessDeniedException.class,
+        () -> service.grantRoleForActiveAccount(UUID.randomUUID(), TenantRole.RIDER));
+    TenantContext.clear();
+  }
 }


### PR DESCRIPTION
## Summary
- Delivers `feat(fleet): add marketplace profiles and driver shifts` as part 5 of 26 in the production marketplace stack.
- Contains 36 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/102`
- Head: `stack/05-fleet`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.