### PR TITLE
feat(operations): add idempotency outbox and audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The current implementation supports:
 - OSRM-backed route distance and duration estimates
 - Tenant-scoped rider and driver profiles, driver approval, vehicles, and driver shifts
 - Tenant-scoped service products, versioned pricing rules, and immutable rider fare quotes
+- Tenant-scoped idempotency, transactional outbox/inbox, and append-only audit foundations
 
 The production roadmap includes:
 
@@ -152,6 +153,7 @@ versioned endpoint is:
 | `POST`, `GET` | `/api/v1/pricing-rules` | Create or list versioned pricing rules; requires `TENANT_ADMIN` |
 | `POST`, `GET` | `/api/v1/quotes` | Create or list the authenticated rider's immutable fare quotes |
 | `GET` | `/api/v1/quotes/{id}` | Read one fare quote owned by the authenticated rider |
+| `GET` | `/api/v1/admin/audit-events` | List tenant audit events; requires `TENANT_ADMIN` or `SUPPORT` |
 
 Operational probes are available at `/actuator/health/liveness` and
 `/actuator/health/readiness`. API responses include `X-Correlation-ID`; clients may supply this
@@ -181,9 +183,28 @@ tenant context, never from request data. Quotes have no update API and persisted
 never recalculated when products or rules change. Configure validity with `QUOTE_TTL` (default
 `PT10M`).
 
+`POST /api/v1/quotes` requires an `Idempotency-Key` of 1 to 255 characters. Keys are scoped by
+tenant, authenticated account, and operation. Repeating the same canonical request returns the
+original `201` response without recalculating or writing another quote; reusing a live key with a
+different request returns `409 idempotency-key-reused`. Records expire after `IDEMPOTENCY_TTL`
+(default `PT24H`). Only a response representation explicitly selected by the calling service is
+stored, never arbitrary servlet responses, headers, bearer tokens, or unredacted request bodies.
+
+Quote creation writes the quote, completed idempotency record, `fare_quote.created` outbox event,
+and `fare_quote.create` audit event in one database transaction. Outbox payloads and audit summaries
+must be deliberately minimized by callers. Outbox consumers lease tenant-qualified batches using
+`FOR UPDATE SKIP LOCKED`; expired leases can be reclaimed, retries clear lease state, and permanent
+failures remain inspectable. Inbox receipts deduplicate by tenant, consumer, and event ID. Audit
+events are append-only: the database rejects updates and deletes. The audit list is tenant-scoped,
+newest-first, and limited to 200 rows per request.
+
 The backend validates OIDC issuer, audience, signature, expiry, and subject. Configure
 `OIDC_ISSUER_URI` and `OIDC_AUDIENCE`; authorization roles are stored in tenant memberships rather
 than trusted solely from bearer-token claims.
+
+Correlation IDs are bounded to 128 characters and flow through request metadata into outbox and
+audit records. Sensitive values must not be placed in correlation IDs, idempotency keys, event
+payloads, audit summaries, or retry error text.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,13 @@ the persisted `RIDER` role and derive rider ownership from the authenticated ten
 and rider identifiers are not accepted in quote request bodies. Monetary arithmetic is checked for
 overflow, and quote snapshots are immutable through the HTTP API.
 
+Fare quote creation requires a tenant/account/operation-scoped idempotency key. Only a
+caller-selected safe response is retained for replay; raw requests, authorization headers, and
+arbitrary responses must never be stored. Outbox payloads and audit summaries must be explicitly
+minimized and redacted. Correlation IDs are bounded and must not contain secrets. Audit reads
+require `TENANT_ADMIN` or `SUPPORT`, all operational queries are tenant-qualified, and database
+triggers reject audit updates and deletes.
+
 ## Reporting A Vulnerability
 
 Use GitHub private vulnerability reporting for this repository. Open the repository's **Security**

--- a/src/main/java/in/rsh/cab/audit/AuditEvent.java
+++ b/src/main/java/in/rsh/cab/audit/AuditEvent.java
@@ -1,0 +1,16 @@
+package in.rsh.cab.audit;
+
+import java.time.Instant;
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public record AuditEvent(
+    UUID id,
+    UUID actorAccountId,
+    String action,
+    String targetType,
+    UUID targetId,
+    String outcome,
+    String correlationId,
+    JsonNode summary,
+    Instant occurredAt) {}

--- a/src/main/java/in/rsh/cab/audit/AuditService.java
+++ b/src/main/java/in/rsh/cab/audit/AuditService.java
@@ -1,0 +1,49 @@
+package in.rsh.cab.audit;
+
+import in.rsh.cab.audit.internal.persistence.AuditRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import in.rsh.cab.web.RequestMetadata;
+import java.time.Clock;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+
+@Service
+public class AuditService {
+
+  private final AuditRepository events;
+  private final Clock clock;
+
+  public AuditService(AuditRepository events, Clock clock) {
+    this.events = events;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public UUID record(
+      UUID tenantId, UUID actorAccountId, String action, String targetType, UUID targetId,
+      String outcome, JsonNode redactedSummary) {
+    UUID id = UUID.randomUUID();
+    events.insert(
+        id, tenantId, actorAccountId, action, targetType, targetId, outcome,
+        RequestMetadata.correlationIdOrNull(), redactedSummary, clock.instant());
+    return id;
+  }
+
+  @Transactional(readOnly = true)
+  public List<AuditEvent> list(int limit) {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(TenantRole.TENANT_ADMIN)
+        && !context.roles().contains(TenantRole.SUPPORT)) {
+      throw new TenantAccessDeniedException("TENANT_ADMIN or SUPPORT role is required");
+    }
+    if (limit < 1 || limit > 200) {
+      throw new IllegalArgumentException("Audit limit must be between 1 and 200");
+    }
+    return events.findLatest(context.tenantId(), limit);
+  }
+}

--- a/src/main/java/in/rsh/cab/audit/internal/persistence/AuditRepository.java
+++ b/src/main/java/in/rsh/cab/audit/internal/persistence/AuditRepository.java
@@ -1,0 +1,16 @@
+package in.rsh.cab.audit.internal.persistence;
+
+import in.rsh.cab.audit.AuditEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public interface AuditRepository {
+
+  void insert(
+      UUID id, UUID tenantId, UUID actorAccountId, String action, String targetType, UUID targetId,
+      String outcome, String correlationId, JsonNode summary, Instant occurredAt);
+
+  List<AuditEvent> findLatest(UUID tenantId, int limit);
+}

--- a/src/main/java/in/rsh/cab/audit/internal/persistence/JdbcAuditRepository.java
+++ b/src/main/java/in/rsh/cab/audit/internal/persistence/JdbcAuditRepository.java
@@ -1,0 +1,71 @@
+package in.rsh.cab.audit.internal.persistence;
+
+import in.rsh.cab.audit.AuditEvent;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Repository
+public class JdbcAuditRepository implements AuditRepository {
+
+  private final JdbcClient jdbc;
+  private final ObjectMapper objectMapper;
+
+  public JdbcAuditRepository(JdbcClient jdbc, ObjectMapper objectMapper) {
+    this.jdbc = jdbc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void insert(
+      UUID id, UUID tenantId, UUID actorAccountId, String action, String targetType, UUID targetId,
+      String outcome, String correlationId, JsonNode summary, Instant occurredAt) {
+    jdbc.sql("""
+            INSERT INTO audit_events
+              (id, tenant_id, actor_account_id, action, target_type, target_id,
+               outcome, correlation_id, summary, occurred_at)
+            VALUES
+              (:id, :tenantId, :actorId, :action, :targetType, :targetId,
+               :outcome, :correlationId, CAST(:summary AS jsonb), :occurredAt)
+            """)
+        .param("id", id).param("tenantId", tenantId).param("actorId", actorAccountId)
+        .param("action", action).param("targetType", targetType).param("targetId", targetId)
+        .param("outcome", outcome).param("correlationId", correlationId)
+        .param("summary", summary.toString()).param("occurredAt", Timestamp.from(occurredAt)).update();
+  }
+
+  @Override
+  public List<AuditEvent> findLatest(UUID tenantId, int limit) {
+    return jdbc.sql("""
+            SELECT id, actor_account_id, action, target_type, target_id, outcome,
+                   correlation_id, summary, occurred_at
+            FROM audit_events
+            WHERE tenant_id = :tenantId
+            ORDER BY occurred_at DESC, id DESC
+            LIMIT :limit
+            """)
+        .param("tenantId", tenantId).param("limit", limit).query(this::map).list();
+  }
+
+  private AuditEvent map(ResultSet resultSet, int rowNumber) throws SQLException {
+    try {
+      return new AuditEvent(
+          resultSet.getObject("id", UUID.class),
+          resultSet.getObject("actor_account_id", UUID.class), resultSet.getString("action"),
+          resultSet.getString("target_type"), resultSet.getObject("target_id", UUID.class),
+          resultSet.getString("outcome"), resultSet.getString("correlation_id"),
+          objectMapper.readTree(resultSet.getString("summary")),
+          resultSet.getTimestamp("occurred_at").toInstant());
+    } catch (JacksonException exception) {
+      throw new SQLException("Stored audit summary is invalid", exception);
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/audit/internal/web/AuditController.java
+++ b/src/main/java/in/rsh/cab/audit/internal/web/AuditController.java
@@ -1,0 +1,25 @@
+package in.rsh.cab.audit.internal.web;
+
+import in.rsh.cab.audit.AuditEvent;
+import in.rsh.cab.audit.AuditService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/audit-events")
+public class AuditController {
+
+  private final AuditService audit;
+
+  public AuditController(AuditService audit) {
+    this.audit = audit;
+  }
+
+  @GetMapping
+  public List<AuditEvent> list(@RequestParam(defaultValue = "100") int limit) {
+    return audit.list(limit);
+  }
+}

--- a/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import in.rsh.cab.routing.RouteProviderException;
+import in.rsh.cab.operations.IdempotencyConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,14 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ConflictException.class)
   public ResponseEntity<ProblemDetail> handleConflict(ConflictException exception) {
     return problem(HttpStatus.CONFLICT, "Conflict", exception.getMessage(), "resource-conflict");
+  }
+
+  @ExceptionHandler(IdempotencyConflictException.class)
+  public ResponseEntity<ProblemDetail> handleIdempotencyConflict(
+      IdempotencyConflictException exception) {
+    String code = exception.reason() == IdempotencyConflictException.Reason.KEY_REUSED
+        ? "idempotency-key-reused" : "idempotency-in-progress";
+    return problem(HttpStatus.CONFLICT, "Idempotency conflict", exception.getMessage(), code);
   }
 
   @ExceptionHandler({IllegalArgumentException.class, InvalidRequestException.class})

--- a/src/main/java/in/rsh/cab/operations/IdempotencyConflictException.java
+++ b/src/main/java/in/rsh/cab/operations/IdempotencyConflictException.java
@@ -1,0 +1,22 @@
+package in.rsh.cab.operations;
+
+public class IdempotencyConflictException extends RuntimeException {
+
+  private final Reason reason;
+
+  public IdempotencyConflictException(Reason reason) {
+    super(reason == Reason.KEY_REUSED
+        ? "Idempotency key was already used for a different request"
+        : "A request with this idempotency key is still in progress");
+    this.reason = reason;
+  }
+
+  public Reason reason() {
+    return reason;
+  }
+
+  public enum Reason {
+    KEY_REUSED,
+    IN_PROGRESS
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/IdempotencyRecord.java
+++ b/src/main/java/in/rsh/cab/operations/IdempotencyRecord.java
@@ -1,0 +1,18 @@
+package in.rsh.cab.operations;
+
+import java.time.Instant;
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public record IdempotencyRecord(
+    UUID id,
+    UUID tenantId,
+    UUID actorAccountId,
+    String operation,
+    String key,
+    String requestHash,
+    IdempotencyState state,
+    UUID resourceId,
+    int httpStatus,
+    JsonNode safeResponse,
+    Instant expiresAt) {}

--- a/src/main/java/in/rsh/cab/operations/IdempotencyReservation.java
+++ b/src/main/java/in/rsh/cab/operations/IdempotencyReservation.java
@@ -1,0 +1,26 @@
+package in.rsh.cab.operations;
+
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public record IdempotencyReservation(
+    Status status, UUID recordId, UUID resourceId, int httpStatus, JsonNode safeResponse) {
+
+  public enum Status {
+    RESERVED,
+    REPLAY
+  }
+
+  static IdempotencyReservation reserved(UUID recordId) {
+    return new IdempotencyReservation(Status.RESERVED, recordId, null, 0, null);
+  }
+
+  static IdempotencyReservation replay(IdempotencyRecord record) {
+    return new IdempotencyReservation(
+        Status.REPLAY,
+        record.id(),
+        record.resourceId(),
+        record.httpStatus(),
+        record.safeResponse());
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/IdempotencyService.java
+++ b/src/main/java/in/rsh/cab/operations/IdempotencyService.java
@@ -1,0 +1,91 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.operations.internal.persistence.IdempotencyRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+
+@Service
+public class IdempotencyService {
+
+  private final IdempotencyRepository records;
+  private final Clock clock;
+  private final Duration ttl;
+
+  public IdempotencyService(
+      IdempotencyRepository records,
+      Clock clock,
+      @Value("${idempotency.ttl:PT24H}") Duration ttl) {
+    if (ttl.isZero() || ttl.isNegative()) {
+      throw new IllegalArgumentException("Idempotency TTL must be positive");
+    }
+    this.records = records;
+    this.clock = clock;
+    this.ttl = ttl;
+  }
+
+  @Transactional
+  public IdempotencyReservation reserve(
+      UUID tenantId, UUID actorAccountId, String operation, String key, String requestHash) {
+    validate(operation, key, requestHash);
+    Instant now = clock.instant();
+    UUID id = UUID.randomUUID();
+    Instant expiresAt = now.plus(ttl);
+    if (records.insertReservation(
+        id, tenantId, actorAccountId, operation, key, requestHash, now, expiresAt)) {
+      return IdempotencyReservation.reserved(id);
+    }
+
+    IdempotencyRecord existing = records.lock(tenantId, actorAccountId, operation, key)
+        .orElseThrow(() -> new IllegalStateException("Conflicting idempotency record disappeared"));
+    if (!existing.expiresAt().isAfter(now) || existing.state() == IdempotencyState.FAILED) {
+      records.replaceReservation(
+          tenantId, actorAccountId, existing.id(), id, requestHash, now, expiresAt);
+      return IdempotencyReservation.reserved(id);
+    }
+    if (!existing.requestHash().equals(requestHash)) {
+      throw new IdempotencyConflictException(IdempotencyConflictException.Reason.KEY_REUSED);
+    }
+    if (existing.state() == IdempotencyState.COMPLETED) {
+      return IdempotencyReservation.replay(existing);
+    }
+    throw new IdempotencyConflictException(IdempotencyConflictException.Reason.IN_PROGRESS);
+  }
+
+  @Transactional
+  public void complete(
+      UUID tenantId, UUID actorAccountId, UUID recordId, String resourceType, UUID resourceId,
+      int httpStatus, JsonNode safeResponse) {
+    if (httpStatus < 200 || httpStatus > 299) {
+      throw new IllegalArgumentException("Completed idempotency status must be successful");
+    }
+    records.complete(
+        tenantId, actorAccountId, recordId, resourceType, resourceId, httpStatus,
+        safeResponse, clock.instant());
+  }
+
+  @Transactional
+  public void fail(UUID tenantId, UUID actorAccountId, UUID recordId) {
+    records.fail(tenantId, actorAccountId, recordId, clock.instant());
+  }
+
+  private void validate(String operation, String key, String requestHash) {
+    if (operation == null || operation.isBlank() || operation.length() > 120) {
+      throw new InvalidRequestException("Idempotency operation is invalid");
+    }
+    if (key == null || key.isBlank() || key.length() > 255) {
+      throw new InvalidRequestException("Idempotency-Key must contain 1 to 255 characters");
+    }
+    if (requestHash == null || !requestHash.equals(requestHash.toLowerCase(Locale.ROOT))
+        || !requestHash.matches("[0-9a-f]{64}")) {
+      throw new InvalidRequestException("Idempotency request hash must be lowercase SHA-256");
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/IdempotencyState.java
+++ b/src/main/java/in/rsh/cab/operations/IdempotencyState.java
@@ -1,0 +1,7 @@
+package in.rsh.cab.operations;
+
+public enum IdempotencyState {
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED
+}

--- a/src/main/java/in/rsh/cab/operations/InboxService.java
+++ b/src/main/java/in/rsh/cab/operations/InboxService.java
@@ -1,0 +1,27 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.operations.internal.persistence.InboxRepository;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class InboxService {
+
+  private final InboxRepository receipts;
+  private final Clock clock;
+
+  public InboxService(InboxRepository receipts, Clock clock) {
+    this.receipts = receipts;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public boolean receive(UUID tenantId, String consumer, UUID eventId) {
+    if (consumer == null || consumer.isBlank() || consumer.length() > 160) {
+      throw new IllegalArgumentException("Inbox consumer must contain 1 to 160 characters");
+    }
+    return receipts.insert(UUID.randomUUID(), tenantId, consumer, eventId, clock.instant());
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/OutboxEvent.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxEvent.java
@@ -1,0 +1,19 @@
+package in.rsh.cab.operations;
+
+import java.time.Instant;
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public record OutboxEvent(
+    UUID id,
+    UUID tenantId,
+    String aggregateType,
+    UUID aggregateId,
+    long aggregateVersion,
+    String eventType,
+    int eventVersion,
+    JsonNode payload,
+    Instant occurredAt,
+    String correlationId,
+    UUID causationId,
+    int attempts) {}

--- a/src/main/java/in/rsh/cab/operations/OutboxPoller.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxPoller.java
@@ -1,0 +1,53 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.operations.internal.persistence.OutboxRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OutboxPoller {
+
+  private final OutboxRepository events;
+  private final Clock clock;
+
+  public OutboxPoller(OutboxRepository events, Clock clock) {
+    this.events = events;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public List<OutboxEvent> lease(UUID tenantId, int limit, Duration leaseDuration) {
+    if (limit < 1 || leaseDuration.isZero() || leaseDuration.isNegative()) {
+      throw new IllegalArgumentException("Outbox lease limit and duration must be positive");
+    }
+    Instant now = clock.instant();
+    return events.lease(tenantId, limit, now, now.plus(leaseDuration));
+  }
+
+  @Transactional
+  public void published(UUID tenantId, UUID eventId) {
+    events.markPublished(tenantId, eventId, clock.instant());
+  }
+
+  @Transactional
+  public void retry(UUID tenantId, UUID eventId, Instant availableAt, String error) {
+    events.markRetry(tenantId, eventId, availableAt, sanitizeError(error));
+  }
+
+  @Transactional
+  public void failed(UUID tenantId, UUID eventId, String error) {
+    events.markFailed(tenantId, eventId, sanitizeError(error));
+  }
+
+  private String sanitizeError(String error) {
+    if (error == null) {
+      return null;
+    }
+    return error.length() <= 500 ? error : error.substring(0, 500);
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/OutboxService.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxService.java
@@ -1,0 +1,35 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.operations.internal.persistence.OutboxRepository;
+import in.rsh.cab.web.RequestMetadata;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+
+@Service
+public class OutboxService {
+
+  private final OutboxRepository events;
+  private final Clock clock;
+
+  public OutboxService(OutboxRepository events, Clock clock) {
+    this.events = events;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public UUID append(
+      UUID tenantId, String aggregateType, UUID aggregateId, long aggregateVersion,
+      String eventType, int eventVersion, JsonNode payload, UUID causationId) {
+    UUID id = UUID.randomUUID();
+    Instant now = clock.instant();
+    events.insert(
+        id, tenantId, aggregateType, aggregateId, aggregateVersion, eventType, eventVersion,
+        payload, now, now, RequestMetadata.correlationIdOrNull(), causationId);
+    return id;
+  }
+
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/IdempotencyRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/IdempotencyRepository.java
@@ -1,0 +1,27 @@
+package in.rsh.cab.operations.internal.persistence;
+
+import in.rsh.cab.operations.IdempotencyRecord;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public interface IdempotencyRepository {
+
+  boolean insertReservation(
+      UUID id, UUID tenantId, UUID actorAccountId, String operation, String key,
+      String requestHash, Instant now, Instant expiresAt);
+
+  Optional<IdempotencyRecord> lock(
+      UUID tenantId, UUID actorAccountId, String operation, String key);
+
+  void replaceReservation(
+      UUID tenantId, UUID actorAccountId, UUID oldId, UUID newId,
+      String requestHash, Instant now, Instant expiresAt);
+
+  void complete(
+      UUID tenantId, UUID actorAccountId, UUID recordId, String resourceType, UUID resourceId,
+      int httpStatus, JsonNode safeResponse, Instant now);
+
+  void fail(UUID tenantId, UUID actorAccountId, UUID recordId, Instant now);
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/InboxRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/InboxRepository.java
@@ -1,0 +1,9 @@
+package in.rsh.cab.operations.internal.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface InboxRepository {
+
+  boolean insert(UUID id, UUID tenantId, String consumer, UUID eventId, Instant receivedAt);
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcIdempotencyRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcIdempotencyRepository.java
@@ -1,0 +1,133 @@
+package in.rsh.cab.operations.internal.persistence;
+
+import in.rsh.cab.operations.IdempotencyRecord;
+import in.rsh.cab.operations.IdempotencyState;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Repository
+public class JdbcIdempotencyRepository implements IdempotencyRepository {
+
+  private final JdbcClient jdbc;
+  private final ObjectMapper objectMapper;
+
+  public JdbcIdempotencyRepository(JdbcClient jdbc, ObjectMapper objectMapper) {
+    this.jdbc = jdbc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean insertReservation(
+      UUID id, UUID tenantId, UUID actorAccountId, String operation, String key,
+      String requestHash, Instant now, Instant expiresAt) {
+    return jdbc.sql("""
+            INSERT INTO idempotency_records
+              (id, tenant_id, actor_account_id, operation, idempotency_key, request_hash,
+               state, created_at, expires_at, updated_at)
+            VALUES
+              (:id, :tenantId, :actorId, :operation, :key, :hash,
+               'IN_PROGRESS', :now, :expiresAt, :now)
+            ON CONFLICT (tenant_id, actor_account_id, operation, idempotency_key) DO NOTHING
+            """)
+        .param("id", id).param("tenantId", tenantId).param("actorId", actorAccountId)
+        .param("operation", operation).param("key", key).param("hash", requestHash)
+        .param("now", Timestamp.from(now)).param("expiresAt", Timestamp.from(expiresAt))
+        .update() == 1;
+  }
+
+  @Override
+  public Optional<IdempotencyRecord> lock(
+      UUID tenantId, UUID actorAccountId, String operation, String key) {
+    return jdbc.sql("""
+            SELECT id, tenant_id, actor_account_id, operation, idempotency_key, request_hash,
+                   state, resource_id, http_status, safe_response, expires_at
+            FROM idempotency_records
+            WHERE tenant_id = :tenantId AND actor_account_id = :actorId
+              AND operation = :operation AND idempotency_key = :key
+            FOR UPDATE
+            """)
+        .param("tenantId", tenantId).param("actorId", actorAccountId)
+        .param("operation", operation).param("key", key).query(this::map).optional();
+  }
+
+  @Override
+  public void replaceReservation(
+      UUID tenantId, UUID actorAccountId, UUID oldId, UUID newId,
+      String requestHash, Instant now, Instant expiresAt) {
+    int updated = jdbc.sql("""
+            UPDATE idempotency_records
+            SET id = :newId, request_hash = :hash, state = 'IN_PROGRESS',
+                resource_type = NULL, resource_id = NULL, http_status = NULL,
+                safe_response = NULL, created_at = :now, expires_at = :expiresAt, updated_at = :now
+            WHERE tenant_id = :tenantId AND actor_account_id = :actorId AND id = :oldId
+            """)
+        .param("newId", newId).param("hash", requestHash).param("now", Timestamp.from(now))
+        .param("expiresAt", Timestamp.from(expiresAt)).param("tenantId", tenantId)
+        .param("actorId", actorAccountId).param("oldId", oldId).update();
+    requireOne(updated);
+  }
+
+  @Override
+  public void complete(
+      UUID tenantId, UUID actorAccountId, UUID recordId, String resourceType, UUID resourceId,
+      int httpStatus, JsonNode safeResponse, Instant now) {
+    int updated = jdbc.sql("""
+            UPDATE idempotency_records
+            SET state = 'COMPLETED', resource_type = :resourceType, resource_id = :resourceId,
+                http_status = :httpStatus, safe_response = CAST(:response AS jsonb), updated_at = :now
+            WHERE tenant_id = :tenantId AND actor_account_id = :actorId
+              AND id = :recordId AND state = 'IN_PROGRESS'
+            """)
+        .param("resourceType", resourceType).param("resourceId", resourceId)
+        .param("httpStatus", httpStatus)
+        .param("response", safeResponse == null ? null : safeResponse.toString())
+        .param("now", Timestamp.from(now)).param("tenantId", tenantId)
+        .param("actorId", actorAccountId).param("recordId", recordId).update();
+    requireOne(updated);
+  }
+
+  @Override
+  public void fail(UUID tenantId, UUID actorAccountId, UUID recordId, Instant now) {
+    int updated = jdbc.sql("""
+            UPDATE idempotency_records
+            SET state = 'FAILED', updated_at = :now
+            WHERE tenant_id = :tenantId AND actor_account_id = :actorId
+              AND id = :recordId AND state = 'IN_PROGRESS'
+            """)
+        .param("now", Timestamp.from(now)).param("tenantId", tenantId)
+        .param("actorId", actorAccountId).param("recordId", recordId).update();
+    requireOne(updated);
+  }
+
+  private IdempotencyRecord map(ResultSet resultSet, int rowNumber) throws SQLException {
+    try {
+      String response = resultSet.getString("safe_response");
+      Integer httpStatus = (Integer) resultSet.getObject("http_status");
+      return new IdempotencyRecord(
+          resultSet.getObject("id", UUID.class), resultSet.getObject("tenant_id", UUID.class),
+          resultSet.getObject("actor_account_id", UUID.class), resultSet.getString("operation"),
+          resultSet.getString("idempotency_key"), resultSet.getString("request_hash"),
+          IdempotencyState.valueOf(resultSet.getString("state")),
+          resultSet.getObject("resource_id", UUID.class), httpStatus == null ? 0 : httpStatus,
+          response == null ? null : objectMapper.readTree(response),
+          resultSet.getTimestamp("expires_at").toInstant());
+    } catch (JacksonException exception) {
+      throw new SQLException("Stored idempotency response is invalid", exception);
+    }
+  }
+
+  private void requireOne(int updated) {
+    if (updated != 1) {
+      throw new IllegalStateException("Idempotency record state changed unexpectedly");
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcInboxRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcInboxRepository.java
@@ -1,0 +1,28 @@
+package in.rsh.cab.operations.internal.persistence;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcInboxRepository implements InboxRepository {
+
+  private final JdbcClient jdbc;
+
+  public JdbcInboxRepository(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public boolean insert(UUID id, UUID tenantId, String consumer, UUID eventId, Instant receivedAt) {
+    return jdbc.sql("""
+            INSERT INTO inbox_receipts (id, tenant_id, consumer, event_id, received_at)
+            VALUES (:id, :tenantId, :consumer, :eventId, :receivedAt)
+            ON CONFLICT (tenant_id, consumer, event_id) DO NOTHING
+            """)
+        .param("id", id).param("tenantId", tenantId).param("consumer", consumer)
+        .param("eventId", eventId).param("receivedAt", Timestamp.from(receivedAt)).update() == 1;
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcOutboxRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcOutboxRepository.java
@@ -1,0 +1,132 @@
+package in.rsh.cab.operations.internal.persistence;
+
+import in.rsh.cab.operations.OutboxEvent;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Repository
+public class JdbcOutboxRepository implements OutboxRepository {
+
+  private final JdbcClient jdbc;
+  private final ObjectMapper objectMapper;
+
+  public JdbcOutboxRepository(JdbcClient jdbc, ObjectMapper objectMapper) {
+    this.jdbc = jdbc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void insert(
+      UUID id, UUID tenantId, String aggregateType, UUID aggregateId, long aggregateVersion,
+      String eventType, int eventVersion, JsonNode payload, Instant occurredAt, Instant availableAt,
+      String correlationId, UUID causationId) {
+    jdbc.sql("""
+            INSERT INTO outbox_events
+              (id, tenant_id, aggregate_type, aggregate_id, aggregate_version, event_type,
+               event_version, payload, occurred_at, available_at, correlation_id, causation_id,
+               status, attempts)
+            VALUES
+              (:id, :tenantId, :aggregateType, :aggregateId, :aggregateVersion, :eventType,
+               :eventVersion, CAST(:payload AS jsonb), :occurredAt, :availableAt, :correlationId,
+               :causationId, 'PENDING', 0)
+            """)
+        .param("id", id).param("tenantId", tenantId).param("aggregateType", aggregateType)
+        .param("aggregateId", aggregateId).param("aggregateVersion", aggregateVersion)
+        .param("eventType", eventType).param("eventVersion", eventVersion)
+        .param("payload", payload.toString()).param("occurredAt", Timestamp.from(occurredAt))
+        .param("availableAt", Timestamp.from(availableAt)).param("correlationId", correlationId)
+        .param("causationId", causationId).update();
+  }
+
+  @Override
+  public List<OutboxEvent> lease(UUID tenantId, int limit, Instant now, Instant leaseExpiresAt) {
+    return jdbc.sql("""
+            WITH candidates AS (
+              SELECT id
+              FROM outbox_events
+              WHERE tenant_id = :tenantId AND available_at <= :now
+                AND (status = 'PENDING'
+                  OR (status = 'PROCESSING' AND lease_expires_at <= :now))
+              ORDER BY available_at, occurred_at, id
+              FOR UPDATE SKIP LOCKED
+              LIMIT :limit
+            )
+            UPDATE outbox_events event
+            SET status = 'PROCESSING', attempts = event.attempts + 1,
+                lease_started_at = :now, lease_expires_at = :leaseExpiresAt,
+                published_at = NULL, last_error = NULL
+            FROM candidates
+            WHERE event.tenant_id = :tenantId AND event.id = candidates.id
+            RETURNING event.id, event.tenant_id, event.aggregate_type, event.aggregate_id,
+                      event.aggregate_version, event.event_type, event.event_version, event.payload,
+                      event.occurred_at, event.correlation_id, event.causation_id, event.attempts
+            """)
+        .param("tenantId", tenantId).param("now", Timestamp.from(now))
+        .param("leaseExpiresAt", Timestamp.from(leaseExpiresAt))
+        .param("limit", limit).query(this::map).list();
+  }
+
+  @Override
+  public void markPublished(UUID tenantId, UUID eventId, Instant publishedAt) {
+    requireOne(jdbc.sql("""
+            UPDATE outbox_events
+            SET status = 'PUBLISHED', published_at = :publishedAt,
+                lease_started_at = NULL, lease_expires_at = NULL, last_error = NULL
+            WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+            """)
+        .param("publishedAt", Timestamp.from(publishedAt)).param("tenantId", tenantId)
+        .param("eventId", eventId).update());
+  }
+
+  @Override
+  public void markRetry(UUID tenantId, UUID eventId, Instant availableAt, String error) {
+    requireOne(jdbc.sql("""
+            UPDATE outbox_events
+            SET status = 'PENDING', available_at = :availableAt,
+                lease_started_at = NULL, lease_expires_at = NULL, last_error = :error
+            WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+            """)
+        .param("availableAt", Timestamp.from(availableAt)).param("error", error)
+        .param("tenantId", tenantId).param("eventId", eventId).update());
+  }
+
+  @Override
+  public void markFailed(UUID tenantId, UUID eventId, String error) {
+    requireOne(jdbc.sql("""
+            UPDATE outbox_events
+            SET status = 'FAILED', lease_started_at = NULL, lease_expires_at = NULL,
+                last_error = :error
+            WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+            """)
+        .param("error", error).param("tenantId", tenantId).param("eventId", eventId).update());
+  }
+
+  private OutboxEvent map(ResultSet resultSet, int rowNumber) throws SQLException {
+    try {
+      return new OutboxEvent(
+          resultSet.getObject("id", UUID.class), resultSet.getObject("tenant_id", UUID.class),
+          resultSet.getString("aggregate_type"), resultSet.getObject("aggregate_id", UUID.class),
+          resultSet.getLong("aggregate_version"), resultSet.getString("event_type"),
+          resultSet.getInt("event_version"), objectMapper.readTree(resultSet.getString("payload")),
+          resultSet.getTimestamp("occurred_at").toInstant(), resultSet.getString("correlation_id"),
+          resultSet.getObject("causation_id", UUID.class), resultSet.getInt("attempts"));
+    } catch (JacksonException exception) {
+      throw new SQLException("Stored outbox payload is invalid", exception);
+    }
+  }
+
+  private void requireOne(int updated) {
+    if (updated != 1) {
+      throw new IllegalStateException("Outbox event is not leased by this publisher");
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/OutboxRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/OutboxRepository.java
@@ -1,0 +1,23 @@
+package in.rsh.cab.operations.internal.persistence;
+
+import in.rsh.cab.operations.OutboxEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import tools.jackson.databind.JsonNode;
+
+public interface OutboxRepository {
+
+  void insert(
+      UUID id, UUID tenantId, String aggregateType, UUID aggregateId, long aggregateVersion,
+      String eventType, int eventVersion, JsonNode payload, Instant occurredAt, Instant availableAt,
+      String correlationId, UUID causationId);
+
+  List<OutboxEvent> lease(UUID tenantId, int limit, Instant now, Instant leaseExpiresAt);
+
+  void markPublished(UUID tenantId, UUID eventId, Instant publishedAt);
+
+  void markRetry(UUID tenantId, UUID eventId, Instant availableAt, String error);
+
+  void markFailed(UUID tenantId, UUID eventId, String error);
+}

--- a/src/main/java/in/rsh/cab/pricing/PricingService.java
+++ b/src/main/java/in/rsh/cab/pricing/PricingService.java
@@ -5,6 +5,10 @@ import in.rsh.cab.exception.InvalidRequestException;
 import in.rsh.cab.exception.NotFoundException;
 import in.rsh.cab.geography.GeoPoint;
 import in.rsh.cab.geography.internal.persistence.ServiceAreaRepository;
+import in.rsh.cab.audit.AuditService;
+import in.rsh.cab.operations.IdempotencyReservation;
+import in.rsh.cab.operations.IdempotencyService;
+import in.rsh.cab.operations.OutboxService;
 import in.rsh.cab.pricing.internal.persistence.PricingRepository;
 import in.rsh.cab.routing.RouteEstimate;
 import in.rsh.cab.routing.RouteEstimator;
@@ -25,6 +29,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class PricingService {
@@ -35,12 +41,20 @@ public class PricingService {
   private final RouteEstimator routeEstimator;
   private final Clock clock;
   private final Duration quoteTtl;
+  private final IdempotencyService idempotency;
+  private final OutboxService outbox;
+  private final AuditService audit;
+  private final ObjectMapper objectMapper;
 
   public PricingService(
       PricingRepository pricing,
       ServiceAreaRepository serviceAreas,
       RouteEstimator routeEstimator,
       Clock clock,
+      IdempotencyService idempotency,
+      OutboxService outbox,
+      AuditService audit,
+      ObjectMapper objectMapper,
       @Value("${pricing.quote-ttl:PT10M}") Duration quoteTtl) {
     if (quoteTtl.isZero() || quoteTtl.isNegative()) {
       throw new IllegalArgumentException("Quote TTL must be positive");
@@ -49,6 +63,10 @@ public class PricingService {
     this.serviceAreas = serviceAreas;
     this.routeEstimator = routeEstimator;
     this.clock = clock;
+    this.idempotency = idempotency;
+    this.outbox = outbox;
+    this.audit = audit;
+    this.objectMapper = objectMapper;
     this.quoteTtl = quoteTtl;
   }
 
@@ -132,8 +150,17 @@ public class PricingService {
   }
 
   @Transactional
-  public FareQuote createQuote(UUID productId, GeoPoint pickup, GeoPoint dropoff) {
+  public QuoteCreation createQuote(
+      String idempotencyKey, UUID productId, GeoPoint pickup, GeoPoint dropoff) {
     TenantContext context = require(TenantRole.RIDER);
+    String requestHash = fingerprint(productId, pickup, dropoff);
+    IdempotencyReservation reservation = idempotency.reserve(
+        context.tenantId(), context.accountId(), "fare-quote.create", idempotencyKey, requestHash);
+    if (reservation.status() == IdempotencyReservation.Status.REPLAY) {
+      return new QuoteCreation(
+          objectMapper.treeToValue(reservation.safeResponse(), FareQuote.class),
+          reservation.httpStatus(), true);
+    }
     ServiceProduct product =
         pricing.findProduct(context.tenantId(), productId)
             .filter(candidate -> candidate.status() == ProductStatus.ACTIVE)
@@ -153,11 +180,30 @@ public class PricingService {
     try {
       FareQuote quote = calculateQuote(product.id(), rule, pickup, dropoff, distanceMeters, durationSeconds, now);
       pricing.insertQuote(context.tenantId(), context.accountId(), quote);
-      return quote;
+      JsonNode safeQuote = objectMapper.valueToTree(quote);
+      outbox.append(
+          context.tenantId(), "fare_quote", quote.id(), quote.version(), "fare_quote.created", 1,
+          objectMapper.valueToTree(new FareQuoteCreated(quote.id(), quote.productId(),
+              quote.totalMinor(), quote.currency(), quote.expiresAt())), null);
+      audit.record(
+          context.tenantId(), context.accountId(), "fare_quote.create", "fare_quote", quote.id(),
+          "SUCCESS", objectMapper.valueToTree(new FareQuoteAuditSummary(
+              quote.productId(), quote.totalMinor(), quote.currency())));
+      idempotency.complete(
+          context.tenantId(), context.accountId(), reservation.recordId(), "fare_quote", quote.id(),
+          201, safeQuote);
+      return new QuoteCreation(quote, 201, false);
     } catch (ArithmeticException exception) {
       throw new InvalidRequestException("Fare exceeds the supported monetary range");
     }
   }
+
+  public record QuoteCreation(FareQuote quote, int httpStatus, boolean replayed) {}
+
+  private record FareQuoteCreated(
+      UUID quoteId, UUID productId, long totalMinor, String currency, Instant expiresAt) {}
+
+  private record FareQuoteAuditSummary(UUID productId, long totalMinor, String currency) {}
 
   @Transactional(readOnly = true)
   public FareQuote getOwnQuote(UUID quoteId) {

--- a/src/main/java/in/rsh/cab/pricing/internal/web/FareQuoteController.java
+++ b/src/main/java/in/rsh/cab/pricing/internal/web/FareQuoteController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,10 +30,14 @@ public class FareQuoteController {
   }
 
   @PostMapping
-  public ResponseEntity<FareQuote> create(@Valid @RequestBody CreateFareQuoteRequest request) {
-    FareQuote quote = pricing.createQuote(
-        request.productId(), request.pickup().toGeoPoint(), request.dropoff().toGeoPoint());
-    return ResponseEntity.created(URI.create("/api/v1/quotes/" + quote.id())).body(quote);
+  public ResponseEntity<FareQuote> create(
+      @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+      @Valid @RequestBody CreateFareQuoteRequest request) {
+    PricingService.QuoteCreation result = pricing.createQuote(
+        idempotencyKey, request.productId(), request.pickup().toGeoPoint(), request.dropoff().toGeoPoint());
+    return ResponseEntity.status(result.httpStatus())
+        .location(URI.create("/api/v1/quotes/" + result.quote().id()))
+        .body(result.quote());
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
+++ b/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
@@ -35,6 +35,7 @@ public class SecurityConfiguration {
                         "/api/v1/driver/shifts/**",
                         "/api/v1/products/**",
                         "/api/v1/pricing-rules/**",
+                        "/api/v1/admin/audit-events/**",
                         "/api/v1/quotes/**")
                     .authenticated()
                     .requestMatchers("/api/v1/**")

--- a/src/main/java/in/rsh/cab/web/CorrelationIdFilter.java
+++ b/src/main/java/in/rsh/cab/web/CorrelationIdFilter.java
@@ -21,12 +21,15 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     String supplied = request.getHeader(HEADER_NAME);
-    String correlationId = supplied == null || supplied.isBlank() ? UUID.randomUUID().toString() : supplied;
+    String correlationId = supplied == null || supplied.isBlank() || supplied.length() > 128
+        ? UUID.randomUUID().toString() : supplied;
     response.setHeader(HEADER_NAME, correlationId);
     MDC.put(MDC_KEY, correlationId);
+    RequestMetadata.set(new RequestMetadata(correlationId));
     try {
       filterChain.doFilter(request, response);
     } finally {
+      RequestMetadata.clear();
       MDC.remove(MDC_KEY);
     }
   }

--- a/src/main/java/in/rsh/cab/web/RequestMetadata.java
+++ b/src/main/java/in/rsh/cab/web/RequestMetadata.java
@@ -1,0 +1,19 @@
+package in.rsh.cab.web;
+
+public record RequestMetadata(String correlationId) {
+
+  private static final ThreadLocal<RequestMetadata> CURRENT = new ThreadLocal<>();
+
+  public static String correlationIdOrNull() {
+    RequestMetadata metadata = CURRENT.get();
+    return metadata == null ? null : metadata.correlationId();
+  }
+
+  static void set(RequestMetadata metadata) {
+    CURRENT.set(metadata);
+  }
+
+  static void clear() {
+    CURRENT.remove();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,4 @@ spring.security.oauth2.resourceserver.jwt.audiences=${OIDC_AUDIENCE:cab-api}
 
 routing.osrm.base-url=${OSRM_BASE_URL:http://localhost:5000}
 pricing.quote-ttl=${QUOTE_TTL:PT10M}
+idempotency.ttl=${IDEMPOTENCY_TTL:PT24H}

--- a/src/main/resources/db/migration/V6__reliable_operations.sql
+++ b/src/main/resources/db/migration/V6__reliable_operations.sql
@@ -1,0 +1,119 @@
+CREATE TABLE idempotency_records (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    actor_account_id uuid NOT NULL,
+    operation varchar(120) NOT NULL,
+    idempotency_key varchar(255) NOT NULL,
+    request_hash varchar(64) NOT NULL,
+    state varchar(32) NOT NULL,
+    resource_type varchar(120),
+    resource_id uuid,
+    http_status integer,
+    safe_response jsonb,
+    created_at timestamptz NOT NULL,
+    expires_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_idempotency_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_idempotency_scope
+        UNIQUE (tenant_id, actor_account_id, operation, idempotency_key),
+    CONSTRAINT fk_idempotency_membership
+        FOREIGN KEY (tenant_id, actor_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_idempotency_hash CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_idempotency_state
+        CHECK (state IN ('IN_PROGRESS', 'COMPLETED', 'FAILED')),
+    CONSTRAINT chk_idempotency_expiry CHECK (expires_at > created_at),
+    CONSTRAINT chk_idempotency_completion CHECK (
+        (state = 'COMPLETED' AND resource_type IS NOT NULL AND resource_id IS NOT NULL
+            AND http_status BETWEEN 200 AND 299)
+        OR (state <> 'COMPLETED' AND resource_type IS NULL AND resource_id IS NULL
+            AND http_status IS NULL AND safe_response IS NULL)
+    )
+);
+
+CREATE TABLE outbox_events (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    aggregate_type varchar(120) NOT NULL,
+    aggregate_id uuid NOT NULL,
+    aggregate_version bigint NOT NULL,
+    event_type varchar(160) NOT NULL,
+    event_version integer NOT NULL,
+    payload jsonb NOT NULL,
+    occurred_at timestamptz NOT NULL,
+    available_at timestamptz NOT NULL,
+    correlation_id varchar(128),
+    causation_id uuid,
+    status varchar(32) NOT NULL,
+    attempts integer NOT NULL DEFAULT 0,
+    lease_started_at timestamptz,
+    lease_expires_at timestamptz,
+    published_at timestamptz,
+    last_error varchar(500),
+    CONSTRAINT uq_outbox_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT chk_outbox_aggregate_version CHECK (aggregate_version >= 0),
+    CONSTRAINT chk_outbox_event_version CHECK (event_version > 0),
+    CONSTRAINT chk_outbox_status
+        CHECK (status IN ('PENDING', 'PROCESSING', 'PUBLISHED', 'FAILED')),
+    CONSTRAINT chk_outbox_attempts CHECK (attempts >= 0),
+    CONSTRAINT chk_outbox_lease CHECK (
+        (status = 'PROCESSING' AND lease_started_at IS NOT NULL AND lease_expires_at > lease_started_at)
+        OR (status <> 'PROCESSING' AND lease_started_at IS NULL AND lease_expires_at IS NULL)
+    ),
+    CONSTRAINT chk_outbox_published CHECK (
+        (status = 'PUBLISHED' AND published_at IS NOT NULL)
+        OR (status <> 'PUBLISHED' AND published_at IS NULL)
+    )
+);
+
+CREATE TABLE inbox_receipts (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    consumer varchar(160) NOT NULL,
+    event_id uuid NOT NULL,
+    received_at timestamptz NOT NULL,
+    CONSTRAINT uq_inbox_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_inbox_receipt UNIQUE (tenant_id, consumer, event_id)
+);
+
+CREATE TABLE audit_events (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    actor_account_id uuid NOT NULL,
+    action varchar(160) NOT NULL,
+    target_type varchar(120) NOT NULL,
+    target_id uuid,
+    outcome varchar(32) NOT NULL,
+    correlation_id varchar(128),
+    summary jsonb NOT NULL,
+    occurred_at timestamptz NOT NULL,
+    CONSTRAINT uq_audit_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_audit_membership
+        FOREIGN KEY (tenant_id, actor_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_audit_outcome CHECK (outcome IN ('SUCCESS', 'FAILURE', 'DENIED'))
+);
+
+CREATE INDEX idx_idempotency_tenant_actor_expiry
+    ON idempotency_records (tenant_id, actor_account_id, expires_at);
+CREATE INDEX idx_outbox_tenant_poll
+    ON outbox_events (tenant_id, status, available_at, lease_expires_at, occurred_at);
+CREATE INDEX idx_outbox_tenant_aggregate
+    ON outbox_events (tenant_id, aggregate_type, aggregate_id, aggregate_version);
+CREATE INDEX idx_inbox_tenant_received
+    ON inbox_receipts (tenant_id, received_at DESC);
+CREATE INDEX idx_audit_tenant_occurred
+    ON audit_events (tenant_id, occurred_at DESC, id DESC);
+CREATE INDEX idx_audit_tenant_target
+    ON audit_events (tenant_id, target_type, target_id, occurred_at DESC);
+
+CREATE FUNCTION reject_audit_event_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_events is append-only';
+END;
+$$;
+
+CREATE TRIGGER audit_events_immutable
+BEFORE UPDATE OR DELETE ON audit_events
+FOR EACH ROW EXECUTE FUNCTION reject_audit_event_mutation();

--- a/src/test/java/in/rsh/cab/audit/AuditServiceTest.java
+++ b/src/test/java/in/rsh/cab/audit/AuditServiceTest.java
@@ -1,0 +1,68 @@
+package in.rsh.cab.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.audit.internal.persistence.AuditRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class AuditServiceTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final UUID ACTOR = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T12:00:00Z");
+  private final AuditRepository repository = mock(AuditRepository.class);
+  private final AuditService service =
+      new AuditService(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+
+  @AfterEach
+  void clearContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void recordsRedactedSummaryAndListsForAdmin() {
+    var summary = new ObjectMapper().createObjectNode().put("totalMinor", 900);
+    UUID target = UUID.randomUUID();
+    UUID id = service.record(TENANT, ACTOR, "quote.create", "quote", target, "SUCCESS", summary);
+    verify(repository).insert(
+        id, TENANT, ACTOR, "quote.create", "quote", target, "SUCCESS", null, summary, NOW);
+
+    AuditEvent event = new AuditEvent(
+        id, ACTOR, "quote.create", "quote", target, "SUCCESS", null, summary, NOW);
+    when(repository.findLatest(TENANT, 50)).thenReturn(List.of(event));
+    context(TenantRole.TENANT_ADMIN);
+    assertEquals(List.of(event), service.list(50));
+  }
+
+  @Test
+  void allowsSupportButRejectsOtherRolesAndInvalidLimits() {
+    context(TenantRole.SUPPORT);
+    service.list(1);
+
+    context(TenantRole.RIDER);
+    assertThrows(TenantAccessDeniedException.class, () -> service.list(1));
+    context(TenantRole.TENANT_ADMIN);
+    assertThrows(IllegalArgumentException.class, () -> service.list(0));
+    assertThrows(IllegalArgumentException.class, () -> service.list(201));
+  }
+
+  private void context(TenantRole role) {
+    TenantContext.set(new TenantContext(TENANT, ACTOR, UUID.randomUUID(), Set.of(role)));
+  }
+}

--- a/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
@@ -1,12 +1,17 @@
 package in.rsh.cab.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.sun.net.httpserver.HttpServer;
+import in.rsh.cab.operations.InboxService;
+import in.rsh.cab.operations.OutboxEvent;
+import in.rsh.cab.operations.OutboxPoller;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -14,15 +19,22 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -51,6 +63,10 @@ class MarketplaceHttpIT {
   private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @LocalServerPort private int port;
+
+  @Autowired private JdbcClient jdbc;
+  @Autowired private OutboxPoller outboxPoller;
+  @Autowired private InboxService inbox;
 
   @DynamicPropertySource
   static void databaseProperties(DynamicPropertyRegistry registry) {
@@ -221,19 +237,31 @@ class MarketplaceHttpIT {
     assertEquals(1, JsonParser.parseString(
         getWithTenant("/api/v1/pricing-rules", tenantId, "platform-admin").body()).getAsJsonArray().size());
 
+    String quoteBody =
+        "{\"productId\":\"" + productId + "\","
+            + "\"pickup\":{\"latitude\":12.95,\"longitude\":77.6},"
+            + "\"dropoff\":{\"latitude\":13.0,\"longitude\":77.65}}";
     HttpResponse<String> quoteCreated =
-        postWithTenant(
+        postWithTenantAndIdempotency(
             "/api/v1/quotes",
             tenantId,
-            "{\"productId\":\"" + productId + "\","
-                + "\"pickup\":{\"latitude\":12.95,\"longitude\":77.6},"
-                + "\"dropoff\":{\"latitude\":13.0,\"longitude\":77.65}}");
+            "quote-key-1",
+            quoteBody);
     assertEquals(201, quoteCreated.statusCode());
     JsonObject quote = JsonParser.parseString(quoteCreated.body()).getAsJsonObject();
     assertEquals(809, quote.get("totalMinor").getAsLong());
     assertEquals("USD", quote.get("currency").getAsString());
     assertEquals("ACTIVE", quote.get("status").getAsString());
     String quoteId = quote.get("id").getAsString();
+    HttpResponse<String> quoteReplay = postWithTenantAndIdempotency(
+        "/api/v1/quotes", tenantId, "quote-key-1", quoteBody);
+    assertEquals(201, quoteReplay.statusCode());
+    assertEquals(quoteCreated.body(), quoteReplay.body());
+    HttpResponse<String> quoteConflict = postWithTenantAndIdempotency(
+        "/api/v1/quotes", tenantId, "quote-key-1",
+        quoteBody.replace("13.0", "13.01"));
+    assertEquals(409, quoteConflict.statusCode());
+    assertTrue(quoteConflict.body().contains("idempotency-key-reused"));
     assertEquals(200,
         getWithTenant("/api/v1/quotes/" + quoteId, tenantId, "platform-admin").statusCode());
     assertEquals(1, JsonParser.parseString(
@@ -241,6 +269,34 @@ class MarketplaceHttpIT {
     assertEquals(404,
         getWithTenant("/api/v1/quotes/00000000-0000-0000-0000-000000000000",
             tenantId, "platform-admin").statusCode());
+
+    HttpResponse<String> auditEvents = getWithTenant(
+        "/api/v1/admin/audit-events", tenantId, "platform-admin");
+    assertEquals(200, auditEvents.statusCode());
+    JsonArray auditList = JsonParser.parseString(auditEvents.body()).getAsJsonArray();
+    assertEquals(1, auditList.size());
+    JsonObject audit = auditList.get(0).getAsJsonObject();
+    assertEquals("fare_quote.create", audit.get("action").getAsString());
+    assertEquals(quoteId, audit.get("targetId").getAsString());
+    assertEquals("marketplace-http-it", audit.get("correlationId").getAsString());
+
+    UUID tenantUuid = UUID.fromString(tenantId);
+    List<OutboxEvent> leased = outboxPoller.lease(tenantUuid, 10, Duration.ofSeconds(30));
+    assertEquals(1, leased.size());
+    assertEquals("marketplace-http-it", leased.get(0).correlationId());
+    outboxPoller.retry(tenantUuid, leased.get(0).id(), Instant.now().minusSeconds(1), "temporary");
+    List<OutboxEvent> retried = outboxPoller.lease(tenantUuid, 10, Duration.ofSeconds(30));
+    assertEquals(2, retried.get(0).attempts());
+    outboxPoller.published(tenantUuid, retried.get(0).id());
+    assertTrue(outboxPoller.lease(tenantUuid, 10, Duration.ofSeconds(30)).isEmpty());
+
+    UUID incomingEvent = UUID.randomUUID();
+    assertTrue(inbox.receive(tenantUuid, "marketplace-http-it", incomingEvent));
+    assertFalse(inbox.receive(tenantUuid, "marketplace-http-it", incomingEvent));
+    UUID auditId = UUID.fromString(audit.get("id").getAsString());
+    assertThrows(DataAccessException.class,
+        () -> jdbc.sql("UPDATE audit_events SET action = 'changed' WHERE tenant_id = :tenantId AND id = :id")
+            .param("tenantId", tenantUuid).param("id", auditId).update());
 
     HttpResponse<String> route =
         postWithTenant(
@@ -269,6 +325,21 @@ class MarketplaceHttpIT {
             .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
             .header("Authorization", "Bearer platform-admin")
             .header("X-Tenant-ID", tenantId)
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpResponse<String> postWithTenantAndIdempotency(
+      String path, String tenantId, String idempotencyKey, String body) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(uri(path))
+            .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer platform-admin")
+            .header("X-Tenant-ID", tenantId)
+            .header("X-Correlation-ID", "marketplace-http-it")
+            .header("Idempotency-Key", idempotencyKey)
             .POST(HttpRequest.BodyPublishers.ofString(body))
             .build();
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import in.rsh.cab.routing.RouteProviderException;
+import in.rsh.cab.operations.IdempotencyConflictException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -44,6 +45,18 @@ class GlobalExceptionHandlerTest {
         HttpStatus.CONFLICT,
         "resource-conflict",
         "Version is stale");
+    assertProblem(
+        handler.handleIdempotencyConflict(new IdempotencyConflictException(
+            IdempotencyConflictException.Reason.KEY_REUSED)),
+        HttpStatus.CONFLICT,
+        "idempotency-key-reused",
+        "Idempotency key was already used for a different request");
+    assertProblem(
+        handler.handleIdempotencyConflict(new IdempotencyConflictException(
+            IdempotencyConflictException.Reason.IN_PROGRESS)),
+        HttpStatus.CONFLICT,
+        "idempotency-in-progress",
+        "A request with this idempotency key is still in progress");
     assertProblem(
         handler.handleBadRequest(new InvalidRequestException("Invalid request")),
         HttpStatus.BAD_REQUEST,

--- a/src/test/java/in/rsh/cab/operations/IdempotencyServiceTest.java
+++ b/src/test/java/in/rsh/cab/operations/IdempotencyServiceTest.java
@@ -1,0 +1,135 @@
+package in.rsh.cab.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.operations.internal.persistence.IdempotencyRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class IdempotencyServiceTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final UUID ACTOR = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T12:00:00Z");
+  private static final String HASH = "a".repeat(64);
+  private final IdempotencyRepository repository = mock(IdempotencyRepository.class);
+  private IdempotencyService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new IdempotencyService(
+        repository, Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofHours(1));
+  }
+
+  @Test
+  void reservesNewRequest() {
+    when(repository.insertReservation(
+        org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(TENANT),
+        org.mockito.ArgumentMatchers.eq(ACTOR), org.mockito.ArgumentMatchers.eq("quote.create"),
+        org.mockito.ArgumentMatchers.eq("key"), org.mockito.ArgumentMatchers.eq(HASH),
+        org.mockito.ArgumentMatchers.eq(NOW),
+        org.mockito.ArgumentMatchers.eq(NOW.plusSeconds(3600)))).thenReturn(true);
+
+    IdempotencyReservation reservation =
+        service.reserve(TENANT, ACTOR, "quote.create", "key", HASH);
+
+    assertEquals(IdempotencyReservation.Status.RESERVED, reservation.status());
+  }
+
+  @Test
+  void replaysCompletedRequest() {
+    UUID id = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    var response = new ObjectMapper().createObjectNode().put("id", resource.toString());
+    when(repository.lock(TENANT, ACTOR, "quote.create", "key"))
+        .thenReturn(Optional.of(new IdempotencyRecord(
+            id, TENANT, ACTOR, "quote.create", "key", HASH, IdempotencyState.COMPLETED,
+            resource, 201, response, NOW.plusSeconds(60))));
+
+    IdempotencyReservation reservation =
+        service.reserve(TENANT, ACTOR, "quote.create", "key", HASH);
+
+    assertEquals(IdempotencyReservation.Status.REPLAY, reservation.status());
+    assertEquals(response, reservation.safeResponse());
+    assertEquals(resource, reservation.resourceId());
+  }
+
+  @Test
+  void rejectsHashReuseAndActiveRequest() {
+    when(repository.lock(TENANT, ACTOR, "quote.create", "key"))
+        .thenReturn(Optional.of(record(HASH, IdempotencyState.IN_PROGRESS, NOW.plusSeconds(60))));
+    IdempotencyConflictException active = assertThrows(
+        IdempotencyConflictException.class,
+        () -> service.reserve(TENANT, ACTOR, "quote.create", "key", HASH));
+    assertEquals(IdempotencyConflictException.Reason.IN_PROGRESS, active.reason());
+
+    IdempotencyConflictException reused = assertThrows(
+        IdempotencyConflictException.class,
+        () -> service.reserve(TENANT, ACTOR, "quote.create", "key", "b".repeat(64)));
+    assertEquals(IdempotencyConflictException.Reason.KEY_REUSED, reused.reason());
+  }
+
+  @Test
+  void replacesExpiredOrFailedReservationsEvenWhenPayloadChanged() {
+    IdempotencyRecord expired = record(HASH, IdempotencyState.COMPLETED, NOW);
+    when(repository.lock(TENANT, ACTOR, "quote.create", "expired"))
+        .thenReturn(Optional.of(expired));
+    assertEquals(IdempotencyReservation.Status.RESERVED,
+        service.reserve(TENANT, ACTOR, "quote.create", "expired", "b".repeat(64)).status());
+
+    IdempotencyRecord failed = record(HASH, IdempotencyState.FAILED, NOW.plusSeconds(60));
+    when(repository.lock(TENANT, ACTOR, "quote.create", "failed"))
+        .thenReturn(Optional.of(failed));
+    assertEquals(IdempotencyReservation.Status.RESERVED,
+        service.reserve(TENANT, ACTOR, "quote.create", "failed", HASH).status());
+  }
+
+  @Test
+  void validatesInputsAndCompletionThenSupportsFailure() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new IdempotencyService(repository, Clock.systemUTC(), Duration.ZERO));
+    assertThrows(InvalidRequestException.class,
+        () -> service.reserve(TENANT, ACTOR, "", "key", HASH));
+    assertThrows(InvalidRequestException.class,
+        () -> service.reserve(TENANT, ACTOR, "operation", "", HASH));
+    assertThrows(InvalidRequestException.class,
+        () -> service.reserve(TENANT, ACTOR, "operation", "key", "INVALID"));
+    assertThrows(IllegalArgumentException.class,
+        () -> service.complete(TENANT, ACTOR, UUID.randomUUID(), "quote", UUID.randomUUID(),
+            500, new ObjectMapper().createObjectNode()));
+
+    UUID recordId = UUID.randomUUID();
+    UUID resourceId = UUID.randomUUID();
+    var response = new ObjectMapper().createObjectNode().put("safe", true);
+    service.complete(TENANT, ACTOR, recordId, "quote", resourceId, 201, response);
+    verify(repository).complete(TENANT, ACTOR, recordId, "quote", resourceId, 201, response, NOW);
+    service.complete(TENANT, ACTOR, recordId, "quote", resourceId, 204, null);
+    verify(repository).complete(TENANT, ACTOR, recordId, "quote", resourceId, 204, null, NOW);
+    service.fail(TENANT, ACTOR, recordId);
+    verify(repository).fail(TENANT, ACTOR, recordId, NOW);
+  }
+
+  @Test
+  void detectsDisappearingConflict() {
+    assertThrows(IllegalStateException.class,
+        () -> service.reserve(TENANT, ACTOR, "quote.create", "key", HASH));
+  }
+
+  private IdempotencyRecord record(String hash, IdempotencyState state, Instant expiresAt) {
+    return new IdempotencyRecord(
+        UUID.randomUUID(), TENANT, ACTOR, "quote.create", "key", hash, state,
+        null, 0, null, expiresAt);
+  }
+}

--- a/src/test/java/in/rsh/cab/operations/InboxServiceTest.java
+++ b/src/test/java/in/rsh/cab/operations/InboxServiceTest.java
@@ -1,0 +1,32 @@
+package in.rsh.cab.operations;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.operations.internal.persistence.InboxRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class InboxServiceTest {
+
+  @Test
+  void reportsFirstReceiptAndDuplicates() {
+    InboxRepository repository = mock(InboxRepository.class);
+    Instant now = Instant.parse("2026-08-08T12:00:00Z");
+    InboxService service = new InboxService(repository, Clock.fixed(now, ZoneOffset.UTC));
+    UUID tenant = UUID.randomUUID();
+    UUID event = UUID.randomUUID();
+    when(repository.insert(any(), any(), any(), any(), any())).thenReturn(true, false);
+
+    assertTrue(service.receive(tenant, "billing", event));
+    assertFalse(service.receive(tenant, "billing", event));
+    assertThrows(IllegalArgumentException.class, () -> service.receive(tenant, " ", event));
+  }
+}

--- a/src/test/java/in/rsh/cab/operations/OutboxServiceTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxServiceTest.java
@@ -1,0 +1,68 @@
+package in.rsh.cab.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.operations.internal.persistence.OutboxRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class OutboxServiceTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T12:00:00Z");
+  private final OutboxRepository repository = mock(OutboxRepository.class);
+  private final OutboxService service =
+      new OutboxService(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+  private final OutboxPoller poller =
+      new OutboxPoller(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+
+  @Test
+  void appendsAndLeasesEvents() {
+    UUID aggregateId = UUID.randomUUID();
+    var payload = new ObjectMapper().createObjectNode().put("safe", true);
+    UUID eventId = service.append(TENANT, "quote", aggregateId, 0, "quote.created", 1, payload, null);
+    verify(repository).insert(
+        eventId, TENANT, "quote", aggregateId, 0, "quote.created", 1, payload,
+        NOW, NOW, null, null);
+
+    OutboxEvent event = new OutboxEvent(
+        eventId, TENANT, "quote", aggregateId, 0, "quote.created", 1,
+        payload, NOW, null, null, 1);
+    when(repository.lease(TENANT, 10, NOW, NOW.plusSeconds(30))).thenReturn(List.of(event));
+    assertEquals(List.of(event), poller.lease(TENANT, 10, Duration.ofSeconds(30)));
+  }
+
+  @Test
+  void completesRetryAndPermanentFailureWithBoundedErrors() {
+    UUID eventId = UUID.randomUUID();
+    poller.published(TENANT, eventId);
+    verify(repository).markPublished(TENANT, eventId, NOW);
+
+    poller.retry(TENANT, eventId, NOW.plusSeconds(10), "temporary");
+    verify(repository).markRetry(TENANT, eventId, NOW.plusSeconds(10), "temporary");
+
+    poller.failed(TENANT, eventId, "x".repeat(600));
+    verify(repository).markFailed(TENANT, eventId, "x".repeat(500));
+    poller.failed(TENANT, eventId, null);
+    verify(repository).markFailed(TENANT, eventId, null);
+  }
+
+  @Test
+  void validatesLeaseInputs() {
+    assertThrows(IllegalArgumentException.class,
+        () -> poller.lease(TENANT, 0, Duration.ofSeconds(1)));
+    assertThrows(IllegalArgumentException.class,
+        () -> poller.lease(TENANT, 1, Duration.ZERO));
+  }
+}

--- a/src/test/java/in/rsh/cab/pricing/PricingServiceTest.java
+++ b/src/test/java/in/rsh/cab/pricing/PricingServiceTest.java
@@ -14,6 +14,10 @@ import in.rsh.cab.exception.InvalidRequestException;
 import in.rsh.cab.exception.NotFoundException;
 import in.rsh.cab.geography.GeoPoint;
 import in.rsh.cab.geography.internal.persistence.ServiceAreaRepository;
+import in.rsh.cab.audit.AuditService;
+import in.rsh.cab.operations.IdempotencyReservation;
+import in.rsh.cab.operations.IdempotencyService;
+import in.rsh.cab.operations.OutboxService;
 import in.rsh.cab.pricing.internal.persistence.PricingRepository;
 import in.rsh.cab.routing.RouteEstimate;
 import in.rsh.cab.routing.RouteEstimator;
@@ -32,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import tools.jackson.databind.ObjectMapper;
 
 class PricingServiceTest {
 
@@ -44,12 +49,20 @@ class PricingServiceTest {
   private final PricingRepository repository = mock(PricingRepository.class);
   private final ServiceAreaRepository serviceAreas = mock(ServiceAreaRepository.class);
   private final RouteEstimator routes = mock(RouteEstimator.class);
+  private final IdempotencyService idempotency = mock(IdempotencyService.class);
+  private final OutboxService outbox = mock(OutboxService.class);
+  private final AuditService audit = mock(AuditService.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
   private PricingService service;
 
   @BeforeEach
   void setUp() {
     service = new PricingService(repository, serviceAreas, routes,
-        Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofMinutes(10));
+        Clock.fixed(NOW, ZoneOffset.UTC), idempotency, outbox, audit, objectMapper,
+        Duration.ofMinutes(10));
+    when(idempotency.reserve(any(), any(), any(), any(), any()))
+        .thenReturn(new IdempotencyReservation(
+            IdempotencyReservation.Status.RESERVED, UUID.randomUUID(), null, 0, null));
     admin();
   }
 
@@ -62,7 +75,7 @@ class PricingServiceTest {
   void validatesPositiveQuoteTtl() {
     assertThrows(IllegalArgumentException.class,
         () -> new PricingService(repository, serviceAreas, routes,
-            Clock.systemUTC(), Duration.ZERO));
+            Clock.systemUTC(), idempotency, outbox, audit, objectMapper, Duration.ZERO));
   }
 
   @Test
@@ -134,7 +147,7 @@ class PricingServiceTest {
     when(repository.findEffectiveRule(TENANT_ID, PRODUCT_ID, NOW)).thenReturn(Optional.of(rule));
     when(routes.estimate(PICKUP, DROPOFF)).thenReturn(new RouteEstimate(2450.5, 480));
 
-    FareQuote quote = service.createQuote(PRODUCT_ID, PICKUP, DROPOFF);
+    FareQuote quote = service.createQuote("quote-key", PRODUCT_ID, PICKUP, DROPOFF).quote();
 
     assertEquals(2451, quote.routeDistanceMeters());
     assertEquals(245, quote.distanceFareMinor());
@@ -149,6 +162,9 @@ class PricingServiceTest {
     assertEquals(QuoteStatus.ACTIVE, quote.status());
     assertEquals(0, quote.version());
     verify(repository).insertQuote(TENANT_ID, ACCOUNT_ID, quote);
+    verify(outbox).append(any(), any(), any(), any(Long.class), any(), any(Integer.class), any(), any());
+    verify(audit).record(any(), any(), any(), any(), any(), any(), any());
+    verify(idempotency).complete(any(), any(), any(), any(), any(), any(Integer.class), any());
   }
 
   @Test
@@ -160,7 +176,7 @@ class PricingServiceTest {
     when(repository.findEffectiveRule(TENANT_ID, PRODUCT_ID, NOW)).thenReturn(Optional.of(rule));
     when(routes.estimate(PICKUP, DROPOFF)).thenReturn(new RouteEstimate(1000, 60));
 
-    FareQuote quote = service.createQuote(PRODUCT_ID, PICKUP, DROPOFF);
+    FareQuote quote = service.createQuote("quote-key", PRODUCT_ID, PICKUP, DROPOFF).quote();
 
     assertEquals(0, quote.minimumAdjustmentMinor());
     assertEquals(0, quote.surgeMinor());
@@ -169,24 +185,48 @@ class PricingServiceTest {
   }
 
   @Test
+  void quoteReplayReturnsStoredSafeRepresentationWithoutCreatingAgain() {
+    rider();
+    FareQuote stored = quote();
+    when(idempotency.reserve(any(), any(), any(), any(), any()))
+        .thenReturn(new IdempotencyReservation(
+            IdempotencyReservation.Status.REPLAY, UUID.randomUUID(), stored.id(), 201,
+            objectMapper.valueToTree(stored)));
+
+    PricingService.QuoteCreation result =
+        service.createQuote("replay-key", PRODUCT_ID, PICKUP, DROPOFF);
+
+    assertEquals(stored, result.quote());
+    assertEquals(201, result.httpStatus());
+    assertEquals(true, result.replayed());
+    org.mockito.Mockito.verifyNoInteractions(repository, serviceAreas, routes, outbox, audit);
+  }
+
+  @Test
   void quoteRejectsUnavailableInputsAndOverflow() {
     rider();
-    assertThrows(NotFoundException.class, () -> service.createQuote(PRODUCT_ID, PICKUP, DROPOFF));
+    assertThrows(NotFoundException.class,
+        () -> service.createQuote("key-1", PRODUCT_ID, PICKUP, DROPOFF));
     when(repository.findProduct(TENANT_ID, PRODUCT_ID)).thenReturn(Optional.of(product(ProductStatus.INACTIVE)));
-    assertThrows(NotFoundException.class, () -> service.createQuote(PRODUCT_ID, PICKUP, DROPOFF));
+    assertThrows(NotFoundException.class,
+        () -> service.createQuote("key-2", PRODUCT_ID, PICKUP, DROPOFF));
 
     when(repository.findProduct(TENANT_ID, PRODUCT_ID)).thenReturn(Optional.of(product(ProductStatus.ACTIVE)));
-    assertThrows(ConflictException.class, () -> service.createQuote(PRODUCT_ID, PICKUP, DROPOFF));
+    assertThrows(ConflictException.class,
+        () -> service.createQuote("key-3", PRODUCT_ID, PICKUP, DROPOFF));
     when(serviceAreas.coversRoute(TENANT_ID, PICKUP, DROPOFF)).thenReturn(true);
-    assertThrows(ConflictException.class, () -> service.createQuote(PRODUCT_ID, PICKUP, DROPOFF));
+    assertThrows(ConflictException.class,
+        () -> service.createQuote("key-4", PRODUCT_ID, PICKUP, DROPOFF));
 
     PricingRule overflow = rule(1, Long.MAX_VALUE, 0, 0, null, null);
     when(repository.findEffectiveRule(TENANT_ID, PRODUCT_ID, NOW)).thenReturn(Optional.of(overflow));
     when(routes.estimate(PICKUP, DROPOFF)).thenReturn(new RouteEstimate(1000, 0));
-    assertThrows(InvalidRequestException.class, () -> service.createQuote(PRODUCT_ID, PICKUP, DROPOFF));
+    assertThrows(InvalidRequestException.class,
+        () -> service.createQuote("key-5", PRODUCT_ID, PICKUP, DROPOFF));
 
     when(routes.estimate(PICKUP, DROPOFF)).thenReturn(new RouteEstimate(1e20, 0));
-    assertThrows(InvalidRequestException.class, () -> service.createQuote(PRODUCT_ID, PICKUP, DROPOFF));
+    assertThrows(InvalidRequestException.class,
+        () -> service.createQuote("key-6", PRODUCT_ID, PICKUP, DROPOFF));
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/web/CorrelationIdFilterTest.java
+++ b/src/test/java/in/rsh/cab/web/CorrelationIdFilterTest.java
@@ -21,12 +21,27 @@ class CorrelationIdFilterTest {
     request.addHeader(CorrelationIdFilter.HEADER_NAME, "request-123");
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain chain =
-        (ignoredRequest, ignoredResponse) -> assertEquals("request-123", MDC.get("correlationId"));
+        (ignoredRequest, ignoredResponse) -> {
+          assertEquals("request-123", MDC.get("correlationId"));
+          assertEquals("request-123", RequestMetadata.correlationIdOrNull());
+        };
 
     filter.doFilter(request, response, chain);
 
     assertEquals("request-123", response.getHeader(CorrelationIdFilter.HEADER_NAME));
     assertNull(MDC.get("correlationId"));
+    assertNull(RequestMetadata.correlationIdOrNull());
+  }
+
+  @Test
+  void replacesOverlongCorrelationId() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(CorrelationIdFilter.HEADER_NAME, "x".repeat(129));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, (ignoredRequest, ignoredResponse) -> {});
+
+    assertFalse("x".repeat(129).equals(response.getHeader(CorrelationIdFilter.HEADER_NAME)));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Delivers `feat(operations): add idempotency outbox and audit` as part 7 of 26 in the production marketplace stack.
- Contains 38 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/104`
- Head: `stack/07-operations`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.