### PR TITLE
feat(payments): add refunds ledger and settlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ The current implementation supports:
 - Tenant-scoped service products, versioned pricing rules, and immutable rider fare quotes
 - Tenant-scoped idempotency, transactional outbox/inbox, and append-only audit foundations
 - Tenant-scoped live driver locations, dispatch offers, and the complete ride lifecycle
+- Provider-neutral capture/refund processing, configurable commission, immutable double-entry ledger, earnings, and settlements
 
 The production roadmap includes:
 
 - Strict tenant isolation and broader role-based access
 - Driver document upload and verification workflows
-- Provider-neutral payments, notifications, refunds, and settlements
+- Notifications and production payment-provider adapters
 - Auditing, webhooks, ratings, support, and safety workflows
 - OpenAPI, observability, Docker Compose, and a Helm chart
 
@@ -122,7 +123,10 @@ In another terminal:
 ```
 
 The application reads `DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `REDIS_HOST`,
-`REDIS_PORT`, and `OSRM_BASE_URL`. OSRM defaults to `http://localhost:5000`. Defaults are intended
+`REDIS_PORT`, and `OSRM_BASE_URL`. Payment settings use `PAYMENT_PROVIDER`,
+`FAKE_PAYMENT_CONFIG_REFERENCE`, `FAKE_PAYMENT_WEBHOOK_SECRET_REFERENCE`,
+`FAKE_PAYMENT_WEBHOOK_SECRET`, and `PAYMENT_WEBHOOK_TOLERANCE`. OSRM defaults to
+`http://localhost:5000`. Defaults are intended
 for local development only. Flyway applies pending migrations; Hibernate validates the resulting
 schema and never creates or drops production tables.
 
@@ -160,6 +164,11 @@ versioned endpoint is:
 | `GET` | `/api/v1/driver/offers` | List the authenticated driver's pending, unexpired offers |
 | `POST` | `/api/v1/driver/offers/{id}/accept` | Atomically reserve supply and assign exactly one driver |
 | `POST` | `/api/v1/driver/rides/{id}/{action}` | Apply `arriving`, `arrive`, `start`, `complete`, or `cancel` lifecycle actions |
+| `GET` | `/api/v1/rides/{id}/payment` | Read the authenticated rider's payment status |
+| `POST` | `/api/v1/finance/payments/{id}/refunds` | Request a bounded refund; requires `FINANCE` or `TENANT_ADMIN` |
+| `GET` | `/api/v1/driver/earnings` | Read the authenticated driver's ledger balance |
+| `POST`, `GET` | `/api/v1/finance/settlements` | Settle positive driver balances or list batches; creation requires `FINANCE` |
+| `POST` | `/api/v1/payment-providers/{provider}/accounts/{id}/events` | Receive signed provider callbacks |
 
 Operational probes are available at `/actuator/health/liveness` and
 `/actuator/health/readiness`. API responses include `X-Correlation-ID`; clients may supply this
@@ -191,6 +200,20 @@ writes initial history, outbox, audit, and idempotency completion in the same tr
 shift transitions are optimistic. Offer acceptance locks only the chosen offer and conditionally
 reserves its shift; database partial unique constraints enforce one accepted offer per ride and one
 active ride per shift. Completion and allowed cancellations release the shift to `AVAILABLE`.
+
+Ride completion creates a `CAPTURE_PENDING` payment and transactional
+`payment.capture_requested` outbox event. It never calls a provider inside the ride transaction.
+An outbox consumer invokes the callable `PaymentOperationWorker`; provider success is authoritative
+only after a signed callback. The included `FakePaymentProvider` is for local development and tests.
+Callbacks use HMAC-SHA256 over `<unix-seconds>.<raw-body>`, enforce a configurable replay window,
+deduplicate by payment account and provider event ID, and ignore stale provider versions. Callback
+rows retain normalized identifiers and monetary metadata, not raw provider bodies.
+
+Capture posts a balanced ledger transaction from provider receivable to driver payable and platform
+revenue according to `PAYMENTS_PLATFORM_COMMISSION_BASIS_POINTS` (15% by default). Successful
+refunds reverse both shares proportionally, and completed payouts move driver payable to payout clearing. Ledger
+transactions and entries are append-only, source-idempotent, single-currency, and checked for equal
+debits and credits at commit. Refund reservations and successful refunds cannot exceed capture.
 
 Pricing amounts use signed 64-bit integer minor units and ISO 4217 currency codes. Active pricing
 rules cannot overlap for the same tenant and product. Quote creation requires one active service

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,18 @@ Quote consumption, offer acceptance, ride assignment, shift reservation, history
 writes use database transactions and conditional updates. Fare and currency snapshots are never
 accepted from clients or recalculated during the lifecycle.
 
+Payment APIs derive tenant, rider, driver, and finance authority from persisted memberships. The
+database stores opaque payment-method tokens and provider/configuration references only; PAN, CVV,
+bank credentials, API keys, and webhook secrets must never be persisted. Fake-provider callback
+secrets are resolved from environment configuration. Provider callbacks are HMAC authenticated over
+the timestamp and exact raw body, rejected outside the replay window, account-scoped, idempotent,
+and provider-version ordered. Raw callback bodies are not retained.
+
+Provider calls run only from the outbox-driven payment worker, never in ride database transactions.
+Payment identity and monetary snapshots are immutable, captures cannot exceed authorization, and
+refund reservations/successes cannot exceed capture. Financial postings are source-idempotent,
+balanced, single-currency double entries; database triggers reject ledger updates and deletes.
+
 ## Reporting A Vulnerability
 
 Use GitHub private vulnerability reporting for this repository. Open the repository's **Security**

--- a/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import in.rsh.cab.routing.RouteProviderException;
 import in.rsh.cab.operations.IdempotencyConflictException;
+import in.rsh.cab.payment.PaymentSignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -53,6 +54,12 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ProblemDetail> handleTenantAccessDenied(
       TenantAccessDeniedException exception) {
     return problem(HttpStatus.FORBIDDEN, "Tenant access denied", exception.getMessage(), "tenant-access-denied");
+  }
+
+  @ExceptionHandler(PaymentSignatureException.class)
+  public ResponseEntity<ProblemDetail> handlePaymentSignature(PaymentSignatureException exception) {
+    return problem(HttpStatus.UNAUTHORIZED, "Invalid provider signature", exception.getMessage(),
+        "invalid-provider-signature");
   }
 
   @ExceptionHandler(RouteProviderException.class)

--- a/src/main/java/in/rsh/cab/payment/DriverEarning.java
+++ b/src/main/java/in/rsh/cab/payment/DriverEarning.java
@@ -1,0 +1,3 @@
+package in.rsh.cab.payment;
+
+public record DriverEarning(String currency, long availableMinor) {}

--- a/src/main/java/in/rsh/cab/payment/FakePaymentProvider.java
+++ b/src/main/java/in/rsh/cab/payment/FakePaymentProvider.java
@@ -1,0 +1,72 @@
+package in.rsh.cab.payment;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FakePaymentProvider implements PaymentProvider {
+
+  private final String secretReference;
+  private final byte[] webhookSecret;
+
+  public FakePaymentProvider(
+      @Value("${payments.fake.webhook-secret-reference}") String secretReference,
+      @Value("${payments.fake.webhook-secret}") String webhookSecret) {
+    this.secretReference = secretReference;
+    this.webhookSecret = webhookSecret.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public String name() {
+    return "fake";
+  }
+
+  @Override
+  public Submission capture(
+      PaymentAccount account, UUID paymentId, long amountMinor, String currency,
+      String idempotencyKey) {
+    return new Submission("fake-pay-" + paymentId, "fake-request-" + idempotencyKey);
+  }
+
+  @Override
+  public Submission refund(
+      PaymentAccount account, UUID paymentId, UUID refundId, String providerPaymentId,
+      long amountMinor, String currency, String idempotencyKey) {
+    return new Submission("fake-refund-" + refundId, "fake-request-" + idempotencyKey);
+  }
+
+  @Override
+  public boolean verifies(
+      PaymentAccount account, Instant timestamp, String rawBody, String signature) {
+    if (!secretReference.equals(account.webhookSecretReference()) || signature == null) {
+      return false;
+    }
+    byte[] expected = hmac(timestamp.getEpochSecond() + "." + rawBody);
+    try {
+      return MessageDigest.isEqual(expected, HexFormat.of().parseHex(signature));
+    } catch (IllegalArgumentException exception) {
+      return false;
+    }
+  }
+
+  public String sign(Instant timestamp, String rawBody) {
+    return HexFormat.of().formatHex(hmac(timestamp.getEpochSecond() + "." + rawBody));
+  }
+
+  private byte[] hmac(String value) {
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(webhookSecret, "HmacSHA256"));
+      return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception exception) {
+      throw new IllegalStateException("Cannot calculate webhook signature", exception);
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/payment/Payment.java
+++ b/src/main/java/in/rsh/cab/payment/Payment.java
@@ -1,0 +1,20 @@
+package in.rsh.cab.payment;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record Payment(
+    UUID id,
+    UUID rideId,
+    UUID riderAccountId,
+    long amountMinor,
+    long authorizedMinor,
+    long capturedMinor,
+    String currency,
+    PaymentState state,
+    String providerPaymentId,
+    long providerVersion,
+    long version,
+    String failureCode,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/src/main/java/in/rsh/cab/payment/PaymentAccount.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentAccount.java
@@ -1,0 +1,7 @@
+package in.rsh.cab.payment;
+
+import java.util.UUID;
+
+public record PaymentAccount(
+    UUID id, UUID tenantId, String provider, String configReference,
+    String webhookSecretReference, boolean active) {}

--- a/src/main/java/in/rsh/cab/payment/PaymentOperationWorker.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentOperationWorker.java
@@ -1,0 +1,86 @@
+package in.rsh.cab.payment;
+
+import in.rsh.cab.operations.OutboxEvent;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public class PaymentOperationWorker {
+
+  private final PaymentRepository payments;
+  private final Map<String, PaymentProvider> providers;
+  private final TransactionTemplate transactions;
+  private final Clock clock;
+
+  public PaymentOperationWorker(
+      PaymentRepository payments, List<PaymentProvider> providers,
+      TransactionTemplate transactions, Clock clock) {
+    this.payments = payments;
+    this.providers = providers.stream().collect(Collectors.toUnmodifiableMap(
+        PaymentProvider::name, Function.identity()));
+    this.transactions = transactions;
+    this.clock = clock;
+  }
+
+  public boolean process(OutboxEvent event) {
+    if ("payment.capture_requested".equals(event.eventType())) {
+      return capture(event);
+    }
+    if ("payment.refund_requested".equals(event.eventType())) {
+      return refund(event);
+    }
+    return false;
+  }
+
+  private boolean capture(OutboxEvent event) {
+    Payment payment = payments.find(event.tenantId(), event.aggregateId()).orElse(null);
+    if (payment == null || !Boolean.TRUE.equals(transactions.execute(
+        status -> payments.markCaptureProcessing(event.tenantId(), payment.id())))) {
+      return false;
+    }
+    PaymentAccount account = payments.findAccountForPayment(event.tenantId(), payment.id())
+        .orElseThrow();
+    try {
+      PaymentProvider.Submission submitted = provider(account).capture(account, payment.id(),
+          payment.amountMinor(), payment.currency(), "capture:" + payment.id());
+      transactions.executeWithoutResult(status -> payments.markCaptureSubmitted(event.tenantId(),
+          payment.id(), submitted.providerObjectId(), submitted.providerRequestId()));
+      return true;
+    } catch (RuntimeException exception) {
+      transactions.executeWithoutResult(status -> payments.markCaptureSubmissionFailed(
+          event.tenantId(), payment.id(), "PROVIDER_UNAVAILABLE", clock.instant()));
+      throw exception;
+    }
+  }
+
+  private boolean refund(OutboxEvent event) {
+    Refund refund = payments.findRefund(event.tenantId(), event.aggregateId()).orElse(null);
+    if (refund == null || !Boolean.TRUE.equals(transactions.execute(
+        status -> payments.markRefundProcessing(event.tenantId(), refund.id())))) {
+      return false;
+    }
+    Payment payment = payments.find(event.tenantId(), refund.paymentId()).orElseThrow();
+    PaymentAccount account = payments.findAccountForPayment(event.tenantId(), payment.id())
+        .orElseThrow();
+    PaymentProvider.Submission submitted = provider(account).refund(account, payment.id(),
+        refund.id(), payment.providerPaymentId(), refund.amountMinor(), refund.currency(),
+        "refund:" + refund.id());
+    transactions.executeWithoutResult(status -> payments.markRefundSubmitted(
+        event.tenantId(), refund.id(), submitted.providerObjectId(), clock.instant()));
+    return true;
+  }
+
+  private PaymentProvider provider(PaymentAccount account) {
+    PaymentProvider provider = providers.get(account.provider());
+    if (provider == null) {
+      throw new IllegalStateException("Payment provider is not configured: " + account.provider());
+    }
+    return provider;
+  }
+}

--- a/src/main/java/in/rsh/cab/payment/PaymentProvider.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentProvider.java
@@ -1,0 +1,21 @@
+package in.rsh.cab.payment;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface PaymentProvider {
+
+  String name();
+
+  Submission capture(
+      PaymentAccount account, UUID paymentId, long amountMinor, String currency,
+      String idempotencyKey);
+
+  Submission refund(
+      PaymentAccount account, UUID paymentId, UUID refundId, String providerPaymentId,
+      long amountMinor, String currency, String idempotencyKey);
+
+  boolean verifies(PaymentAccount account, Instant timestamp, String rawBody, String signature);
+
+  record Submission(String providerObjectId, String providerRequestId) {}
+}

--- a/src/main/java/in/rsh/cab/payment/PaymentService.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentService.java
@@ -1,0 +1,163 @@
+package in.rsh.cab.payment;
+
+import in.rsh.cab.audit.AuditService;
+import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.operations.OutboxService;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
+import in.rsh.cab.ride.Ride;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+@Service
+public class PaymentService {
+
+  private final PaymentRepository payments;
+  private final DriverProfileRepository drivers;
+  private final OutboxService outbox;
+  private final AuditService audit;
+  private final ObjectMapper json;
+  private final Clock clock;
+  private final String provider;
+  private final String configReference;
+  private final String secretReference;
+
+  public PaymentService(
+      PaymentRepository payments, DriverProfileRepository drivers, OutboxService outbox,
+      AuditService audit, ObjectMapper json, Clock clock,
+      @Value("${payments.provider}") String provider,
+      @Value("${payments.fake.config-reference}") String configReference,
+      @Value("${payments.fake.webhook-secret-reference}") String secretReference) {
+    this.payments = payments;
+    this.drivers = drivers;
+    this.outbox = outbox;
+    this.audit = audit;
+    this.json = json;
+    this.clock = clock;
+    this.provider = provider;
+    this.configReference = configReference;
+    this.secretReference = secretReference;
+  }
+
+  @Transactional
+  public void requestCapture(UUID tenantId, Ride ride) {
+    Instant now = clock.instant();
+    PaymentAccount account = payments.activeAccount(
+        tenantId, provider, configReference, secretReference, now);
+    Payment payment = new Payment(UUID.randomUUID(), ride.id(), ride.riderAccountId(),
+        ride.fareMinor(), ride.fareMinor(), 0, ride.currency(), PaymentState.CAPTURE_PENDING,
+        null, 0, 0, null, now, now);
+    payments.insertCaptureRequest(tenantId, account.id(), payment, UUID.randomUUID());
+    Payment stored = payments.findByRide(tenantId, ride.riderAccountId(), ride.id()).orElseThrow();
+    outbox.append(tenantId, "payment", stored.id(), stored.version(),
+        "payment.capture_requested", 1,
+        json.valueToTree(new OperationRequested(stored.id(), null)), null);
+  }
+
+  @Transactional(readOnly = true)
+  public Payment getOwn(UUID paymentId) {
+    TenantContext context = require(TenantRole.RIDER);
+    return payments.findOwn(context.tenantId(), context.accountId(), paymentId)
+        .orElseThrow(() -> new NotFoundException("Payment not found"));
+  }
+
+  @Transactional(readOnly = true)
+  public Payment getOwnByRide(UUID rideId) {
+    TenantContext context = require(TenantRole.RIDER);
+    return payments.findByRide(context.tenantId(), context.accountId(), rideId)
+        .orElseThrow(() -> new NotFoundException("Payment not found"));
+  }
+
+  @Transactional
+  public Refund refund(UUID paymentId, long amountMinor, String reason) {
+    TenantContext context = requireAny(TenantRole.FINANCE, TenantRole.TENANT_ADMIN);
+    Payment payment = payments.find(context.tenantId(), paymentId)
+        .orElseThrow(() -> new NotFoundException("Payment not found"));
+    if (payment.state() != PaymentState.CAPTURED) {
+      throw new ConflictException("Only captured payments can be refunded");
+    }
+    long committed = payments.committedRefundMinor(context.tenantId(), paymentId);
+    if (amountMinor <= 0 || committed > payment.capturedMinor()
+        || amountMinor > payment.capturedMinor() - committed) {
+      throw new ConflictException("Refund exceeds the unrefunded captured amount");
+    }
+    Instant now = clock.instant();
+    Refund refund = new Refund(UUID.randomUUID(), paymentId, amountMinor, payment.currency(),
+        reason, RefundState.PENDING, null, 0, 0, now, now);
+    try {
+      payments.insertRefund(context.tenantId(), refund, context.accountId());
+    } catch (DataIntegrityViolationException exception) {
+      throw new ConflictException("Refund exceeds the unrefunded captured amount");
+    }
+    outbox.append(context.tenantId(), "refund", refund.id(), 0, "payment.refund_requested", 1,
+        json.valueToTree(new OperationRequested(paymentId, refund.id())), null);
+    audit.record(context.tenantId(), context.accountId(), "payment.refund_requested", "refund",
+        refund.id(), "SUCCESS", json.valueToTree(new RefundAudit(paymentId, amountMinor,
+            payment.currency())));
+    return refund;
+  }
+
+  @Transactional(readOnly = true)
+  public Refund getRefund(UUID refundId) {
+    TenantContext context = requireAny(TenantRole.FINANCE, TenantRole.TENANT_ADMIN);
+    return payments.findRefund(context.tenantId(), refundId)
+        .orElseThrow(() -> new NotFoundException("Refund not found"));
+  }
+
+  @Transactional(readOnly = true)
+  public List<DriverEarning> ownEarnings() {
+    TenantContext context = require(TenantRole.DRIVER);
+    UUID driverId = drivers.findByTenantIdAndAccountId(context.tenantId(), context.accountId())
+        .orElseThrow(() -> new NotFoundException("Driver profile not found")).id();
+    return payments.earnings(context.tenantId(), driverId);
+  }
+
+  @Transactional
+  public SettlementBatch settle(String currency) {
+    TenantContext context = require(TenantRole.FINANCE);
+    SettlementBatch batch = payments.createSettlement(
+        context.tenantId(), context.accountId(), currency, clock.instant());
+    outbox.append(context.tenantId(), "settlement", batch.id(), 0, "settlement.completed", 1,
+        json.valueToTree(new SettlementAudit(batch.currency(), batch.totalMinor())), null);
+    audit.record(context.tenantId(), context.accountId(), "settlement.create", "settlement",
+        batch.id(), "SUCCESS", json.valueToTree(new SettlementAudit(
+            batch.currency(), batch.totalMinor())));
+    return batch;
+  }
+
+  @Transactional(readOnly = true)
+  public List<SettlementBatch> settlements() {
+    TenantContext context = requireAny(TenantRole.FINANCE, TenantRole.TENANT_ADMIN);
+    return payments.settlements(context.tenantId());
+  }
+
+  private TenantContext require(TenantRole role) {
+    return requireAny(role);
+  }
+
+  private TenantContext requireAny(TenantRole... roles) {
+    TenantContext context = TenantContext.require();
+    if (Set.of(roles).stream().noneMatch(context.roles()::contains)) {
+      throw new TenantAccessDeniedException("Required payment role is missing");
+    }
+    return context;
+  }
+
+  public record OperationRequested(UUID paymentId, UUID refundId) {}
+
+  private record RefundAudit(UUID paymentId, long amountMinor, String currency) {}
+
+  private record SettlementAudit(String currency, long amountMinor) {}
+}

--- a/src/main/java/in/rsh/cab/payment/PaymentSignatureException.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentSignatureException.java
@@ -1,0 +1,8 @@
+package in.rsh.cab.payment;
+
+public class PaymentSignatureException extends RuntimeException {
+
+  public PaymentSignatureException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/in/rsh/cab/payment/PaymentState.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentState.java
@@ -1,0 +1,11 @@
+package in.rsh.cab.payment;
+
+public enum PaymentState {
+  CREATED,
+  AUTHORIZATION_PENDING,
+  AUTHORIZED,
+  CAPTURE_PENDING,
+  CAPTURED,
+  FAILED,
+  VOIDED
+}

--- a/src/main/java/in/rsh/cab/payment/ProviderCallbackService.java
+++ b/src/main/java/in/rsh/cab/payment/ProviderCallbackService.java
@@ -1,0 +1,123 @@
+package in.rsh.cab.payment;
+
+import in.rsh.cab.operations.OutboxService;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+@Service
+public class ProviderCallbackService {
+
+  private final PaymentRepository payments;
+  private final Map<String, PaymentProvider> providers;
+  private final OutboxService outbox;
+  private final ObjectMapper json;
+  private final Clock clock;
+  private final Duration tolerance;
+  private final int commissionBasisPoints;
+
+  public ProviderCallbackService(
+      PaymentRepository payments, List<PaymentProvider> providers, OutboxService outbox,
+      ObjectMapper json, Clock clock,
+      @Value("${payments.webhook-tolerance}") Duration tolerance,
+      @Value("${payments.platform-commission-basis-points:1500}") int commissionBasisPoints) {
+    if (commissionBasisPoints < 0 || commissionBasisPoints > 10_000) {
+      throw new IllegalArgumentException("Platform commission must be between 0 and 10000 basis points");
+    }
+    this.payments = payments;
+    this.providers = providers.stream().collect(Collectors.toUnmodifiableMap(
+        PaymentProvider::name, Function.identity()));
+    this.outbox = outbox;
+    this.json = json;
+    this.clock = clock;
+    this.tolerance = tolerance;
+    this.commissionBasisPoints = commissionBasisPoints;
+  }
+
+  @Transactional
+  public Result process(
+      UUID accountId, String providerName, Instant timestamp, String signature, String rawBody) {
+    Instant now = clock.instant();
+    if (timestamp.isBefore(now.minus(tolerance)) || timestamp.isAfter(now.plus(tolerance))) {
+      throw new PaymentSignatureException("Webhook timestamp is outside the replay window");
+    }
+    PaymentAccount account = payments.findAccount(accountId)
+        .filter(value -> value.provider().equals(providerName))
+        .orElseThrow(() -> new PaymentSignatureException("Payment account is not available"));
+    PaymentProvider provider = providers.get(providerName);
+    if (provider == null || !provider.verifies(account, timestamp, rawBody, signature)) {
+      throw new PaymentSignatureException("Webhook signature is invalid");
+    }
+    ProviderEvent event;
+    try {
+      event = json.readValue(rawBody, ProviderEvent.class);
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("Webhook body is invalid", exception);
+    }
+    if (!payments.insertProviderEvent(UUID.randomUUID(), account, event, now)) {
+      return new Result(false, false);
+    }
+    boolean applied = switch (event.type()) {
+      case CAPTURE_SUCCEEDED -> applyCapture(account, event, now, true);
+      case CAPTURE_FAILED -> applyCapture(account, event, now, false);
+      case REFUND_SUCCEEDED -> applyRefund(account, event, now, true);
+      case REFUND_FAILED -> applyRefund(account, event, now, false);
+    };
+    payments.markProviderEvent(account.id(), event.eventId(), applied, now);
+    return new Result(true, applied);
+  }
+
+  private boolean applyCapture(
+      PaymentAccount account, ProviderEvent event, Instant now, boolean succeeded) {
+    if (event.paymentId() == null || event.refundId() != null
+        || (succeeded && (event.amountMinor() == null || event.currency() == null))) {
+      return false;
+    }
+    boolean applied = payments.applyCaptureEvent(account, event, now, succeeded);
+    if (applied && succeeded) {
+      payments.postCaptureLedger(
+          account.tenantId(), event.paymentId(), commissionBasisPoints, now);
+    }
+    if (applied) {
+      outbox.append(account.tenantId(), "payment", event.paymentId(), event.providerVersion(),
+          succeeded ? "payment.captured" : "payment.capture_failed", 1,
+          json.valueToTree(new PaymentResult(event.paymentId(), event.amountMinor(), event.currency())),
+          null);
+    }
+    return applied;
+  }
+
+  private boolean applyRefund(
+      PaymentAccount account, ProviderEvent event, Instant now, boolean succeeded) {
+    if (event.refundId() == null || event.paymentId() == null
+        || (succeeded && (event.amountMinor() == null || event.currency() == null))) {
+      return false;
+    }
+    boolean applied = payments.applyRefundEvent(account, event, now, succeeded);
+    if (applied && succeeded) {
+      payments.postRefundLedger(
+          account.tenantId(), event.refundId(), commissionBasisPoints, now);
+    }
+    if (applied) {
+      outbox.append(account.tenantId(), "refund", event.refundId(), event.providerVersion(),
+          succeeded ? "payment.refunded" : "payment.refund_failed", 1,
+          json.valueToTree(new PaymentResult(event.paymentId(), event.amountMinor(), event.currency())),
+          null);
+    }
+    return applied;
+  }
+
+  public record Result(boolean accepted, boolean applied) {}
+
+  private record PaymentResult(UUID paymentId, Long amountMinor, String currency) {}
+}

--- a/src/main/java/in/rsh/cab/payment/ProviderEvent.java
+++ b/src/main/java/in/rsh/cab/payment/ProviderEvent.java
@@ -1,0 +1,22 @@
+package in.rsh.cab.payment;
+
+import java.util.UUID;
+
+public record ProviderEvent(
+    String eventId,
+    Type type,
+    UUID paymentId,
+    UUID refundId,
+    String providerObjectId,
+    long providerVersion,
+    Long amountMinor,
+    String currency,
+    String failureCode) {
+
+  public enum Type {
+    CAPTURE_SUCCEEDED,
+    CAPTURE_FAILED,
+    REFUND_SUCCEEDED,
+    REFUND_FAILED
+  }
+}

--- a/src/main/java/in/rsh/cab/payment/Refund.java
+++ b/src/main/java/in/rsh/cab/payment/Refund.java
@@ -1,0 +1,17 @@
+package in.rsh.cab.payment;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record Refund(
+    UUID id,
+    UUID paymentId,
+    long amountMinor,
+    String currency,
+    String reason,
+    RefundState state,
+    String providerRefundId,
+    long providerVersion,
+    long version,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/src/main/java/in/rsh/cab/payment/RefundState.java
+++ b/src/main/java/in/rsh/cab/payment/RefundState.java
@@ -1,0 +1,8 @@
+package in.rsh.cab.payment;
+
+public enum RefundState {
+  REQUESTED,
+  PENDING,
+  SUCCEEDED,
+  FAILED
+}

--- a/src/main/java/in/rsh/cab/payment/SettlementBatch.java
+++ b/src/main/java/in/rsh/cab/payment/SettlementBatch.java
@@ -1,0 +1,12 @@
+package in.rsh.cab.payment;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record SettlementBatch(
+    UUID id, String currency, String state, long totalMinor, Instant createdAt,
+    List<Payout> payouts) {
+
+  public record Payout(UUID id, UUID driverId, long amountMinor, String currency, String state) {}
+}

--- a/src/main/java/in/rsh/cab/payment/internal/persistence/JdbcPaymentRepository.java
+++ b/src/main/java/in/rsh/cab/payment/internal/persistence/JdbcPaymentRepository.java
@@ -1,0 +1,507 @@
+package in.rsh.cab.payment.internal.persistence;
+
+import in.rsh.cab.payment.DriverEarning;
+import in.rsh.cab.payment.Payment;
+import in.rsh.cab.payment.PaymentAccount;
+import in.rsh.cab.payment.PaymentState;
+import in.rsh.cab.payment.ProviderEvent;
+import in.rsh.cab.payment.Refund;
+import in.rsh.cab.payment.RefundState;
+import in.rsh.cab.payment.SettlementBatch;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcPaymentRepository implements PaymentRepository {
+
+  private static final String PAYMENT_SELECT = """
+      SELECT id, ride_id, rider_account_id, amount_minor, authorized_minor, captured_minor,
+             currency, state, provider_payment_id, provider_version, version, failure_code,
+             created_at, updated_at FROM payments
+      """;
+  private final JdbcClient jdbc;
+
+  public JdbcPaymentRepository(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public PaymentAccount activeAccount(
+      UUID tenantId, String provider, String configReference, String secretReference, Instant now) {
+    jdbc.sql("""
+            INSERT INTO payment_accounts
+              (id, tenant_id, provider, config_reference, webhook_secret_reference, active,
+               created_at, updated_at)
+            VALUES (:id, :tenantId, :provider, :configReference, :secretReference, true, :now, :now)
+            ON CONFLICT (tenant_id, provider) DO NOTHING
+            """)
+        .param("id", UUID.randomUUID()).param("tenantId", tenantId).param("provider", provider)
+        .param("configReference", configReference).param("secretReference", secretReference)
+        .param("now", Timestamp.from(now)).update();
+    return jdbc.sql("""
+            SELECT id, tenant_id, provider, config_reference, webhook_secret_reference, active
+            FROM payment_accounts WHERE tenant_id = :tenantId AND provider = :provider AND active
+            """)
+        .param("tenantId", tenantId).param("provider", provider).query(this::mapAccount).single();
+  }
+
+  @Override
+  public Optional<PaymentAccount> findAccount(UUID accountId) {
+    return jdbc.sql("""
+            SELECT id, tenant_id, provider, config_reference, webhook_secret_reference, active
+            FROM payment_accounts WHERE id = :id AND active
+            """)
+        .param("id", accountId).query(this::mapAccount).optional();
+  }
+
+  @Override
+  public Optional<PaymentAccount> findAccountForPayment(UUID tenantId, UUID paymentId) {
+    return jdbc.sql("""
+            SELECT a.id, a.tenant_id, a.provider, a.config_reference,
+                   a.webhook_secret_reference, a.active
+            FROM payment_accounts a JOIN payments p
+              ON p.tenant_id = a.tenant_id AND p.payment_account_id = a.id
+            WHERE p.tenant_id = :tenantId AND p.id = :paymentId AND a.active
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId)
+        .query(this::mapAccount).optional();
+  }
+
+  @Override
+  public void insertCaptureRequest(UUID tenantId, UUID accountId, Payment payment, UUID attemptId) {
+    jdbc.sql("""
+            INSERT INTO payments
+              (id, tenant_id, payment_account_id, ride_id, rider_account_id, amount_minor,
+               authorized_minor, captured_minor, currency, state, provider_version, version,
+               created_at, updated_at)
+            VALUES (:id, :tenantId, :accountId, :rideId, :riderId, :amount, :amount, 0,
+                    :currency, 'CAPTURE_PENDING', 0, 0, :now, :now)
+            ON CONFLICT (tenant_id, ride_id) DO NOTHING
+            """)
+        .param("id", payment.id()).param("tenantId", tenantId).param("accountId", accountId)
+        .param("rideId", payment.rideId()).param("riderId", payment.riderAccountId())
+        .param("amount", payment.amountMinor()).param("currency", payment.currency())
+        .param("now", Timestamp.from(payment.createdAt())).update();
+    Payment stored = jdbc.sql(PAYMENT_SELECT + " WHERE tenant_id = :tenantId AND ride_id = :rideId")
+        .param("tenantId", tenantId).param("rideId", payment.rideId()).query(this::mapPayment).single();
+    jdbc.sql("""
+            INSERT INTO payment_attempts
+              (id, tenant_id, payment_id, operation, idempotency_key, state, created_at)
+            VALUES (:id, :tenantId, :paymentId, 'CAPTURE', :key, 'PENDING', :now)
+            ON CONFLICT (tenant_id, payment_id, operation, idempotency_key) DO NOTHING
+            """)
+        .param("id", attemptId).param("tenantId", tenantId).param("paymentId", stored.id())
+        .param("key", "capture:" + stored.id()).param("now", Timestamp.from(payment.createdAt())).update();
+  }
+
+  @Override
+  public Optional<Payment> findOwn(UUID tenantId, UUID riderAccountId, UUID paymentId) {
+    return jdbc.sql(PAYMENT_SELECT
+            + " WHERE tenant_id = :tenantId AND rider_account_id = :riderId AND id = :id")
+        .param("tenantId", tenantId).param("riderId", riderAccountId).param("id", paymentId)
+        .query(this::mapPayment).optional();
+  }
+
+  @Override
+  public Optional<Payment> findByRide(UUID tenantId, UUID riderAccountId, UUID rideId) {
+    return jdbc.sql(PAYMENT_SELECT
+            + " WHERE tenant_id = :tenantId AND rider_account_id = :riderId AND ride_id = :rideId")
+        .param("tenantId", tenantId).param("riderId", riderAccountId).param("rideId", rideId)
+        .query(this::mapPayment).optional();
+  }
+
+  @Override
+  public Optional<Payment> find(UUID tenantId, UUID paymentId) {
+    return jdbc.sql(PAYMENT_SELECT + " WHERE tenant_id = :tenantId AND id = :id")
+        .param("tenantId", tenantId).param("id", paymentId).query(this::mapPayment).optional();
+  }
+
+  @Override
+  public boolean markCaptureProcessing(UUID tenantId, UUID paymentId) {
+    return jdbc.sql("""
+            UPDATE payment_attempts SET state = 'PROCESSING'
+            WHERE tenant_id = :tenantId AND payment_id = :paymentId
+              AND operation = 'CAPTURE' AND state IN ('PENDING', 'PROCESSING')
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId).update() == 1;
+  }
+
+  @Override
+  public void markCaptureSubmitted(
+      UUID tenantId, UUID paymentId, String providerPaymentId, String providerRequestId) {
+    jdbc.sql("""
+            UPDATE payments SET provider_payment_id = :providerPaymentId
+            WHERE tenant_id = :tenantId AND id = :paymentId AND state = 'CAPTURE_PENDING'
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId)
+        .param("providerPaymentId", providerPaymentId).update();
+    jdbc.sql("""
+            UPDATE payment_attempts SET provider_request_id = :requestId
+            WHERE tenant_id = :tenantId AND payment_id = :paymentId
+              AND operation = 'CAPTURE' AND state = 'PROCESSING'
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId)
+        .param("requestId", providerRequestId).update();
+  }
+
+  @Override
+  public void markCaptureSubmissionFailed(
+      UUID tenantId, UUID paymentId, String failureCode, Instant now) {
+    jdbc.sql("""
+            UPDATE payments SET state = 'FAILED', failure_code = :failure, version = version + 1,
+              updated_at = :now WHERE tenant_id = :tenantId AND id = :paymentId
+              AND state = 'CAPTURE_PENDING'
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId).param("failure", failureCode)
+        .param("now", Timestamp.from(now)).update();
+    jdbc.sql("""
+            UPDATE payment_attempts SET state = 'FAILED', failure_code = :failure, completed_at = :now
+            WHERE tenant_id = :tenantId AND payment_id = :paymentId AND operation = 'CAPTURE'
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId).param("failure", failureCode)
+        .param("now", Timestamp.from(now)).update();
+  }
+
+  @Override
+  public void insertRefund(UUID tenantId, Refund refund, UUID requesterId) {
+    jdbc.sql("""
+            INSERT INTO refunds
+              (id, tenant_id, payment_id, amount_minor, currency, reason, state,
+               provider_version, version, requested_by_account_id, created_at, updated_at)
+            VALUES (:id, :tenantId, :paymentId, :amount, :currency, :reason, 'PENDING',
+                    0, 0, :requesterId, :now, :now)
+            """)
+        .param("id", refund.id()).param("tenantId", tenantId).param("paymentId", refund.paymentId())
+        .param("amount", refund.amountMinor()).param("currency", refund.currency())
+        .param("reason", refund.reason()).param("requesterId", requesterId)
+        .param("now", Timestamp.from(refund.createdAt())).update();
+  }
+
+  @Override
+  public Optional<Refund> findRefund(UUID tenantId, UUID refundId) {
+    return jdbc.sql("""
+            SELECT id, payment_id, amount_minor, currency, reason, state, provider_refund_id,
+                   provider_version, version, created_at, updated_at
+            FROM refunds WHERE tenant_id = :tenantId AND id = :id
+            """)
+        .param("tenantId", tenantId).param("id", refundId).query(this::mapRefund).optional();
+  }
+
+  @Override
+  public long committedRefundMinor(UUID tenantId, UUID paymentId) {
+    return jdbc.sql("""
+            SELECT COALESCE(sum(amount_minor), 0) FROM refunds
+            WHERE tenant_id = :tenantId AND payment_id = :paymentId
+              AND state IN ('REQUESTED', 'PENDING', 'SUCCEEDED')
+            """)
+        .param("tenantId", tenantId).param("paymentId", paymentId).query(Long.class).single();
+  }
+
+  @Override
+  public boolean markRefundProcessing(UUID tenantId, UUID refundId) {
+    return jdbc.sql("""
+            UPDATE refunds SET state = 'PENDING'
+            WHERE tenant_id = :tenantId AND id = :id AND state IN ('REQUESTED', 'PENDING')
+              AND provider_refund_id IS NULL
+            """)
+        .param("tenantId", tenantId).param("id", refundId).update() == 1;
+  }
+
+  @Override
+  public void markRefundSubmitted(
+      UUID tenantId, UUID refundId, String providerRefundId, Instant now) {
+    jdbc.sql("""
+            UPDATE refunds SET provider_refund_id = :providerId, updated_at = :now
+            WHERE tenant_id = :tenantId AND id = :id AND state = 'PENDING'
+            """)
+        .param("tenantId", tenantId).param("id", refundId).param("providerId", providerRefundId)
+        .param("now", Timestamp.from(now)).update();
+  }
+
+  @Override
+  public boolean insertProviderEvent(
+      UUID id, PaymentAccount account, ProviderEvent event, Instant receivedAt) {
+    return jdbc.sql("""
+            INSERT INTO provider_events
+              (id, tenant_id, payment_account_id, provider_event_id, event_type,
+               provider_object_id, provider_version, amount_minor, currency, status, received_at)
+            VALUES (:id, :tenantId, :accountId, :eventId, :eventType, :objectId,
+                    :providerVersion, :amount, :currency, 'RECEIVED', :receivedAt)
+            ON CONFLICT (payment_account_id, provider_event_id) DO NOTHING
+            """)
+        .param("id", id).param("tenantId", account.tenantId()).param("accountId", account.id())
+        .param("eventId", event.eventId()).param("eventType", event.type().name())
+        .param("objectId", event.providerObjectId()).param("providerVersion", event.providerVersion())
+        .param("amount", event.amountMinor()).param("currency", event.currency())
+        .param("receivedAt", Timestamp.from(receivedAt)).update() == 1;
+  }
+
+  @Override
+  public boolean applyCaptureEvent(
+      PaymentAccount account, ProviderEvent event, Instant now, boolean succeeded) {
+    int changed = jdbc.sql("""
+            UPDATE payments SET state = :state, captured_minor = CASE WHEN :succeeded
+                THEN :amount ELSE captured_minor END, provider_payment_id = :providerId,
+                provider_version = :providerVersion, failure_code = :failure,
+                version = version + 1, updated_at = :now
+            WHERE tenant_id = :tenantId AND payment_account_id = :accountId AND id = :paymentId
+              AND provider_version < :providerVersion
+              AND (:currency IS NULL OR currency = :currency)
+              AND (:amount IS NULL OR amount_minor = :amount)
+              AND state IN ('CAPTURE_PENDING', 'FAILED')
+            """)
+        .param("state", succeeded ? "CAPTURED" : "FAILED").param("succeeded", succeeded)
+        .param("amount", event.amountMinor()).param("providerId", event.providerObjectId())
+        .param("providerVersion", event.providerVersion()).param("failure", event.failureCode())
+        .param("now", Timestamp.from(now)).param("tenantId", account.tenantId())
+        .param("accountId", account.id()).param("paymentId", event.paymentId())
+        .param("currency", event.currency()).update();
+    if (changed == 1) {
+      jdbc.sql("""
+              UPDATE payment_attempts SET state = :state, failure_code = :failure, completed_at = :now
+              WHERE tenant_id = :tenantId AND payment_id = :paymentId AND operation = 'CAPTURE'
+              """)
+          .param("state", succeeded ? "SUCCEEDED" : "FAILED").param("failure", event.failureCode())
+          .param("now", Timestamp.from(now)).param("tenantId", account.tenantId())
+          .param("paymentId", event.paymentId()).update();
+    }
+    return changed == 1;
+  }
+
+  @Override
+  public boolean applyRefundEvent(
+      PaymentAccount account, ProviderEvent event, Instant now, boolean succeeded) {
+    return jdbc.sql("""
+            UPDATE refunds r SET state = :state, provider_refund_id = :providerId,
+              provider_version = :providerVersion, failure_code = :failure,
+              version = r.version + 1, updated_at = :now
+            FROM payments p
+            WHERE r.tenant_id = :tenantId AND r.id = :refundId
+              AND p.tenant_id = r.tenant_id AND p.id = r.payment_id
+              AND p.id = :paymentId
+              AND p.payment_account_id = :accountId AND r.provider_version < :providerVersion
+              AND (:currency IS NULL OR r.currency = :currency)
+              AND (:amount IS NULL OR r.amount_minor = :amount)
+              AND r.state IN ('REQUESTED', 'PENDING', 'FAILED')
+            """)
+        .param("state", succeeded ? "SUCCEEDED" : "FAILED")
+        .param("providerId", event.providerObjectId()).param("providerVersion", event.providerVersion())
+        .param("failure", event.failureCode()).param("now", Timestamp.from(now))
+        .param("tenantId", account.tenantId()).param("refundId", event.refundId())
+        .param("paymentId", event.paymentId()).param("accountId", account.id())
+        .param("currency", event.currency())
+        .param("amount", event.amountMinor()).update() == 1;
+  }
+
+  @Override
+  public void markProviderEvent(UUID accountId, String eventId, boolean applied, Instant now) {
+    jdbc.sql("""
+            UPDATE provider_events SET status = :status, processed_at = :now
+            WHERE payment_account_id = :accountId AND provider_event_id = :eventId
+            """)
+        .param("status", applied ? "APPLIED" : "IGNORED").param("now", Timestamp.from(now))
+        .param("accountId", accountId).param("eventId", eventId).update();
+  }
+
+  @Override
+  public void postCaptureLedger(
+      UUID tenantId, UUID paymentId, int commissionBasisPoints, Instant now) {
+    postMarketplaceLedger(
+        tenantId, "PAYMENT_CAPTURE", paymentId, "Ride payment captured", now, """
+        SELECT p.captured_minor amount, p.currency, r.driver_id account_id
+        FROM payments p JOIN rides r ON r.tenant_id = p.tenant_id AND r.id = p.ride_id
+        WHERE p.tenant_id = :tenantId AND p.id = :sourceId AND p.state = 'CAPTURED'
+        """, commissionBasisPoints, false);
+  }
+
+  @Override
+  public void postRefundLedger(
+      UUID tenantId, UUID refundId, int commissionBasisPoints, Instant now) {
+    postMarketplaceLedger(
+        tenantId, "PAYMENT_REFUND", refundId, "Ride payment refunded", now, """
+        SELECT f.amount_minor amount, f.currency, r.driver_id account_id
+        FROM refunds f JOIN payments p ON p.tenant_id = f.tenant_id AND p.id = f.payment_id
+        JOIN rides r ON r.tenant_id = p.tenant_id AND r.id = p.ride_id
+        WHERE f.tenant_id = :tenantId AND f.id = :sourceId AND f.state = 'SUCCEEDED'
+        """, commissionBasisPoints, true);
+  }
+
+  @Override
+  public List<DriverEarning> earnings(UUID tenantId, UUID driverId) {
+    return jdbc.sql("""
+            SELECT currency, sum(credit_minor - debit_minor) available_minor
+            FROM ledger_entries WHERE tenant_id = :tenantId AND account_type = 'DRIVER_PAYABLE'
+              AND account_id = :driverId GROUP BY currency ORDER BY currency
+            """)
+        .param("tenantId", tenantId).param("driverId", driverId)
+        .query((rs, row) -> new DriverEarning(rs.getString("currency"), rs.getLong("available_minor")))
+        .list();
+  }
+
+  @Override
+  public SettlementBatch createSettlement(
+      UUID tenantId, UUID actorId, String currency, Instant now) {
+    jdbc.sql("SELECT id FROM tenants WHERE id = :tenantId FOR UPDATE")
+        .param("tenantId", tenantId).query(UUID.class).single();
+    List<Balance> balances = jdbc.sql("""
+            SELECT account_id, sum(credit_minor - debit_minor) amount
+            FROM ledger_entries WHERE tenant_id = :tenantId AND account_type = 'DRIVER_PAYABLE'
+              AND currency = :currency GROUP BY account_id
+            HAVING sum(credit_minor - debit_minor) > 0 ORDER BY account_id
+            """)
+        .param("tenantId", tenantId).param("currency", currency)
+        .query((rs, row) -> new Balance(rs.getObject("account_id", UUID.class), rs.getLong("amount")))
+        .list();
+    UUID batchId = UUID.randomUUID();
+    long total = balances.stream().mapToLong(Balance::amount).sum();
+    jdbc.sql("""
+            INSERT INTO settlement_batches
+              (id, tenant_id, currency, state, total_minor, created_by_account_id, created_at, completed_at)
+            VALUES (:id, :tenantId, :currency, 'COMPLETED', :total, :actorId, :now, :now)
+            """)
+        .param("id", batchId).param("tenantId", tenantId).param("currency", currency)
+        .param("total", total).param("actorId", actorId).param("now", Timestamp.from(now)).update();
+    List<SettlementBatch.Payout> payouts = balances.stream().map(balance -> {
+      UUID payoutId = UUID.randomUUID();
+      jdbc.sql("""
+              INSERT INTO payouts
+                (id, tenant_id, settlement_batch_id, driver_id, amount_minor, currency, state,
+                 version, created_at, updated_at)
+              VALUES (:id, :tenantId, :batchId, :driverId, :amount, :currency, 'PAID', 0, :now, :now)
+              """)
+          .param("id", payoutId).param("tenantId", tenantId).param("batchId", batchId)
+          .param("driverId", balance.driverId()).param("amount", balance.amount())
+          .param("currency", currency).param("now", Timestamp.from(now)).update();
+      postSettlementLedger(tenantId, payoutId, balance, currency, now);
+      return new SettlementBatch.Payout(payoutId, balance.driverId(), balance.amount(), currency, "PAID");
+    }).toList();
+    return new SettlementBatch(batchId, currency, "COMPLETED", total, now, payouts);
+  }
+
+  @Override
+  public List<SettlementBatch> settlements(UUID tenantId) {
+    return jdbc.sql("""
+            SELECT id, currency, state, total_minor, created_at FROM settlement_batches
+            WHERE tenant_id = :tenantId ORDER BY created_at DESC, id
+            """)
+        .param("tenantId", tenantId).query((rs, row) -> new SettlementBatch(
+            rs.getObject("id", UUID.class), rs.getString("currency"), rs.getString("state"),
+            rs.getLong("total_minor"), rs.getTimestamp("created_at").toInstant(), List.of())).list();
+  }
+
+  private void postMarketplaceLedger(
+      UUID tenantId, String sourceType, UUID sourceId, String description, Instant now,
+      String sourceSql, int commissionBasisPoints, boolean refund) {
+    Optional<LedgerSource> source = jdbc.sql(sourceSql).param("tenantId", tenantId)
+        .param("sourceId", sourceId).query((rs, row) -> new LedgerSource(
+            rs.getLong("amount"), rs.getString("currency"), rs.getObject("account_id", UUID.class)))
+        .optional();
+    if (source.isEmpty()) {
+      return;
+    }
+    UUID transactionId = UUID.randomUUID();
+    int inserted = jdbc.sql("""
+            INSERT INTO ledger_transactions
+              (id, tenant_id, source_type, source_id, description, created_at)
+            VALUES (:id, :tenantId, :sourceType, :sourceId, :description, :now)
+            ON CONFLICT (tenant_id, source_type, source_id) DO NOTHING
+            """)
+        .param("id", transactionId).param("tenantId", tenantId).param("sourceType", sourceType)
+        .param("sourceId", sourceId).param("description", description)
+        .param("now", Timestamp.from(now)).update();
+    if (inserted == 0) {
+      return;
+    }
+    LedgerSource value = source.orElseThrow();
+    long platformAmount = java.math.BigInteger.valueOf(value.amount())
+        .multiply(java.math.BigInteger.valueOf(commissionBasisPoints))
+        .divide(java.math.BigInteger.valueOf(10_000))
+        .longValueExact();
+    long driverAmount = Math.subtractExact(value.amount(), platformAmount);
+    if (refund) {
+      insertEntry(tenantId, transactionId, "DRIVER_PAYABLE", value.accountId(),
+          driverAmount, 0, value.currency(), now);
+      if (platformAmount > 0) {
+        insertEntry(tenantId, transactionId, "PLATFORM_REVENUE", null,
+            platformAmount, 0, value.currency(), now);
+      }
+      insertEntry(tenantId, transactionId, "PROVIDER_RECEIVABLE", null,
+          0, value.amount(), value.currency(), now);
+    } else {
+      insertEntry(tenantId, transactionId, "PROVIDER_RECEIVABLE", null,
+          value.amount(), 0, value.currency(), now);
+      insertEntry(tenantId, transactionId, "DRIVER_PAYABLE", value.accountId(),
+          0, driverAmount, value.currency(), now);
+      if (platformAmount > 0) {
+        insertEntry(tenantId, transactionId, "PLATFORM_REVENUE", null,
+            0, platformAmount, value.currency(), now);
+      }
+    }
+  }
+
+  private void postSettlementLedger(
+      UUID tenantId, UUID payoutId, Balance balance, String currency, Instant now) {
+    UUID transactionId = UUID.randomUUID();
+    jdbc.sql("""
+            INSERT INTO ledger_transactions
+              (id, tenant_id, source_type, source_id, description, created_at)
+            VALUES (:id, :tenantId, 'PAYOUT', :payoutId, 'Driver payout', :now)
+            """)
+        .param("id", transactionId).param("tenantId", tenantId).param("payoutId", payoutId)
+        .param("now", Timestamp.from(now)).update();
+    insertEntry(tenantId, transactionId, "DRIVER_PAYABLE", balance.driverId(),
+        balance.amount(), 0, currency, now);
+    insertEntry(tenantId, transactionId, "PAYOUT_CLEARING", null,
+        0, balance.amount(), currency, now);
+  }
+
+  private void insertEntry(
+      UUID tenantId, UUID transactionId, String accountType, UUID accountId,
+      long debit, long credit, String currency, Instant now) {
+    jdbc.sql("""
+            INSERT INTO ledger_entries
+              (id, tenant_id, transaction_id, account_type, account_id,
+               debit_minor, credit_minor, currency, created_at)
+            VALUES (:id, :tenantId, :transactionId, :accountType, :accountId,
+                    :debit, :credit, :currency, :now)
+            """)
+        .param("id", UUID.randomUUID()).param("tenantId", tenantId)
+        .param("transactionId", transactionId).param("accountType", accountType)
+        .param("accountId", accountId).param("debit", debit).param("credit", credit)
+        .param("currency", currency).param("now", Timestamp.from(now)).update();
+  }
+
+  private PaymentAccount mapAccount(ResultSet rs, int row) throws SQLException {
+    return new PaymentAccount(rs.getObject("id", UUID.class), rs.getObject("tenant_id", UUID.class),
+        rs.getString("provider"), rs.getString("config_reference"),
+        rs.getString("webhook_secret_reference"), rs.getBoolean("active"));
+  }
+
+  private Payment mapPayment(ResultSet rs, int row) throws SQLException {
+    return new Payment(rs.getObject("id", UUID.class), rs.getObject("ride_id", UUID.class),
+        rs.getObject("rider_account_id", UUID.class), rs.getLong("amount_minor"),
+        rs.getLong("authorized_minor"), rs.getLong("captured_minor"), rs.getString("currency"),
+        PaymentState.valueOf(rs.getString("state")), rs.getString("provider_payment_id"),
+        rs.getLong("provider_version"), rs.getLong("version"), rs.getString("failure_code"),
+        rs.getTimestamp("created_at").toInstant(), rs.getTimestamp("updated_at").toInstant());
+  }
+
+  private Refund mapRefund(ResultSet rs, int row) throws SQLException {
+    return new Refund(rs.getObject("id", UUID.class), rs.getObject("payment_id", UUID.class),
+        rs.getLong("amount_minor"), rs.getString("currency"), rs.getString("reason"),
+        RefundState.valueOf(rs.getString("state")), rs.getString("provider_refund_id"),
+        rs.getLong("provider_version"), rs.getLong("version"),
+        rs.getTimestamp("created_at").toInstant(), rs.getTimestamp("updated_at").toInstant());
+  }
+
+  private record LedgerSource(long amount, String currency, UUID accountId) {}
+
+  private record Balance(UUID driverId, long amount) {}
+}

--- a/src/main/java/in/rsh/cab/payment/internal/persistence/PaymentRepository.java
+++ b/src/main/java/in/rsh/cab/payment/internal/persistence/PaymentRepository.java
@@ -1,0 +1,68 @@
+package in.rsh.cab.payment.internal.persistence;
+
+import in.rsh.cab.payment.DriverEarning;
+import in.rsh.cab.payment.Payment;
+import in.rsh.cab.payment.PaymentAccount;
+import in.rsh.cab.payment.ProviderEvent;
+import in.rsh.cab.payment.Refund;
+import in.rsh.cab.payment.SettlementBatch;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentRepository {
+
+  PaymentAccount activeAccount(
+      UUID tenantId, String provider, String configReference, String secretReference, Instant now);
+
+  Optional<PaymentAccount> findAccount(UUID accountId);
+
+  Optional<PaymentAccount> findAccountForPayment(UUID tenantId, UUID paymentId);
+
+  void insertCaptureRequest(UUID tenantId, UUID accountId, Payment payment, UUID attemptId);
+
+  Optional<Payment> findOwn(UUID tenantId, UUID riderAccountId, UUID paymentId);
+
+  Optional<Payment> findByRide(UUID tenantId, UUID riderAccountId, UUID rideId);
+
+  Optional<Payment> find(UUID tenantId, UUID paymentId);
+
+  boolean markCaptureProcessing(UUID tenantId, UUID paymentId);
+
+  void markCaptureSubmitted(UUID tenantId, UUID paymentId, String providerPaymentId,
+      String providerRequestId);
+
+  void markCaptureSubmissionFailed(UUID tenantId, UUID paymentId, String failureCode, Instant now);
+
+  void insertRefund(UUID tenantId, Refund refund, UUID requesterId);
+
+  Optional<Refund> findRefund(UUID tenantId, UUID refundId);
+
+  long committedRefundMinor(UUID tenantId, UUID paymentId);
+
+  boolean markRefundProcessing(UUID tenantId, UUID refundId);
+
+  void markRefundSubmitted(UUID tenantId, UUID refundId, String providerRefundId, Instant now);
+
+  boolean insertProviderEvent(
+      UUID id, PaymentAccount account, ProviderEvent event, Instant receivedAt);
+
+  boolean applyCaptureEvent(
+      PaymentAccount account, ProviderEvent event, Instant now, boolean succeeded);
+
+  boolean applyRefundEvent(
+      PaymentAccount account, ProviderEvent event, Instant now, boolean succeeded);
+
+  void markProviderEvent(UUID accountId, String eventId, boolean applied, Instant now);
+
+  void postCaptureLedger(UUID tenantId, UUID paymentId, int commissionBasisPoints, Instant now);
+
+  void postRefundLedger(UUID tenantId, UUID refundId, int commissionBasisPoints, Instant now);
+
+  List<DriverEarning> earnings(UUID tenantId, UUID driverId);
+
+  SettlementBatch createSettlement(UUID tenantId, UUID actorId, String currency, Instant now);
+
+  List<SettlementBatch> settlements(UUID tenantId);
+}

--- a/src/main/java/in/rsh/cab/payment/internal/web/PaymentController.java
+++ b/src/main/java/in/rsh/cab/payment/internal/web/PaymentController.java
@@ -1,0 +1,94 @@
+package in.rsh.cab.payment.internal.web;
+
+import in.rsh.cab.payment.DriverEarning;
+import in.rsh.cab.payment.Payment;
+import in.rsh.cab.payment.PaymentService;
+import in.rsh.cab.payment.ProviderCallbackService;
+import in.rsh.cab.payment.Refund;
+import in.rsh.cab.payment.SettlementBatch;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PaymentController {
+
+  private final PaymentService payments;
+  private final ProviderCallbackService callbacks;
+
+  public PaymentController(PaymentService payments, ProviderCallbackService callbacks) {
+    this.payments = payments;
+    this.callbacks = callbacks;
+  }
+
+  @GetMapping("/api/v1/payments/{id}")
+  public Payment get(@PathVariable UUID id) {
+    return payments.getOwn(id);
+  }
+
+  @GetMapping("/api/v1/rides/{rideId}/payment")
+  public Payment getByRide(@PathVariable UUID rideId) {
+    return payments.getOwnByRide(rideId);
+  }
+
+  @PostMapping("/api/v1/finance/payments/{paymentId}/refunds")
+  public ResponseEntity<Refund> refund(
+      @PathVariable UUID paymentId, @Valid @RequestBody RefundRequest request) {
+    Refund refund = payments.refund(paymentId, request.amountMinor(), request.reason());
+    return ResponseEntity.created(URI.create("/api/v1/payments/" + paymentId + "/refunds/"
+        + refund.id())).body(refund);
+  }
+
+  @GetMapping("/api/v1/finance/refunds/{refundId}")
+  public Refund refund(@PathVariable UUID refundId) {
+    return payments.getRefund(refundId);
+  }
+
+  @GetMapping("/api/v1/driver/earnings")
+  public List<DriverEarning> earnings() {
+    return payments.ownEarnings();
+  }
+
+  @PostMapping("/api/v1/finance/settlements")
+  public ResponseEntity<SettlementBatch> settle(
+      @Valid @RequestBody SettlementRequest request) {
+    SettlementBatch batch = payments.settle(request.currency());
+    return ResponseEntity.created(URI.create("/api/v1/finance/settlements/" + batch.id()))
+        .body(batch);
+  }
+
+  @GetMapping("/api/v1/finance/settlements")
+  public List<SettlementBatch> settlements() {
+    return payments.settlements();
+  }
+
+  @PostMapping("/api/v1/payment-providers/{provider}/accounts/{accountId}/events")
+  public ProviderCallbackService.Result callback(
+      @PathVariable String provider,
+      @PathVariable UUID accountId,
+      @RequestHeader("X-Provider-Timestamp") long timestamp,
+      @RequestHeader("X-Provider-Signature") String signature,
+      @RequestBody String rawBody) {
+    return callbacks.process(accountId, provider, Instant.ofEpochSecond(timestamp), signature, rawBody);
+  }
+
+  public record RefundRequest(
+      @Positive long amountMinor, @NotBlank @Size(max = 500) String reason) {}
+
+  public record SettlementRequest(
+      @NotBlank @Pattern(regexp = "^[A-Z]{3}$") String currency) {}
+}

--- a/src/main/java/in/rsh/cab/ride/RideService.java
+++ b/src/main/java/in/rsh/cab/ride/RideService.java
@@ -9,6 +9,7 @@ import in.rsh.cab.fleet.internal.persistence.FleetRepository;
 import in.rsh.cab.operations.IdempotencyReservation;
 import in.rsh.cab.operations.IdempotencyService;
 import in.rsh.cab.operations.OutboxService;
+import in.rsh.cab.payment.PaymentService;
 import in.rsh.cab.pricing.FareQuote;
 import in.rsh.cab.pricing.internal.persistence.PricingRepository;
 import in.rsh.cab.ride.internal.persistence.RideRepository;
@@ -39,12 +40,13 @@ public class RideService {
   private final IdempotencyService idempotency;
   private final OutboxService outbox;
   private final AuditService audit;
+  private final PaymentService payments;
   private final ObjectMapper json;
   private final Clock clock;
 
   public RideService(
       RideRepository rides, PricingRepository pricing, DispatchRepository dispatch, FleetRepository fleet,
-      IdempotencyService idempotency, OutboxService outbox, AuditService audit,
+      IdempotencyService idempotency, OutboxService outbox, AuditService audit, PaymentService payments,
       ObjectMapper json, Clock clock) {
     this.rides = rides;
     this.pricing = pricing;
@@ -53,6 +55,7 @@ public class RideService {
     this.idempotency = idempotency;
     this.outbox = outbox;
     this.audit = audit;
+    this.payments = payments;
     this.json = json;
     this.clock = clock;
   }
@@ -167,6 +170,9 @@ public class RideService {
     rides.appendHistory(context.tenantId(), next.id(), current.status(), next.status(),
         context.accountId(), reason, next.updatedAt());
     emit(context, next, event, event.replace('.', '_'));
+    if (next.status() == RideStatus.COMPLETED) {
+      payments.requestCapture(context.tenantId(), next);
+    }
     return next;
   }
 

--- a/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
+++ b/src/main/java/in/rsh/cab/security/SecurityConfiguration.java
@@ -25,6 +25,8 @@ public class SecurityConfiguration {
                     .authenticated()
                     .requestMatchers(HttpMethod.POST, "/api/v1/tenants")
                     .hasAuthority("SCOPE_platform.admin")
+                    .requestMatchers("/api/v1/payment-providers/*/accounts/*/events")
+                    .permitAll()
                     .requestMatchers(
                         "/api/v1/current-tenant",
                         "/api/v1/service-areas/**",

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/TenantWebConfiguration.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/TenantWebConfiguration.java
@@ -18,6 +18,6 @@ public class TenantWebConfiguration implements WebMvcConfigurer {
     registry
         .addInterceptor(tenantSelectionInterceptor)
         .addPathPatterns("/api/v1/**")
-        .excludePathPatterns("/api/v1/tenants");
+        .excludePathPatterns("/api/v1/tenants", "/api/v1/payment-providers/**");
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,10 @@ dispatch.candidate-limit=${DISPATCH_CANDIDATE_LIMIT:10}
 dispatch.location-max-age=${DISPATCH_LOCATION_MAX_AGE:PT2M}
 dispatch.location-future-tolerance=${DISPATCH_LOCATION_FUTURE_TOLERANCE:PT30S}
 dispatch.offer-ttl=${DISPATCH_OFFER_TTL:PT30S}
+
+payments.provider=${PAYMENT_PROVIDER:fake}
+payments.fake.config-reference=${FAKE_PAYMENT_CONFIG_REFERENCE:env:FAKE_PAYMENT_ACCOUNT}
+payments.fake.webhook-secret-reference=${FAKE_PAYMENT_WEBHOOK_SECRET_REFERENCE:env:FAKE_PAYMENT_WEBHOOK_SECRET}
+payments.fake.webhook-secret=${FAKE_PAYMENT_WEBHOOK_SECRET:local-development-only}
+payments.webhook-tolerance=${PAYMENT_WEBHOOK_TOLERANCE:PT5M}
+payments.platform-commission-basis-points=${PAYMENTS_PLATFORM_COMMISSION_BASIS_POINTS:1500}

--- a/src/main/resources/db/migration/V8__payments_ledger_and_settlements.sql
+++ b/src/main/resources/db/migration/V8__payments_ledger_and_settlements.sql
@@ -1,0 +1,276 @@
+CREATE TABLE payment_accounts (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    provider varchar(64) NOT NULL,
+    config_reference varchar(255) NOT NULL,
+    webhook_secret_reference varchar(255) NOT NULL,
+    active boolean NOT NULL DEFAULT true,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_payment_account_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_payment_account_provider UNIQUE (tenant_id, provider),
+    CONSTRAINT chk_payment_account_references CHECK (
+        config_reference ~ '^(env|vault|aws-sm|gcp-sm):[A-Za-z0-9_./-]+$'
+        AND webhook_secret_reference ~ '^(env|vault|aws-sm|gcp-sm):[A-Za-z0-9_./-]+$')
+);
+
+CREATE TABLE payments (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    payment_account_id uuid NOT NULL,
+    ride_id uuid NOT NULL,
+    rider_account_id uuid NOT NULL,
+    amount_minor bigint NOT NULL,
+    authorized_minor bigint NOT NULL DEFAULT 0,
+    captured_minor bigint NOT NULL DEFAULT 0,
+    currency varchar(3) NOT NULL,
+    state varchar(32) NOT NULL,
+    payment_method_token varchar(255),
+    provider_payment_id varchar(255),
+    provider_version bigint NOT NULL DEFAULT 0,
+    version bigint NOT NULL DEFAULT 0,
+    failure_code varchar(120),
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_payment_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_payment_ride UNIQUE (tenant_id, ride_id),
+    CONSTRAINT uq_payment_provider_id UNIQUE (payment_account_id, provider_payment_id),
+    CONSTRAINT fk_payment_account FOREIGN KEY (tenant_id, payment_account_id)
+        REFERENCES payment_accounts (tenant_id, id),
+    CONSTRAINT fk_payment_ride FOREIGN KEY (tenant_id, ride_id) REFERENCES rides (tenant_id, id),
+    CONSTRAINT fk_payment_rider FOREIGN KEY (tenant_id, rider_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_payment_amounts CHECK (
+        amount_minor > 0 AND authorized_minor >= 0 AND captured_minor >= 0
+        AND authorized_minor <= amount_minor AND captured_minor <= authorized_minor),
+    CONSTRAINT chk_payment_state CHECK (state IN (
+        'CREATED', 'AUTHORIZATION_PENDING', 'AUTHORIZED', 'CAPTURE_PENDING',
+        'CAPTURED', 'FAILED', 'VOIDED')),
+    CONSTRAINT chk_payment_token CHECK (
+        payment_method_token IS NULL OR payment_method_token ~ '^[A-Za-z0-9_.:-]{1,255}$')
+);
+
+CREATE TABLE payment_attempts (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    payment_id uuid NOT NULL,
+    operation varchar(32) NOT NULL,
+    idempotency_key varchar(255) NOT NULL,
+    state varchar(32) NOT NULL,
+    provider_request_id varchar(255),
+    failure_code varchar(120),
+    created_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    CONSTRAINT uq_payment_attempt_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_payment_attempt_operation UNIQUE (tenant_id, payment_id, operation, idempotency_key),
+    CONSTRAINT fk_payment_attempt_payment FOREIGN KEY (tenant_id, payment_id)
+        REFERENCES payments (tenant_id, id),
+    CONSTRAINT chk_payment_attempt_operation CHECK (operation IN ('AUTHORIZE', 'CAPTURE', 'VOID')),
+    CONSTRAINT chk_payment_attempt_state CHECK (state IN ('PENDING', 'PROCESSING', 'SUCCEEDED', 'FAILED'))
+);
+
+CREATE TABLE refunds (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    payment_id uuid NOT NULL,
+    amount_minor bigint NOT NULL,
+    currency varchar(3) NOT NULL,
+    reason varchar(500) NOT NULL,
+    state varchar(32) NOT NULL,
+    provider_refund_id varchar(255),
+    provider_version bigint NOT NULL DEFAULT 0,
+    version bigint NOT NULL DEFAULT 0,
+    failure_code varchar(120),
+    requested_by_account_id uuid NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_refund_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_refund_provider_id UNIQUE (payment_id, provider_refund_id),
+    CONSTRAINT fk_refund_payment FOREIGN KEY (tenant_id, payment_id)
+        REFERENCES payments (tenant_id, id),
+    CONSTRAINT fk_refund_requester FOREIGN KEY (tenant_id, requested_by_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_refund_amount CHECK (amount_minor > 0),
+    CONSTRAINT chk_refund_reason CHECK (length(trim(reason)) BETWEEN 1 AND 500),
+    CONSTRAINT chk_refund_state CHECK (state IN ('REQUESTED', 'PENDING', 'SUCCEEDED', 'FAILED'))
+);
+
+CREATE TABLE provider_events (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    payment_account_id uuid NOT NULL,
+    provider_event_id varchar(255) NOT NULL,
+    event_type varchar(64) NOT NULL,
+    provider_object_id varchar(255) NOT NULL,
+    provider_version bigint NOT NULL,
+    amount_minor bigint,
+    currency varchar(3),
+    status varchar(32) NOT NULL,
+    received_at timestamptz NOT NULL,
+    processed_at timestamptz,
+    CONSTRAINT uq_provider_event_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_provider_event UNIQUE (payment_account_id, provider_event_id),
+    CONSTRAINT fk_provider_event_account FOREIGN KEY (tenant_id, payment_account_id)
+        REFERENCES payment_accounts (tenant_id, id),
+    CONSTRAINT chk_provider_event_version CHECK (provider_version >= 0),
+    CONSTRAINT chk_provider_event_amount CHECK (amount_minor IS NULL OR amount_minor > 0),
+    CONSTRAINT chk_provider_event_status CHECK (status IN ('RECEIVED', 'APPLIED', 'IGNORED'))
+);
+
+CREATE TABLE ledger_transactions (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    source_type varchar(64) NOT NULL,
+    source_id uuid NOT NULL,
+    description varchar(255) NOT NULL,
+    created_at timestamptz NOT NULL,
+    CONSTRAINT uq_ledger_transaction_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_ledger_source UNIQUE (tenant_id, source_type, source_id)
+);
+
+CREATE TABLE ledger_entries (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    transaction_id uuid NOT NULL,
+    account_type varchar(64) NOT NULL,
+    account_id uuid,
+    debit_minor bigint NOT NULL DEFAULT 0,
+    credit_minor bigint NOT NULL DEFAULT 0,
+    currency varchar(3) NOT NULL,
+    created_at timestamptz NOT NULL,
+    CONSTRAINT uq_ledger_entry_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_ledger_entry_transaction FOREIGN KEY (tenant_id, transaction_id)
+        REFERENCES ledger_transactions (tenant_id, id),
+    CONSTRAINT chk_ledger_side CHECK (
+        (debit_minor > 0 AND credit_minor = 0) OR (credit_minor > 0 AND debit_minor = 0)),
+    CONSTRAINT chk_ledger_account_type CHECK (account_type IN (
+        'PROVIDER_RECEIVABLE', 'DRIVER_PAYABLE', 'PLATFORM_REVENUE', 'PAYOUT_CLEARING'))
+);
+
+CREATE TABLE settlement_batches (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    currency varchar(3) NOT NULL,
+    state varchar(32) NOT NULL,
+    total_minor bigint NOT NULL,
+    created_by_account_id uuid NOT NULL,
+    created_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    CONSTRAINT uq_settlement_batch_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_settlement_creator FOREIGN KEY (tenant_id, created_by_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_settlement_total CHECK (total_minor >= 0),
+    CONSTRAINT chk_settlement_state CHECK (state IN ('CREATED', 'PROCESSING', 'COMPLETED', 'FAILED'))
+);
+
+CREATE TABLE payouts (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    settlement_batch_id uuid NOT NULL,
+    driver_id uuid NOT NULL,
+    amount_minor bigint NOT NULL,
+    currency varchar(3) NOT NULL,
+    state varchar(32) NOT NULL,
+    provider_payout_id varchar(255),
+    version bigint NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT uq_payout_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT uq_payout_batch_driver UNIQUE (tenant_id, settlement_batch_id, driver_id),
+    CONSTRAINT fk_payout_batch FOREIGN KEY (tenant_id, settlement_batch_id)
+        REFERENCES settlement_batches (tenant_id, id),
+    CONSTRAINT fk_payout_driver FOREIGN KEY (tenant_id, driver_id)
+        REFERENCES driver_profiles (tenant_id, id),
+    CONSTRAINT chk_payout_amount CHECK (amount_minor > 0),
+    CONSTRAINT chk_payout_state CHECK (state IN ('PENDING', 'PAID', 'FAILED'))
+);
+
+CREATE INDEX idx_payments_rider ON payments (tenant_id, rider_account_id, created_at DESC);
+CREATE INDEX idx_payment_attempt_pending ON payment_attempts (tenant_id, state, created_at);
+CREATE INDEX idx_refunds_payment ON refunds (tenant_id, payment_id, created_at);
+CREATE INDEX idx_provider_events_object ON provider_events (payment_account_id, provider_object_id, provider_version);
+CREATE INDEX idx_ledger_account ON ledger_entries (tenant_id, account_type, account_id, currency);
+CREATE INDEX idx_payout_driver ON payouts (tenant_id, driver_id, created_at DESC);
+
+CREATE FUNCTION reject_payment_identity_mutation() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       OR NEW.ride_id IS DISTINCT FROM OLD.ride_id
+       OR NEW.rider_account_id IS DISTINCT FROM OLD.rider_account_id
+       OR NEW.amount_minor IS DISTINCT FROM OLD.amount_minor
+       OR NEW.currency IS DISTINCT FROM OLD.currency THEN
+        RAISE EXCEPTION 'payment tenant, ride, rider, amount, and currency are immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER payment_identity_immutable BEFORE UPDATE ON payments
+FOR EACH ROW EXECUTE FUNCTION reject_payment_identity_mutation();
+
+CREATE FUNCTION enforce_successful_refund_limit() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE captured bigint;
+DECLARE refunded bigint;
+BEGIN
+    IF NEW.state = 'SUCCEEDED' THEN
+        SELECT captured_minor INTO captured FROM payments
+        WHERE tenant_id = NEW.tenant_id AND id = NEW.payment_id FOR UPDATE;
+        SELECT COALESCE(sum(amount_minor), 0) INTO refunded FROM refunds
+        WHERE tenant_id = NEW.tenant_id AND payment_id = NEW.payment_id
+          AND state IN ('REQUESTED', 'PENDING', 'SUCCEEDED') AND id <> NEW.id;
+        IF refunded + NEW.amount_minor > captured THEN
+            RAISE EXCEPTION 'successful refunds exceed captured amount';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER refund_limit BEFORE INSERT OR UPDATE ON refunds
+FOR EACH ROW EXECUTE FUNCTION enforce_successful_refund_limit();
+
+CREATE FUNCTION enforce_refund_reservation_limit() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE captured bigint;
+DECLARE reserved bigint;
+BEGIN
+    SELECT captured_minor INTO captured FROM payments
+    WHERE tenant_id = NEW.tenant_id AND id = NEW.payment_id FOR UPDATE;
+    SELECT COALESCE(sum(amount_minor), 0) INTO reserved FROM refunds
+    WHERE tenant_id = NEW.tenant_id AND payment_id = NEW.payment_id
+      AND state IN ('REQUESTED', 'PENDING', 'SUCCEEDED');
+    IF reserved + NEW.amount_minor > captured THEN
+        RAISE EXCEPTION 'refund reservations exceed captured amount';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER refund_reservation_limit BEFORE INSERT ON refunds
+FOR EACH ROW EXECUTE FUNCTION enforce_refund_reservation_limit();
+
+CREATE FUNCTION reject_financial_record_mutation() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION '% is append-only', TG_TABLE_NAME;
+END;
+$$;
+CREATE TRIGGER ledger_transactions_immutable BEFORE UPDATE OR DELETE ON ledger_transactions
+FOR EACH ROW EXECUTE FUNCTION reject_financial_record_mutation();
+CREATE TRIGGER ledger_entries_immutable BEFORE UPDATE OR DELETE ON ledger_entries
+FOR EACH ROW EXECUTE FUNCTION reject_financial_record_mutation();
+CREATE TRIGGER provider_events_immutable_delete BEFORE DELETE ON provider_events
+FOR EACH ROW EXECUTE FUNCTION reject_financial_record_mutation();
+
+CREATE FUNCTION enforce_balanced_ledger_transaction() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE debit_total bigint;
+DECLARE credit_total bigint;
+DECLARE currency_count integer;
+BEGIN
+    SELECT COALESCE(sum(debit_minor), 0), COALESCE(sum(credit_minor), 0), count(DISTINCT currency)
+      INTO debit_total, credit_total, currency_count
+    FROM ledger_entries WHERE tenant_id = NEW.tenant_id AND transaction_id = NEW.transaction_id;
+    IF debit_total = 0 OR debit_total <> credit_total OR currency_count <> 1 THEN
+        RAISE EXCEPTION 'ledger transaction must be non-zero, single-currency, and balanced';
+    END IF;
+    RETURN NULL;
+END;
+$$;
+CREATE CONSTRAINT TRIGGER ledger_transaction_balanced
+AFTER INSERT ON ledger_entries DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_balanced_ledger_transaction();

--- a/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/controller/MarketplaceHttpIT.java
@@ -12,6 +12,10 @@ import com.sun.net.httpserver.HttpServer;
 import in.rsh.cab.operations.InboxService;
 import in.rsh.cab.operations.OutboxEvent;
 import in.rsh.cab.operations.OutboxPoller;
+import in.rsh.cab.payment.FakePaymentProvider;
+import in.rsh.cab.payment.PaymentAccount;
+import in.rsh.cab.payment.PaymentOperationWorker;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -74,6 +78,9 @@ class MarketplaceHttpIT {
   @Autowired private JdbcClient jdbc;
   @Autowired private OutboxPoller outboxPoller;
   @Autowired private InboxService inbox;
+  @Autowired private PaymentOperationWorker paymentWorker;
+  @Autowired private PaymentRepository paymentRepository;
+  @Autowired private FakePaymentProvider fakePaymentProvider;
 
   @DynamicPropertySource
   static void databaseProperties(DynamicPropertyRegistry registry) {
@@ -370,6 +377,65 @@ class MarketplaceHttpIT {
     assertEquals("COMPLETED", completed.get("status").getAsString());
     assertEquals(409, postWithTenant(
         "/api/v1/driver/rides/" + rideId + "/complete", tenantId, "{\"version\":5}").statusCode());
+
+    HttpResponse<String> pendingPaymentResponse = getWithTenant(
+        "/api/v1/rides/" + rideId + "/payment", tenantId, "platform-admin");
+    assertEquals(200, pendingPaymentResponse.statusCode(), pendingPaymentResponse.body());
+    JsonObject pendingPayment = JsonParser.parseString(pendingPaymentResponse.body()).getAsJsonObject();
+    String paymentId = pendingPayment.get("id").getAsString();
+    assertEquals("CAPTURE_PENDING", pendingPayment.get("state").getAsString());
+    assertEquals(809, pendingPayment.get("amountMinor").getAsLong());
+
+    List<OutboxEvent> paymentEvents = outboxPoller.lease(tenantUuid, 100, Duration.ofSeconds(30));
+    OutboxEvent captureRequest = paymentEvents.stream()
+        .filter(event -> event.eventType().equals("payment.capture_requested"))
+        .findFirst().orElseThrow();
+    assertTrue(paymentWorker.process(captureRequest));
+    paymentEvents.forEach(event -> outboxPoller.published(tenantUuid, event.id()));
+
+    PaymentAccount paymentAccount = paymentRepository.findAccountForPayment(
+        tenantUuid, UUID.fromString(paymentId)).orElseThrow();
+    Instant captureTimestamp = Instant.now();
+    String captureBody = "{\"eventId\":\"capture-event-1\",\"type\":\"CAPTURE_SUCCEEDED\","
+        + "\"paymentId\":\"" + paymentId + "\",\"refundId\":null,"
+        + "\"providerObjectId\":\"fake-pay-" + paymentId + "\",\"providerVersion\":1,"
+        + "\"amountMinor\":809,\"currency\":\"USD\",\"failureCode\":null}";
+    HttpResponse<String> captureCallback = providerCallback(
+        paymentAccount.id(), captureTimestamp, captureBody);
+    assertEquals(200, captureCallback.statusCode(), captureCallback.body());
+    assertTrue(JsonParser.parseString(captureCallback.body()).getAsJsonObject().get("applied").getAsBoolean());
+    assertEquals("CAPTURED", JsonParser.parseString(getWithTenant(
+        "/api/v1/payments/" + paymentId, tenantId, "platform-admin").body())
+        .getAsJsonObject().get("state").getAsString());
+    assertEquals(688, JsonParser.parseString(getWithTenant(
+        "/api/v1/driver/earnings", tenantId, "platform-admin").body())
+        .getAsJsonArray().get(0).getAsJsonObject().get("availableMinor").getAsLong());
+
+    HttpResponse<String> refundResponse = postWithTenant(
+        "/api/v1/finance/payments/" + paymentId + "/refunds", tenantId,
+        "{\"amountMinor\":200,\"reason\":\"service adjustment\"}");
+    assertEquals(201, refundResponse.statusCode(), refundResponse.body());
+    String refundId = JsonParser.parseString(refundResponse.body()).getAsJsonObject()
+        .get("id").getAsString();
+    List<OutboxEvent> refundEvents = outboxPoller.lease(tenantUuid, 100, Duration.ofSeconds(30));
+    OutboxEvent refundRequest = refundEvents.stream()
+        .filter(event -> event.eventType().equals("payment.refund_requested"))
+        .findFirst().orElseThrow();
+    assertTrue(paymentWorker.process(refundRequest));
+    refundEvents.forEach(event -> outboxPoller.published(tenantUuid, event.id()));
+
+    Instant refundTimestamp = Instant.now();
+    String refundBody = "{\"eventId\":\"refund-event-1\",\"type\":\"REFUND_SUCCEEDED\","
+        + "\"paymentId\":\"" + paymentId + "\",\"refundId\":\"" + refundId + "\","
+        + "\"providerObjectId\":\"fake-refund-" + refundId + "\",\"providerVersion\":1,"
+        + "\"amountMinor\":200,\"currency\":\"USD\",\"failureCode\":null}";
+    assertEquals(200, providerCallback(paymentAccount.id(), refundTimestamp, refundBody).statusCode());
+    JsonObject refunded = JsonParser.parseString(getWithTenant(
+        "/api/v1/finance/refunds/" + refundId, tenantId, "platform-admin").body()).getAsJsonObject();
+    assertEquals("SUCCEEDED", refunded.get("state").getAsString());
+    assertEquals(518, JsonParser.parseString(getWithTenant(
+        "/api/v1/driver/earnings", tenantId, "platform-admin").body())
+        .getAsJsonArray().get(0).getAsJsonObject().get("availableMinor").getAsLong());
   }
 
   private JsonObject driverRideAction(String tenantId, String rideId, String action, long version)
@@ -442,6 +508,19 @@ class MarketplaceHttpIT {
     }
     HttpRequest request =
         builder.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpResponse<String> providerCallback(
+      UUID accountId, Instant timestamp, String body) throws Exception {
+    HttpRequest request = HttpRequest.newBuilder(uri(
+            "/api/v1/payment-providers/fake/accounts/" + accountId + "/events"))
+        .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+        .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+        .header("X-Provider-Timestamp", Long.toString(timestamp.getEpochSecond()))
+        .header("X-Provider-Signature", fakePaymentProvider.sign(timestamp, body))
+        .POST(HttpRequest.BodyPublishers.ofString(body))
+        .build();
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 

--- a/src/test/java/in/rsh/cab/payment/FakePaymentProviderTest.java
+++ b/src/test/java/in/rsh/cab/payment/FakePaymentProviderTest.java
@@ -1,0 +1,29 @@
+package in.rsh.cab.payment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class FakePaymentProviderTest {
+
+  @Test
+  void signsAndVerifiesExactTimestampAndBody() {
+    FakePaymentProvider provider = new FakePaymentProvider("env:SECRET", "test-secret");
+    PaymentAccount account = new PaymentAccount(UUID.randomUUID(), UUID.randomUUID(), "fake",
+        "env:ACCOUNT", "env:SECRET", true);
+    Instant timestamp = Instant.parse("2026-08-08T10:00:00Z");
+    String body = "{\"eventId\":\"evt-1\"}";
+
+    String signature = provider.sign(timestamp, body);
+
+    assertTrue(provider.verifies(account, timestamp, body, signature));
+    assertFalse(provider.verifies(account, timestamp.plusSeconds(1), body, signature));
+    assertFalse(provider.verifies(account, timestamp, body + " ", signature));
+    assertFalse(provider.verifies(account, timestamp, body, "invalid"));
+    assertFalse(provider.verifies(new PaymentAccount(account.id(), account.tenantId(), "fake",
+        account.configReference(), "env:OTHER", true), timestamp, body, signature));
+  }
+}

--- a/src/test/java/in/rsh/cab/payment/PaymentOperationWorkerTest.java
+++ b/src/test/java/in/rsh/cab/payment/PaymentOperationWorkerTest.java
@@ -1,0 +1,104 @@
+package in.rsh.cab.payment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.operations.OutboxEvent;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.databind.ObjectMapper;
+
+class PaymentOperationWorkerTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
+  private final PaymentRepository repository = mock(PaymentRepository.class);
+  private final PaymentProvider provider = mock(PaymentProvider.class);
+  private PaymentOperationWorker worker;
+
+  @BeforeEach
+  void setUp() {
+    when(provider.name()).thenReturn("fake");
+    worker = new PaymentOperationWorker(repository, List.of(provider),
+        new TransactionTemplate(new TestTransactionManager()),
+        Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
+  @Test
+  void submitsCaptureAfterClaimingDurableAttempt() {
+    Payment payment = payment();
+    PaymentAccount account = account();
+    when(repository.find(TENANT, payment.id())).thenReturn(Optional.of(payment));
+    when(repository.markCaptureProcessing(TENANT, payment.id())).thenReturn(true);
+    when(repository.findAccountForPayment(TENANT, payment.id())).thenReturn(Optional.of(account));
+    when(provider.capture(any(), any(), any(Long.class), any(), any()))
+        .thenReturn(new PaymentProvider.Submission("provider-pay", "provider-request"));
+
+    assertTrue(worker.process(event("payment.capture_requested", payment.id())));
+    verify(repository).markCaptureSubmitted(
+        TENANT, payment.id(), "provider-pay", "provider-request");
+    assertFalse(worker.process(event("other", payment.id())));
+  }
+
+  @Test
+  void recordsSafeFailureCodeWhenProviderCallFails() {
+    Payment payment = payment();
+    when(repository.find(TENANT, payment.id())).thenReturn(Optional.of(payment));
+    when(repository.markCaptureProcessing(TENANT, payment.id())).thenReturn(true);
+    when(repository.findAccountForPayment(TENANT, payment.id())).thenReturn(Optional.of(account()));
+    when(provider.capture(any(), any(), any(Long.class), any(), any()))
+        .thenThrow(new IllegalStateException("secret provider detail"));
+
+    assertThrows(IllegalStateException.class,
+        () -> worker.process(event("payment.capture_requested", payment.id())));
+    verify(repository).markCaptureSubmissionFailed(
+        TENANT, payment.id(), "PROVIDER_UNAVAILABLE", NOW);
+  }
+
+  private Payment payment() {
+    return new Payment(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), 100, 100, 0,
+        "USD", PaymentState.CAPTURE_PENDING, null, 0, 0, null, NOW, NOW);
+  }
+
+  private PaymentAccount account() {
+    return new PaymentAccount(UUID.randomUUID(), TENANT, "fake", "env:A", "env:S", true);
+  }
+
+  private OutboxEvent event(String type, UUID id) {
+    return new OutboxEvent(UUID.randomUUID(), TENANT, "payment", id, 0, type, 1,
+        new ObjectMapper().createObjectNode(), NOW, null, null, 1);
+  }
+
+  private static final class TestTransactionManager extends AbstractPlatformTransactionManager {
+
+    @Override
+    protected Object doGetTransaction() {
+      return new Object();
+    }
+
+    @Override
+    protected void doBegin(Object transaction, TransactionDefinition definition) {}
+
+    @Override
+    protected void doCommit(DefaultTransactionStatus status) {}
+
+    @Override
+    protected void doRollback(DefaultTransactionStatus status) {}
+  }
+}

--- a/src/test/java/in/rsh/cab/payment/PaymentServiceTest.java
+++ b/src/test/java/in/rsh/cab/payment/PaymentServiceTest.java
@@ -1,0 +1,139 @@
+package in.rsh.cab.payment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.audit.AuditService;
+import in.rsh.cab.driver.DriverProfile;
+import in.rsh.cab.driver.DriverStatus;
+import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.geography.GeoPoint;
+import in.rsh.cab.operations.OutboxService;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
+import in.rsh.cab.ride.Ride;
+import in.rsh.cab.ride.RideStatus;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class PaymentServiceTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final UUID ACCOUNT = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
+  private final PaymentRepository repository = mock(PaymentRepository.class);
+  private final DriverProfileRepository drivers = mock(DriverProfileRepository.class);
+  private final OutboxService outbox = mock(OutboxService.class);
+  private final AuditService audit = mock(AuditService.class);
+  private PaymentService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new PaymentService(repository, drivers, outbox, audit, new ObjectMapper(),
+        Clock.fixed(NOW, ZoneOffset.UTC), "fake", "env:A", "env:S");
+    context(TenantRole.RIDER);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void completionCreatesCaptureRequestAndRiderCanReadIt() {
+    Ride ride = ride();
+    PaymentAccount account = new PaymentAccount(
+        UUID.randomUUID(), TENANT, "fake", "env:A", "env:S", true);
+    Payment payment = payment(PaymentState.CAPTURE_PENDING);
+    when(repository.activeAccount(TENANT, "fake", "env:A", "env:S", NOW)).thenReturn(account);
+    when(repository.findByRide(TENANT, ride.riderAccountId(), ride.id()))
+        .thenReturn(Optional.of(payment));
+
+    service.requestCapture(TENANT, ride);
+    assertEquals(payment, service.getOwnByRide(ride.id()));
+    verify(repository).insertCaptureRequest(eq(TENANT), eq(account.id()), any(), any());
+
+    when(repository.findOwn(TENANT, ACCOUNT, payment.id())).thenReturn(Optional.of(payment));
+    assertEquals(payment, service.getOwn(payment.id()));
+    assertThrows(NotFoundException.class, () -> service.getOwn(UUID.randomUUID()));
+  }
+
+  @Test
+  void financeRefundEnforcesCaptureAndRemainingAmount() {
+    context(TenantRole.FINANCE);
+    Payment payment = payment(PaymentState.CAPTURED);
+    when(repository.find(TENANT, payment.id())).thenReturn(Optional.of(payment));
+    when(repository.committedRefundMinor(TENANT, payment.id())).thenReturn(40L);
+
+    Refund refund = service.refund(payment.id(), 60, "adjustment");
+    assertEquals(RefundState.PENDING, refund.state());
+    verify(repository).insertRefund(TENANT, refund, ACCOUNT);
+    when(repository.findRefund(TENANT, refund.id())).thenReturn(Optional.of(refund));
+    assertEquals(refund, service.getRefund(refund.id()));
+    assertThrows(ConflictException.class, () -> service.refund(payment.id(), 61, "too much"));
+
+    Payment pending = payment(PaymentState.CAPTURE_PENDING);
+    when(repository.find(TENANT, pending.id())).thenReturn(Optional.of(pending));
+    assertThrows(ConflictException.class, () -> service.refund(pending.id(), 1, "early"));
+    assertThrows(NotFoundException.class, () -> service.refund(UUID.randomUUID(), 1, "missing"));
+  }
+
+  @Test
+  void driverReadsOwnEarningsAndFinanceCreatesSettlement() {
+    context(TenantRole.DRIVER);
+    UUID driverId = UUID.randomUUID();
+    when(drivers.findByTenantIdAndAccountId(TENANT, ACCOUNT)).thenReturn(Optional.of(
+        new DriverProfile(driverId, ACCOUNT, "Driver", null, DriverStatus.APPROVED, NOW, NOW)));
+    when(repository.earnings(TENANT, driverId)).thenReturn(List.of(new DriverEarning("USD", 100)));
+    assertEquals(100, service.ownEarnings().getFirst().availableMinor());
+
+    context(TenantRole.FINANCE);
+    SettlementBatch batch = new SettlementBatch(
+        UUID.randomUUID(), "USD", "COMPLETED", 100, NOW, List.of());
+    when(repository.createSettlement(TENANT, ACCOUNT, "USD", NOW)).thenReturn(batch);
+    when(repository.settlements(TENANT)).thenReturn(List.of(batch));
+    assertEquals(batch, service.settle("USD"));
+    assertEquals(List.of(batch), service.settlements());
+
+    context(TenantRole.RIDER);
+    assertThrows(TenantAccessDeniedException.class, () -> service.settle("USD"));
+    assertThrows(TenantAccessDeniedException.class, service::settlements);
+  }
+
+  private Payment payment(PaymentState state) {
+    long captured = state == PaymentState.CAPTURED ? 100 : 0;
+    return new Payment(UUID.randomUUID(), UUID.randomUUID(), ACCOUNT, 100, 100, captured,
+        "USD", state, state == PaymentState.CAPTURED ? "provider-pay" : null,
+        1, 1, null, NOW, NOW);
+  }
+
+  private Ride ride() {
+    return new Ride(UUID.randomUUID(), ACCOUNT, UUID.randomUUID(), UUID.randomUUID(),
+        new GeoPoint(12.95, 77.6), new GeoPoint(13, 77.65), 100, "USD",
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), RideStatus.COMPLETED,
+        null, null, NOW.minusSeconds(100), NOW.minusSeconds(90), NOW.minusSeconds(80),
+        NOW.minusSeconds(70), NOW, null, NOW, 6);
+  }
+
+  private void context(TenantRole role) {
+    TenantContext.set(new TenantContext(TENANT, ACCOUNT, UUID.randomUUID(), Set.of(role)));
+  }
+}

--- a/src/test/java/in/rsh/cab/payment/ProviderCallbackServiceTest.java
+++ b/src/test/java/in/rsh/cab/payment/ProviderCallbackServiceTest.java
@@ -1,0 +1,76 @@
+package in.rsh.cab.payment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.operations.OutboxService;
+import in.rsh.cab.payment.internal.persistence.PaymentRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class ProviderCallbackServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
+  private final PaymentRepository repository = mock(PaymentRepository.class);
+  private final PaymentProvider provider = mock(PaymentProvider.class);
+  private final OutboxService outbox = mock(OutboxService.class);
+  private final ObjectMapper json = new ObjectMapper();
+  private final PaymentAccount account = new PaymentAccount(
+      UUID.randomUUID(), UUID.randomUUID(), "fake", "env:A", "env:S", true);
+  private ProviderCallbackService service;
+
+  @BeforeEach
+  void setUp() {
+    when(provider.name()).thenReturn("fake");
+    service = new ProviderCallbackService(repository, List.of(provider), outbox, json,
+        Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofMinutes(5), 1500);
+    when(repository.findAccount(account.id())).thenReturn(Optional.of(account));
+    when(provider.verifies(any(), any(), any(), any())).thenReturn(true);
+  }
+
+  @Test
+  void appliesCaptureOnceAndPostsLedger() throws Exception {
+    UUID paymentId = UUID.randomUUID();
+    String body = json.writeValueAsString(new ProviderEvent("evt-1",
+        ProviderEvent.Type.CAPTURE_SUCCEEDED, paymentId, null, "provider-pay", 1,
+        100L, "USD", null));
+    when(repository.insertProviderEvent(any(), any(), any(), any())).thenReturn(true);
+    when(repository.applyCaptureEvent(any(), any(), any(), any(Boolean.class))).thenReturn(true);
+
+    ProviderCallbackService.Result result = service.process(
+        account.id(), "fake", NOW, "signature", body);
+
+    assertTrue(result.accepted());
+    assertTrue(result.applied());
+    verify(repository).postCaptureLedger(account.tenantId(), paymentId, 1500, NOW);
+  }
+
+  @Test
+  void rejectsReplayTimestampAndDeduplicatesProviderEvent() throws Exception {
+    assertThrows(PaymentSignatureException.class, () -> service.process(
+        account.id(), "fake", NOW.minusSeconds(301), "signature", "{}"));
+    UUID paymentId = UUID.randomUUID();
+    String body = json.writeValueAsString(new ProviderEvent("evt-1",
+        ProviderEvent.Type.CAPTURE_FAILED, paymentId, null, "provider-pay", 1,
+        100L, "USD", "DECLINED"));
+    when(repository.insertProviderEvent(any(), any(), any(), any())).thenReturn(false);
+
+    ProviderCallbackService.Result duplicate = service.process(
+        account.id(), "fake", NOW, "signature", body);
+    assertFalse(duplicate.accepted());
+    assertFalse(duplicate.applied());
+  }
+}

--- a/src/test/java/in/rsh/cab/ride/RideServiceTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideServiceTest.java
@@ -18,6 +18,7 @@ import in.rsh.cab.geography.GeoPoint;
 import in.rsh.cab.operations.IdempotencyReservation;
 import in.rsh.cab.operations.IdempotencyService;
 import in.rsh.cab.operations.OutboxService;
+import in.rsh.cab.payment.PaymentService;
 import in.rsh.cab.pricing.FareQuote;
 import in.rsh.cab.pricing.QuoteStatus;
 import in.rsh.cab.pricing.internal.persistence.PricingRepository;
@@ -48,11 +49,12 @@ class RideServiceTest {
   private final IdempotencyService idempotency = mock(IdempotencyService.class);
   private final OutboxService outbox = mock(OutboxService.class);
   private final AuditService audit = mock(AuditService.class);
+  private final PaymentService payments = mock(PaymentService.class);
   private RideService service;
 
   @BeforeEach
   void setUp() {
-    service = new RideService(rides, pricing, dispatch, fleet, idempotency, outbox, audit,
+    service = new RideService(rides, pricing, dispatch, fleet, idempotency, outbox, audit, payments,
         new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC));
     context(TenantRole.RIDER);
     when(idempotency.reserve(any(), any(), any(), any(), any())).thenReturn(
@@ -108,6 +110,7 @@ class RideServiceTest {
     assertEquals(RideStatus.COMPLETED, completed.status());
     verify(fleet).transitionShift(TENANT, current.driverShiftId(), ShiftStatus.ON_TRIP,
         ShiftStatus.AVAILABLE, NOW);
+    verify(payments).requestCapture(TENANT, completed);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Delivers `feat(payments): add refunds ledger and settlements` as part 9 of 26 in the production marketplace stack.
- Contains 31 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/106`
- Head: `stack/09-payments`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.