### PR TITLE
feat(release): add deployment and secure release automation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.idea
+.settings
+.vscode
+target
+build
+bin
+*.iml
+.classpath
+.project
+.DS_Store
+.env
+deploy
+docs
+README.md
+CONTRIBUTING.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{java,xml,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Local development only. Replace every password before exposing any service.
+COMPOSE_PROJECT_NAME=cab
+APP_PORT=8080
+POSTGRES_DB=cab
+POSTGRES_USER=cab
+POSTGRES_PASSWORD=dev-only-cab-password
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=dev-only-admin-password
+KEYCLOAK_PORT=8081
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=dev-only-minio-password
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+OSRM_PORT=5000
+OSRM_PBF_URL=https://download.geofabrik.de/europe/monaco-latest.osm.pbf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.jar binary
+*.jpg binary
+*.png binary
+*.zip binary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,37 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: maven
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      maven-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      container-images:
+        patterns: ["*"]

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,21 +1,31 @@
 name: Dependabot auto-merge
-on: pull_request_target
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1
-      - name: Print update-type
-        run: echo ${{steps.dependabot-metadata.outputs.update-type}}
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      - name: Enable patch-only auto-merge after required checks
+        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 2'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
+        with:
+          languages: java-kotlin
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Build for analysis
+        run: ./mvnw --batch-mode --no-transfer-progress -DskipTests -Djacoco.skip=true clean package
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
+        with:
+          category: /language:java-kotlin

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     - cron: '23 4 * * 2'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,6 @@ name: Dependency review
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-3.0,AGPL-3.0

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,27 +1,55 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: Java CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: java-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '21'
           distribution: temurin
           cache: maven
+
       - name: Verify
         run: ./mvnw --batch-mode --no-transfer-progress clean verify
+
+      - name: Upload test and coverage reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: java-reports-${{ github.run_id }}
+          path: |
+            target/surefire-reports/
+            target/failsafe-reports/
+            target/site/jacoco/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload package and SBOM
+        if: ${{ success() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: java-package-${{ github.sha }}
+          path: |
+            target/cab-*.jar
+            target/classes/META-INF/sbom/application.cdx.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,27 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  conventional-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate Conventional Commit title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._/-]+\))?(!)?: .+'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            printf '%s\n' 'PR title must use Conventional Commit syntax, for example: feat(api): add ride lookup'
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,236 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semantic version tag to release (for example, v1.2.3)
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Validate release tag
+        id: release
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            printf '%s\n' 'Release tag must be a semantic version such as v1.2.3 or v1.2.3-rc.1.'
+            exit 1
+          fi
+          if [[ "$(git rev-list -n 1 "$RELEASE_TAG")" != "$(git rev-parse HEAD)" ]]; then
+            printf '%s\n' 'The checked-out commit does not match the requested tag.'
+            exit 1
+          fi
+          {
+            printf 'commit=%s\n' "$(git rev-parse HEAD)"
+            printf 'tag=%s\n' "$RELEASE_TAG"
+            printf 'version=%s\n' "${RELEASE_TAG#v}"
+          } >> "$GITHUB_OUTPUT"
+
+  package:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Build and verify release package
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          ./mvnw --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.21.0:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false
+          ./mvnw --batch-mode --no-transfer-progress clean verify
+          cp target/classes/META-INF/sbom/application.cdx.json "target/cab-${VERSION}.cdx.json"
+          (cd target && shasum -a 256 "cab-${VERSION}.jar" "cab-${VERSION}.cdx.json" > SHA256SUMS)
+
+      - name: Upload test and coverage reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-reports-${{ needs.prepare.outputs.tag }}
+          path: |
+            target/surefire-reports/
+            target/failsafe-reports/
+            target/site/jacoco/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            target/cab-${{ needs.prepare.outputs.version }}.jar
+            target/cab-${{ needs.prepare.outputs.version }}.cdx.json
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-assets-${{ needs.prepare.outputs.tag }}
+          path: |
+            target/cab-${{ needs.prepare.outputs.version }}.jar
+            target/cab-${{ needs.prepare.outputs.version }}.cdx.json
+            target/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 30
+
+  container:
+    needs: [prepare, package]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Set release version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: ./mvnw --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.21.0:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false
+
+      - name: Capture build timestamp
+        id: source
+        run: printf 'created=%s\n' "$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e4d4f7c39adfa4c260fb5c147f0622000aa14b99 # v4.0.0
+
+      - name: Build release image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          load: true
+          push: false
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            REVISION=${{ needs.prepare.outputs.commit }}
+            CREATED=${{ steps.source.outputs.created }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for fixable high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
+      - name: Log in to GHCR
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Refuse to overwrite a published image tag
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          if docker manifest inspect "${IMAGE_NAME}:${VERSION}" >/dev/null 2>&1; then
+            printf '%s\n' 'A container image already exists for this version.'
+            exit 1
+          fi
+
+      - name: Push scanned release image
+        id: push
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          docker push "${IMAGE_NAME}:${VERSION}"
+          docker push "${IMAGE_NAME}:${RELEASE_TAG}"
+          repo_digest=$(docker image inspect --format='{{index .RepoDigests 0}}' "${IMAGE_NAME}:${VERSION}")
+          printf 'digest=%s\n' "${repo_digest#*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest container image
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  release:
+    needs: [prepare, package, container]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-assets-${{ needs.prepare.outputs.tag }}
+          path: release-assets
+
+      - name: Create immutable GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_DIGEST: ${{ needs.container.outputs.digest }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            printf '%s\n' 'A GitHub release already exists for this tag.'
+            exit 1
+          fi
+          gh release create "$RELEASE_TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --generate-notes \
+            --title "$RELEASE_TAG" \
+            --notes "Container: ${IMAGE_NAME}@${IMAGE_DIGEST}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 .settings/
 .vscode/
 .factorypath
+.env

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionSha256Sum=305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for releases.
+
+## [Unreleased]
+
+### Added
+
+- CI, dependency review, CodeQL analysis, and Conventional Commit pull request title checks.
+- Release packaging with a JAR, CycloneDX SBOM, checksums, a scanned GHCR image, and provenance.
+- Compatibility, deprecation, release, and repository ruleset guidance.
+
+[Unreleased]: https://github.com/rahilsh/cab/compare/v0.0.1...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Use `!` and a `BREAKING CHANGE:` footer for incompatible changes.
 ## Pull Requests
 
 - Keep changes focused and independently deployable.
+- Use a Conventional Commit title; squash merges use the pull request title as the commit subject.
 - Explain user-visible behavior and migration impact.
 - Update the README, OpenAPI contract, and operations documentation when applicable.
 - Add Flyway migrations for schema changes; never edit an applied migration.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1.7
-FROM eclipse-temurin:21.0.8_9-jdk-jammy AS build
+FROM eclipse-temurin:21.0.8_9-jdk-jammy@sha256:adb9b2d15adf1833d9dae0bdc1cff61ef5a804dc58dfbfb34269f32432b2e5dc AS build
 WORKDIR /workspace
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY .mvn/ .mvn/
 COPY mvnw pom.xml ./
@@ -10,7 +14,7 @@ COPY src/ src/
 RUN ./mvnw -B -DskipTests package && \
     java -Djarmode=tools -jar target/cab-*.jar extract --layers --destination /workspace/layers
 
-FROM eclipse-temurin:21.0.8_9-jre-jammy
+FROM eclipse-temurin:21.0.8_9-jre-jammy@sha256:db1689535962d757a5adabf57387584ed543d38c0b9d1fe870123ea362ad73b0
 ARG VERSION=0.0.1-SNAPSHOT
 ARG REVISION=unknown
 ARG CREATED=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+FROM eclipse-temurin:21.0.8_9-jdk-jammy AS build
+WORKDIR /workspace
+
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+RUN ./mvnw -B -DskipTests dependency:go-offline
+
+COPY src/ src/
+RUN ./mvnw -B -DskipTests package && \
+    java -Djarmode=tools -jar target/cab-*.jar extract --layers --destination /workspace/layers
+
+FROM eclipse-temurin:21.0.8_9-jre-jammy
+ARG VERSION=0.0.1-SNAPSHOT
+ARG REVISION=unknown
+ARG CREATED=unknown
+LABEL org.opencontainers.image.title="Cab Marketplace" \
+      org.opencontainers.image.description="Multi-tenant ride-hailing marketplace API" \
+      org.opencontainers.image.source="https://github.com/rahilsh/cab" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"
+
+RUN groupadd --gid 10001 cab && \
+    useradd --uid 10001 --gid cab --no-create-home --shell /usr/sbin/nologin cab && \
+    mkdir -p /app /tmp && chown -R cab:cab /app /tmp
+WORKDIR /app
+COPY --from=build --chown=cab:cab /workspace/layers/dependencies/ ./
+COPY --from=build --chown=cab:cab /workspace/layers/spring-boot-loader/ ./
+COPY --from=build --chown=cab:cab /workspace/layers/snapshot-dependencies/ ./
+COPY --from=build --chown=cab:cab /workspace/layers/application/ ./
+RUN mv cab-*.jar app.jar
+
+USER 10001:10001
+EXPOSE 8080
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp" \
+    SPRING_PROFILES_ACTIVE=prod
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD ["curl", "--fail", "--silent", "--show-error", "http://127.0.0.1:8080/actuator/health/liveness"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Cab Marketplace
 
+[![Java CI](https://github.com/rahilsh/cab/actions/workflows/maven.yml/badge.svg)](https://github.com/rahilsh/cab/actions/workflows/maven.yml)
+[![CodeQL](https://github.com/rahilsh/cab/actions/workflows/codeql.yml/badge.svg)](https://github.com/rahilsh/cab/actions/workflows/codeql.yml)
+
 Cab Marketplace is an open-source backend for operating multi-tenant ride-hailing services. The
 project is evolving from a single-fleet prototype into a production-oriented modular monolith for
 operators, riders, drivers, vehicles, pricing, dispatch, trips, payments, and settlements.
@@ -99,6 +102,7 @@ TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
 This command:
 
 - Compiles and packages an executable Spring Boot JAR
+- Generates a CycloneDX JSON SBOM at `target/classes/META-INF/sbom/application.cdx.json`
 - Runs unit tests
 - Enforces at least 85% aggregate unit-test line coverage
 - Starts the application on a random real port for HTTP integration tests
@@ -339,6 +343,11 @@ payloads, audit summaries, or retry error text.
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. All commits must follow
 [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Participation is
 governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+CI behavior and required branch protections are documented in [CI and repository rules](docs/CI.md).
+See the [changelog](CHANGELOG.md), [compatibility policy](docs/COMPATIBILITY.md), and
+[release process](RELEASING.md) for release standards. Release automation publishes artifacts and a
+GHCR image but deliberately performs no cloud deployment.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The production roadmap includes:
 - Driver document upload and verification workflows
 - Production notification and payment-provider adapters
 - Expanded moderation, support automation, and safety escalation workflows
-- Docker Compose and a Helm chart
+- Production payment/notification adapters and additional operational hardening
 
 See [the production roadmap](docs/ROADMAP.md) for sequencing and acceptance criteria.
 
@@ -106,22 +106,38 @@ This command:
 Coverage is written to `target/site/jacoco/index.html`. Integration tests use the `*IT` suffix and
 are run by Maven Failsafe. MockMvc tests do not qualify as API integration tests.
 
-Create a local database before running the current prototype:
+## Quick Start
+
+The complete local stack includes the API, PostgreSQL/PostGIS, Redis, Keycloak, OSRM, and MinIO:
 
 ```bash
-docker run --name cab-postgis --rm \
-  -e POSTGRES_DB=cab \
-  -e POSTGRES_USER=cab \
-  -e POSTGRES_PASSWORD=cab \
-  -p 5432:5432 \
-  postgis/postgis:17-3.5
+cp .env.example .env
+# Replace every dev-only password in .env before starting.
+docker-compose up --build
 ```
 
-In another terminal:
+The default OSRM download is the small Monaco extract. Preparation runs once and is cached in a
+named volume; see [the OSRM runbook](docs/runbooks/osrm-data.md) before selecting a larger region.
+The Keycloak realm contains clearly named local users with `dev-only-*` passwords. These users,
+passwords, direct password grants, and `start-dev` mode must never be used outside local development.
+The API validates the public Keycloak issuer while retrieving signing keys on the private Compose
+network. Split-network deployments must configure both `OIDC_ISSUER_URI` and `OIDC_JWK_SET_URI`.
+
+Obtain a local platform administrator token:
 
 ```bash
-./mvnw spring-boot:run
+curl --request POST http://localhost:8081/realms/cab/protocol/openid-connect/token \
+  --data grant_type=password \
+  --data client_id=cab-local-cli \
+  --data username=platform-admin \
+  --data password=dev-only-platform-admin \
+  --data 'scope=openid platform.admin observability.read'
 ```
+
+Local users are `platform-admin`, `operator`, `driver`, and `rider`; their matching realm roles are
+for identity testing only. Marketplace tenant roles remain authoritative in PostgreSQL. MinIO is
+available at `http://localhost:9000` for future evidence-object integration, while the current API
+stores external evidence references only.
 
 The application reads `DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `REDIS_HOST`,
 `REDIS_PORT`, and `OSRM_BASE_URL`. API documentation is disabled by default; set
@@ -132,6 +148,28 @@ The application reads `DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, 
 `http://localhost:5000`. Defaults are intended
 for local development only. Flyway applies pending migrations; Hibernate validates the resulting
 schema and never creates or drops production tables.
+
+## Deployment
+
+`Dockerfile` builds a layered Java 21 image, runs as UID/GID `10001`, includes OCI metadata and a
+healthcheck, and supports a read-only root filesystem with writable `/tmp`. Build it with:
+
+```bash
+docker build --tag cab-marketplace:local .
+```
+
+The Helm chart at `deploy/helm/cab-marketplace` deploys the stateless API with actuator probes,
+resource defaults, non-root/read-only security contexts, and optional ingress, HPA, PDB, and network
+policy. It references an externally managed Kubernetes Secret and contains no credential defaults.
+Production dependencies are intentionally not bundled into the chart.
+
+Read the operations runbooks before deployment:
+
+- [Deployment](docs/runbooks/deployment.md)
+- [Migrations](docs/runbooks/migrations.md)
+- [Backup and restore](docs/runbooks/backup-restore.md)
+- [Incident response and rollback](docs/runbooks/incident-rollback.md)
+- [OSRM data preparation](docs/runbooks/osrm-data.md)
 
 ## API
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,40 @@
+# Releasing
+
+Releases use signed, annotated Semantic Versioning tags and are built only by GitHub Actions. The
+release workflow publishes a verified JAR, CycloneDX SBOM, SHA-256 checksums, a vulnerability-scanned
+GHCR image, and GitHub artifact attestations. It does not deploy to any environment.
+
+## Prepare
+
+1. Confirm `main` is protected as described in [the CI policy](docs/CI.md) and all required checks pass.
+2. Choose the version according to [the compatibility policy](docs/COMPATIBILITY.md).
+3. Move relevant entries from `Unreleased` in `CHANGELOG.md` into a dated version section and update comparison links.
+4. Set the Maven project version and Helm `appVersion`; increment the chart `version` when chart content changed.
+5. Run `./mvnw clean verify`, `docker build --tag cab-marketplace:release-candidate .`, `docker compose config`, and `helm lint deploy/helm/cab-marketplace`.
+6. Merge the focused release-preparation pull request after review and required checks.
+
+## Sign And Publish
+
+Create a signed annotated tag from the reviewed `main` commit. Never move or reuse a release tag.
+
+```bash
+git switch main
+git pull --ff-only
+git tag --sign v1.2.3 --message "Cab Marketplace v1.2.3"
+git tag --verify v1.2.3
+git push origin v1.2.3
+```
+
+The tag starts `.github/workflows/release.yml`. A maintainer may rerun it with `workflow_dispatch`
+only by naming an existing tag. The workflow refuses non-semantic tags and existing GitHub releases.
+Protect `v*` tags with a GitHub ruleset that limits tag creation and deletion to maintainers.
+
+After publication, verify the release assets, checksum file, image digest, and attestations. Consumers
+should pull GHCR images by digest and verify local assets with `shasum -a 256 -c SHA256SUMS`. GitHub
+CLI users can verify provenance with `gh attestation verify <artifact> --repo rahilsh/cab`.
+
+## Correct A Release
+
+Published tags and assets are immutable. If a release is faulty, leave it available for auditability,
+mark it as affected in the changelog or advisory, and publish a new patch version. Follow the incident
+and rollback runbook for deployed environments; release automation never performs rollback or deploy.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,168 @@
+name: ${COMPOSE_PROJECT_NAME:-cab}
+
+services:
+  app:
+    build:
+      context: .
+      args:
+        VERSION: ${APP_VERSION:-0.0.1-SNAPSHOT}
+        REVISION: ${GIT_REVISION:-local}
+        CREATED: ${BUILD_CREATED:-local}
+    image: cab-marketplace:${APP_VERSION:-local}
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=128m,uid=10001,gid=10001
+    environment:
+      DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-cab}
+      DATABASE_USERNAME: ${POSTGRES_USER:-cab}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      REDIS_HOST: redis
+      OIDC_ISSUER_URI: http://localhost:${KEYCLOAK_PORT:-8081}/realms/cab
+      OIDC_JWK_SET_URI: http://keycloak:8080/realms/cab/protocol/openid-connect/certs
+      OIDC_AUDIENCE: cab-api
+      OSRM_BASE_URL: http://osrm:5000
+      SPRING_PROFILES_ACTIVE: prod
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+      osrm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8080/actuator/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 45s
+    restart: unless-stopped
+    networks: [backend]
+
+  postgres:
+    image: postgis/postgis:17-3.5@sha256:45f2a608397fa67d236b012c14a9e3ea31e9fe813edbeb5c1c0d1acbf0d48ea9
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-cab}
+      POSTGRES_USER: ${POSTGRES_USER:-cab}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: unless-stopped
+    networks: [backend]
+
+  redis:
+    image: redis:7.4.5-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+    networks: [backend]
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.4.7@sha256:9409c59bdfb65dbffa20b11e6f18b8abb9281d480c7ca402f51ed3d5977e6007
+    command: ["start-dev", "--import-realm", "--health-enabled=true"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
+      KC_HOSTNAME: http://localhost:${KEYCLOAK_PORT:-8081}
+    ports:
+      - "${KEYCLOAK_PORT:-8081}:8080"
+    volumes:
+      - keycloak-data:/opt/keycloak/data
+      - ./deploy/keycloak/cab-realm.json:/opt/keycloak/data/import/cab-realm.json:ro
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "exec 3<>/dev/tcp/127.0.0.1/9000; printf 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3; grep -q '200 OK' <&3"
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    restart: unless-stopped
+    networks: [backend]
+
+  osrm-prepare:
+    image: ghcr.io/project-osrm/osrm-backend:v5.27.1@sha256:855614a38f464b0558a2ad6eaa7cb8c139f39887da9b38b485ce453c6e6e6124
+    user: "0:0"
+    environment:
+      OSRM_PBF_URL: ${OSRM_PBF_URL:-https://download.geofabrik.de/europe/monaco-latest.osm.pbf}
+    entrypoint: ["/bin/bash", "-ec"]
+    command:
+      - |
+        if [[ ! -f /data/region.osrm.cells ]]; then
+          apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
+          curl --fail --location --retry 3 "$${OSRM_PBF_URL}" --output /data/region.osm.pbf
+          osrm-extract -p /opt/car.lua /data/region.osm.pbf
+          osrm-partition /data/region.osrm
+          osrm-customize /data/region.osrm
+        fi
+    volumes:
+      - osrm-data:/data
+    restart: "no"
+    networks: [backend]
+
+  osrm:
+    image: ghcr.io/project-osrm/osrm-backend:v5.27.1@sha256:855614a38f464b0558a2ad6eaa7cb8c139f39887da9b38b485ce453c6e6e6124
+    command: ["osrm-routed", "--algorithm", "mld", "/data/region.osrm"]
+    ports:
+      - "${OSRM_PORT:-5000}:5000"
+    depends_on:
+      osrm-prepare:
+        condition: service_completed_successfully
+    volumes:
+      - osrm-data:/data:ro
+    healthcheck:
+      test:
+        - CMD
+        - /bin/bash
+        - -ec
+        - "exec 3<>/dev/tcp/127.0.0.1/5000; printf 'GET /route/v1/driving/7.4189,43.7325;7.4246,43.7384?overview=false HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3; grep -q '200 OK' <&3"
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    restart: unless-stopped
+    networks: [backend]
+
+  minio:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z@sha256:d249d1fb6966de4d8ad26c04754b545205ff15a62e4fd19ebd0f26fa5baacbc0
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env}
+    ports:
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+    restart: unless-stopped
+    networks: [backend]
+
+volumes:
+  postgres-data:
+  redis-data:
+  keycloak-data:
+  osrm-data:
+  minio-data:
+
+networks:
+  backend:
+    driver: bridge

--- a/deploy/helm/cab-marketplace/Chart.yaml
+++ b/deploy/helm/cab-marketplace/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: cab-marketplace
+description: Cab Marketplace API
+type: application
+version: 0.1.0
+appVersion: "0.0.1"
+kubeVersion: ">=1.27.0-0"
+annotations:
+  artifacthub.io/license: Apache-2.0

--- a/deploy/helm/cab-marketplace/README.md
+++ b/deploy/helm/cab-marketplace/README.md
@@ -1,0 +1,34 @@
+# Cab Marketplace Helm Chart
+
+This chart deploys only the stateless API. PostgreSQL/PostGIS, Redis, OIDC, OSRM, object storage,
+backup automation, and ingress certificates must be operated separately.
+
+Create the referenced Secret through an external secret controller, sealed-secret workflow, or your
+platform's secret manager. Do not commit the rendered Secret:
+
+```text
+cab-marketplace
+  database-username
+  database-password
+  fake-payment-webhook-secret
+```
+
+Set `config.*` endpoints and install with an immutable image tag:
+
+```bash
+helm upgrade --install cab deploy/helm/cab-marketplace \
+  --namespace cab --create-namespace \
+  --set image.tag=1.0.0 \
+  --set config.databaseUrl=jdbc:postgresql://postgres.example:5432/cab \
+  --set config.redisHost=redis.example \
+  --set config.oidcIssuerUri=https://identity.example/realms/cab \
+  --set config.osrmBaseUrl=http://osrm.routing:5000
+```
+
+The pod runs as UID/GID `10001`, drops all capabilities, uses a read-only root filesystem, and
+mounts a bounded writable `/tmp`. Enable `networkPolicy` only after supplying environment-specific
+egress rules for PostgreSQL, Redis, OIDC, OSRM, payment providers, and configured webhooks.
+
+Flyway runs at application startup. Keep `replicaCount: 1` for a migration-bearing release and wait
+for readiness before enabling HPA or scaling out. See `docs/runbooks/migrations.md` for the required
+pre-deployment checks and rollback constraints.

--- a/deploy/helm/cab-marketplace/templates/_helpers.tpl
+++ b/deploy/helm/cab-marketplace/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "cab-marketplace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "cab-marketplace.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "cab-marketplace.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "cab-marketplace.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{ include "cab-marketplace.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "cab-marketplace.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cab-marketplace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "cab-marketplace.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cab-marketplace.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/cab-marketplace/templates/configmap.yaml
+++ b/deploy/helm/cab-marketplace/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+data:
+  DATABASE_URL: {{ required "config.databaseUrl is required" .Values.config.databaseUrl | quote }}
+  REDIS_HOST: {{ required "config.redisHost is required" .Values.config.redisHost | quote }}
+  REDIS_PORT: {{ .Values.config.redisPort | quote }}
+  OIDC_ISSUER_URI: {{ required "config.oidcIssuerUri is required" .Values.config.oidcIssuerUri | quote }}
+  OIDC_JWK_SET_URI: {{ required "config.oidcJwkSetUri is required" .Values.config.oidcJwkSetUri | quote }}
+  OIDC_AUDIENCE: {{ required "config.oidcAudience is required" .Values.config.oidcAudience | quote }}
+  OSRM_BASE_URL: {{ required "config.osrmBaseUrl is required" .Values.config.osrmBaseUrl | quote }}
+  SPRING_PROFILES_ACTIVE: {{ .Values.config.springProfilesActive | quote }}
+  API_DOCS_ENABLED: {{ .Values.config.apiDocsEnabled | quote }}
+  SWAGGER_UI_ENABLED: {{ .Values.config.swaggerUiEnabled | quote }}

--- a/deploy/helm/cab-marketplace/templates/deployment.yaml
+++ b/deploy/helm/cab-marketplace/templates/deployment.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "cab-marketplace.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "cab-marketplace.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cab-marketplace.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: cab-marketplace
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "cab-marketplace.fullname" . }}
+          env:
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "existingSecret.name is required" .Values.existingSecret.name }}
+                  key: {{ required "existingSecret.databaseUsernameKey is required" .Values.existingSecret.databaseUsernameKey }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret.name }}
+                  key: {{ required "existingSecret.databasePasswordKey is required" .Values.existingSecret.databasePasswordKey }}
+            - name: FAKE_PAYMENT_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret.name }}
+                  key: {{ required "existingSecret.fakePaymentWebhookSecretKey is required" .Values.existingSecret.fakePaymentWebhookSecretKey }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/cab-marketplace/templates/hpa.yaml
+++ b/deploy/helm/cab-marketplace/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cab-marketplace.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/cab-marketplace/templates/ingress.yaml
+++ b/deploy/helm/cab-marketplace/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "cab-marketplace.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/cab-marketplace/templates/networkpolicy.yaml
+++ b/deploy/helm/cab-marketplace/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "cab-marketplace.selectorLabels" . | nindent 6 }}
+  policyTypes: ["Ingress", "Egress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml .Values.networkPolicy.ingressNamespaceSelector | nindent 12 }}
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/cab-marketplace/templates/pdb.yaml
+++ b/deploy/helm/cab-marketplace/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "cab-marketplace.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/cab-marketplace/templates/service.yaml
+++ b/deploy/helm/cab-marketplace/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cab-marketplace.fullname" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cab-marketplace.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cab-marketplace/templates/serviceaccount.yaml
+++ b/deploy/helm/cab-marketplace/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cab-marketplace.serviceAccountName" . }}
+  labels:
+    {{- include "cab-marketplace.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deploy/helm/cab-marketplace/values.yaml
+++ b/deploy/helm/cab-marketplace/values.yaml
@@ -1,0 +1,109 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/rahilsh/cab
+  tag: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: cab.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+config:
+  databaseUrl: jdbc:postgresql://postgresql:5432/cab
+  redisHost: redis
+  redisPort: "6379"
+  oidcIssuerUri: https://identity.example.com/realms/cab
+  oidcJwkSetUri: https://identity.example.com/realms/cab/protocol/openid-connect/certs
+  oidcAudience: cab-api
+  osrmBaseUrl: http://osrm:5000
+  springProfilesActive: prod
+  apiDocsEnabled: "false"
+  swaggerUiEnabled: "false"
+
+# Create this Secret outside Helm. This chart never stores credential values.
+existingSecret:
+  name: ""
+  databaseUsernameKey: database-username
+  databasePasswordKey: database-password
+  fakePaymentWebhookSecretKey: fake-payment-webhook-secret
+
+extraEnv: []
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+probes:
+  startup:
+    failureThreshold: 30
+    periodSeconds: 5
+  liveness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+terminationGracePeriodSeconds: 30
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+networkPolicy:
+  enabled: false
+  ingressNamespaceSelector: {}
+  egress: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/keycloak/cab-realm.json
+++ b/deploy/keycloak/cab-realm.json
@@ -1,0 +1,116 @@
+{
+  "realm": "cab",
+  "enabled": true,
+  "displayName": "Cab Marketplace (local development)",
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "roles": {
+    "realm": [
+      { "name": "platform-admin", "description": "Local platform administrator" },
+      { "name": "tenant-admin", "description": "Local tenant administrator" },
+      { "name": "dispatcher", "description": "Local dispatcher" },
+      { "name": "driver", "description": "Local driver" },
+      { "name": "rider", "description": "Local rider" },
+      { "name": "support", "description": "Local support operator" },
+      { "name": "safety", "description": "Local safety operator" },
+      { "name": "finance", "description": "Local finance operator" }
+    ]
+  },
+  "clientScopes": [
+    {
+      "name": "platform.admin",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true", "display.on.consent.screen": "false" }
+    },
+    {
+      "name": "observability.read",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true", "display.on.consent.screen": "false" }
+    },
+    {
+      "name": "cab-api-audience",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "false", "display.on.consent.screen": "false" },
+      "protocolMappers": [
+        {
+          "name": "cab-api audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "cab-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "cab-api",
+      "name": "Cab API",
+      "enabled": true,
+      "publicClient": false,
+      "bearerOnly": true,
+      "protocol": "openid-connect"
+    },
+    {
+      "clientId": "cab-local-cli",
+      "name": "Cab local CLI",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": false,
+      "protocol": "openid-connect",
+      "defaultClientScopes": ["cab-api-audience"],
+      "optionalClientScopes": ["platform.admin", "observability.read"]
+    }
+  ],
+  "users": [
+    {
+      "username": "platform-admin",
+      "enabled": true,
+      "firstName": "Platform",
+      "lastName": "Admin",
+      "email": "platform-admin@local.invalid",
+      "emailVerified": true,
+      "credentials": [{ "type": "password", "value": "dev-only-platform-admin", "temporary": false }],
+      "realmRoles": ["platform-admin"],
+      "clientRoles": {},
+      "groups": []
+    },
+    {
+      "username": "operator",
+      "enabled": true,
+      "firstName": "Local",
+      "lastName": "Operator",
+      "email": "operator@local.invalid",
+      "emailVerified": true,
+      "credentials": [{ "type": "password", "value": "dev-only-operator", "temporary": false }],
+      "realmRoles": ["tenant-admin", "dispatcher", "support", "safety", "finance"]
+    },
+    {
+      "username": "driver",
+      "enabled": true,
+      "firstName": "Local",
+      "lastName": "Driver",
+      "email": "driver@local.invalid",
+      "emailVerified": true,
+      "credentials": [{ "type": "password", "value": "dev-only-driver", "temporary": false }],
+      "realmRoles": ["driver"]
+    },
+    {
+      "username": "rider",
+      "enabled": true,
+      "firstName": "Local",
+      "lastName": "Rider",
+      "email": "rider@local.invalid",
+      "emailVerified": true,
+      "credentials": [{ "type": "password", "value": "dev-only-rider", "temporary": false }],
+      "realmRoles": ["rider"]
+    }
+  ]
+}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,35 @@
+# CI And Repository Rules
+
+GitHub Actions are pinned to full commit SHAs with version comments. Dependabot proposes weekly,
+grouped Maven, GitHub Actions, and Docker updates. Only patch updates from Dependabot are eligible for
+auto-merge, and GitHub waits for the branch's required reviews and checks before merging.
+
+## Required Ruleset
+
+Repository settings cannot be enforced from this repository. Protect `main` with a GitHub branch
+ruleset that:
+
+- Requires pull requests, at least one approval, CODEOWNERS review, and dismissal of stale approvals.
+- Requires conversation resolution and blocks force pushes and deletions.
+- Requires branches to be current before merge and requires linear history.
+- Requires `Java CI / build`, `Dependency review / review`, `CodeQL / analyze`, and `PR title / conventional-commit`.
+- Prevents bypass except for a documented emergency maintainer role.
+- Restricts workflow-file changes to CODEOWNERS review.
+
+Enable repository auto-merge so the patch-only Dependabot workflow can request it. Do not make the
+Dependabot auto-merge workflow itself a required check because it intentionally skips non-Dependabot
+pull requests and non-patch updates.
+
+Add a tag ruleset for `v*` that prevents updates and deletions and restricts tag creation to release
+maintainers. Require maintainers to sign release tags as described in `RELEASING.md`.
+
+## Workflow Scope
+
+- `maven.yml` runs `./mvnw clean verify` with Docker available for Testcontainers and always retains test and coverage reports.
+- `dependency-review.yml` blocks newly introduced high-severity vulnerable dependencies and selected strong-copyleft licenses.
+- `codeql.yml` analyzes Java on pull requests, `main`, and weekly.
+- `release.yml` builds release artifacts and a GHCR image on semantic tags or a manual existing-tag rerun. It never deploys.
+
+Fork pull requests receive read-only tokens. Workflows that write packages, attestations, or releases
+run only for a maintainer-created release tag. The `pull_request_target` Dependabot workflow never
+checks out or executes pull request code and passes untrusted values through environment variables.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,26 @@
+# Versioning And Compatibility
+
+Cab Marketplace follows Semantic Versioning after the first stable release. Before `1.0.0`, minor
+versions may contain breaking changes and patch versions remain backward compatible within the same
+minor line. The current prototype supports only the latest commit on `main` for security fixes.
+
+## Compatibility
+
+- Patch releases contain backward-compatible fixes and security updates.
+- Minor releases add backward-compatible behavior. Before `1.0.0`, they may also remove previously deprecated prototype behavior.
+- Major releases may make incompatible API, configuration, persistence, event, or operational changes.
+- Public `/api/v1` request and response contracts, environment variable names, database migrations, emitted event schemas, and supported Java/runtime requirements are compatibility surfaces.
+- Additive response fields are compatible; clients must ignore unknown fields. Removing fields, narrowing accepted values, or changing meaning is breaking.
+- Flyway migrations are forward-only. A release must remain compatible with the schema produced by all migrations included in that release; applied migrations are never edited.
+- Persisted data and externally consumed events require an explicit migration or transition path. Silent destructive conversion is not allowed.
+
+## Deprecation
+
+Document a deprecation in the changelog, API documentation, and migration guidance. State the
+replacement and earliest removal version. After `1.0.0`, keep deprecated public behavior through at
+least one minor release and for at least 90 days when practical; security, legal, or data-integrity
+issues may require faster removal and must be called out prominently.
+
+Breaking changes require a Conventional Commit `!` marker or `BREAKING CHANGE:` footer, a changelog
+entry, migration instructions, and the version increment required by this policy. Experimental or
+explicitly internal interfaces may change without a deprecation window but still require release notes.

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,29 @@
+# Backup And Restore Runbook
+
+## Backup Policy
+
+- PostgreSQL: use encrypted provider snapshots plus continuous WAL archiving for point-in-time
+  recovery. Regularly capture a logical `pg_dump --format=custom` for portability.
+- MinIO/S3: enable bucket versioning, object lock where policy requires it, and cross-region
+  replication or scheduled `mc mirror` to a separate account.
+- Keycloak: back up its production database and realm configuration. The repository realm import is
+  local-only and is not a production identity backup.
+- OSRM: retain the source PBF URL/checksum, profile, OSRM image digest, and preparation parameters;
+  regenerate derived files instead of treating them as authoritative.
+- Redis: no authoritative marketplace data lives in Redis. Preserve it only to reduce recovery time.
+
+Encrypt backups with independently managed keys, restrict restore permissions, record retention,
+and alert on missed jobs. Perform a documented restore drill at least quarterly.
+
+## PostgreSQL Restore
+
+1. Declare an incident, stop API writers, and select the recovery point with the business owner.
+2. Restore into a new isolated PostgreSQL instance; install the matching PostGIS extension.
+3. For logical backups, use `pg_restore --clean --if-exists --no-owner --dbname=<target> <backup>`.
+4. Verify row counts, constraints, spatial indexes, `flyway_schema_history`, and balanced ledger data.
+5. Start one API replica against the restored database and exercise health and synthetic workflows.
+6. Switch traffic, monitor, then retain the old database read-only until the recovery is accepted.
+
+Restore evidence objects to their original immutable object keys before reopening safety workflows.
+After a credential-bearing backup restore, rotate database, OIDC, MinIO/S3, payment, and webhook
+credentials as appropriate.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -1,0 +1,28 @@
+# Deployment Runbook
+
+## Preconditions
+
+- Build and scan an immutable image from a reviewed commit; deploy by digest or immutable tag.
+- Run `./mvnw clean verify`, `docker build`, `docker-compose config`, and Helm lint/template.
+- Provision PostgreSQL 17 with PostGIS, Redis 7, OIDC, OSRM, and object storage independently.
+- Create the Kubernetes Secret named by `existingSecret.name`; never pass secrets in Helm values.
+- Verify database backup recency, migration compatibility, dependency capacity, and alert coverage.
+
+## Deploy
+
+1. Follow [the migration runbook](migrations.md). Keep the API at one replica during startup migrations.
+2. Render and review manifests with the exact production values and image digest.
+3. Run `helm upgrade --install cab deploy/helm/cab-marketplace -n cab -f values-production.yaml --wait --timeout 10m`.
+4. Check rollout status, pod events, `/actuator/health/readiness`, logs, error rate, latency, and database/Redis saturation.
+5. Exercise an authenticated read and a low-risk write using a synthetic tenant.
+6. Scale out or enable HPA only after the first pod is ready and Flyway has completed.
+
+The chart deploys the API only. Treat PostgreSQL, Redis, Keycloak/OIDC, OSRM, MinIO/S3, ingress,
+certificates, and monitoring as separately managed production services.
+
+## Local Stack
+
+Copy `.env.example` to `.env`, replace the marked development passwords, and run
+`docker-compose up --build`. The imported Keycloak realm and all credentials in it are strictly for
+local development. MinIO is available for future evidence-object workflows; the current API stores
+only external object keys and metadata and does not upload evidence bytes.

--- a/docs/runbooks/incident-rollback.md
+++ b/docs/runbooks/incident-rollback.md
@@ -1,0 +1,23 @@
+# Incident And Rollback Runbook
+
+## Triage
+
+1. Assign incident command, record start time and impact, and freeze unrelated deployments.
+2. Check readiness, rollout events, structured logs by correlation ID, HTTP error/latency metrics,
+   PostgreSQL locks/connections, Redis availability, OIDC discovery/JWKS, and OSRM responses.
+3. Reduce harm: pause ingress, scale workers/API, disable a failing integration, or reject writes as
+   the incident requires. Preserve logs and audit evidence.
+
+## Rollback
+
+1. Confirm the previous immutable image is compatible with the current database schema.
+2. Run `helm history cab -n cab` and inspect the target revision's image and configuration.
+3. Run `helm rollback cab <revision> -n cab --wait --timeout 10m`.
+4. Verify readiness, synthetic authenticated reads/writes, event processing, metrics, and logs.
+
+Do not use an application rollback to reverse a destructive migration. If compatibility is broken,
+stop writers and follow the database restore procedure. Do not delete Redis keys or outbox/inbox
+records during triage without a reviewed recovery plan; replay may duplicate external side effects.
+
+After recovery, rotate exposed credentials, reconcile queued events and provider state, communicate
+customer impact, and produce a blameless timeline with corrective actions.

--- a/docs/runbooks/migrations.md
+++ b/docs/runbooks/migrations.md
@@ -1,0 +1,33 @@
+# Database Migration Runbook
+
+Flyway migrations are bundled in the application and run before the pod becomes ready. PostgreSQL
+is authoritative; never use Hibernate schema generation or edit an applied migration.
+
+## Before Deployment
+
+1. Read every pending migration and test it against a recent production-sized restore.
+2. Confirm it is backward compatible with the currently running application. Use expand/migrate/
+   contract across releases for destructive changes.
+3. Measure lock time and disk growth; schedule a maintenance window when the operation cannot remain
+   online.
+4. Take and verify a backup immediately before a risky migration.
+5. Set Helm `replicaCount: 1` and disable HPA for the migration-bearing rollout.
+
+## Apply And Verify
+
+1. Deploy one new pod and watch its logs for Flyway completion.
+2. Inspect `flyway_schema_history` and confirm exactly the expected versions succeeded.
+3. Wait for readiness, exercise critical reads/writes, then scale out.
+
+Flyway's PostgreSQL advisory locking prevents concurrent application migrators, but it does not make
+an unsafe DDL change safe. For long migrations, use a separately reviewed Flyway/SQL Job with the
+application Deployment scaled to zero, then restore replicas. The application image does not expose
+a migration-only command and must not be used as a Job that would remain running after startup.
+
+## Failure
+
+- Stop the rollout and preserve logs and database state.
+- If Flyway reports a failed transactional migration, diagnose and correct it in a new migration.
+- Never run `flyway repair` against production without reviewing the schema and checksum impact.
+- A code rollback is safe only when the new schema remains backward compatible. Otherwise restore
+  the pre-migration backup according to [backup and restore](backup-restore.md).

--- a/docs/runbooks/osrm-data.md
+++ b/docs/runbooks/osrm-data.md
@@ -1,0 +1,30 @@
+# OSRM Data Preparation Runbook
+
+Compose defaults to the small Monaco Geofabrik extract so local startup is practical. The
+`osrm-prepare` one-shot service downloads the PBF and creates MLD files in the `osrm-data` volume;
+subsequent starts reuse the files.
+
+## Local Region Change
+
+1. Choose the smallest trusted `.osm.pbf` extract covering the intended service area.
+2. Set `OSRM_PBF_URL` in `.env`.
+3. Stop the stack and remove only the derived OSRM volume with
+   `docker volume rm <compose-project>_osrm-data`.
+4. Run `docker-compose up osrm-prepare`, then `docker-compose up osrm`.
+5. Query representative routes and boundary cases before starting the API.
+
+Large regions require substantial RAM, CPU, disk, and preparation time. Do not use the Compose
+one-shot container as a production data pipeline.
+
+## Production Dataset
+
+1. Pin the PBF source and checksum, OSRM image digest, and routing profile in change control.
+2. Download over TLS, verify checksum, then run `osrm-extract`, `osrm-partition`, and
+   `osrm-customize` in a capacity-controlled build job.
+3. Publish the complete generated dataset as a versioned, immutable artifact.
+4. Start a canary OSRM instance, validate representative routes and latency, then atomically switch
+   API traffic or the OSRM service selector.
+5. Retain the previous dataset for fast rollback and monitor `NoRoute`/error rates after promotion.
+
+OSRM readiness should test a route inside the loaded region. Update the Compose healthcheck sample
+coordinates when replacing Monaco.

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,12 @@
               <goal>check</goal>
             </goals>
           </execution>
-        </executions>
+          </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.9.3</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,14 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-info</id>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,7 @@ management.endpoint.health.probes.enabled=true
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=never
 management.endpoint.prometheus.access=read-only
+management.info.build.enabled=true
 
 springdoc.api-docs.enabled=${API_DOCS_ENABLED:false}
 springdoc.swagger-ui.enabled=${SWAGGER_UI_ENABLED:false}
@@ -25,6 +26,7 @@ springdoc.paths-to-match=/api/v1/**
 springdoc.show-actuator=false
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OIDC_ISSUER_URI:http://localhost:8081/realms/cab}
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${OIDC_JWK_SET_URI:${OIDC_ISSUER_URI:http://localhost:8081/realms/cab}/protocol/openid-connect/certs}
 spring.security.oauth2.resourceserver.jwt.audiences=${OIDC_AUDIENCE:cab-api}
 
 routing.osrm.base-url=${OSRM_BASE_URL:http://localhost:5000}


### PR DESCRIPTION
## Summary
- Delivers `feat(release): add deployment and secure release automation` as part 12 of 26 in the production marketplace stack.
- Contains 41 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/109`
- Head: `stack/12-release`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.