### PR TITLE
feat(drivers): add compliance documents and ride events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ The current implementation supports:
 - OIDC-protected tenant provisioning and operator memberships
 - Tenant-owned PostGIS service areas
 - OSRM-backed route distance and duration estimates
-- Tenant-scoped rider and driver profiles, driver approval, vehicles, and driver shifts
+- Tenant-scoped rider and driver profiles, document verification, driver approval, vehicles, and driver shifts
 - Tenant-scoped service products, versioned pricing rules, and immutable rider fare quotes
 - Tenant-scoped idempotency, transactional outbox/inbox, and append-only audit foundations
 - Tenant-scoped live driver locations, dispatch offers, and the complete ride lifecycle
+- Authorized server-sent ride status updates for participants and operations staff
 - Provider-neutral capture/refund processing, configurable commission, immutable double-entry ledger, earnings, and settlements
 - Provider-neutral local notifications, participant ratings, support/safety workflows, and signed outbound webhooks
 
 The production roadmap includes:
 
 - Broader role-based access and audited platform-support workflows
-- Driver document upload and verification workflows
+- External object-storage integration for document upload orchestration
 - Production notification and payment-provider adapters
 - Expanded moderation, support automation, and safety escalation workflows
 - Production payment/notification adapters and additional operational hardening
@@ -183,6 +184,9 @@ The HTTP API is versioned under `/api/v1`:
 | `POST` | `/api/v1/drivers/{id}/approve` | Approve a pending driver; requires `TENANT_ADMIN` |
 | `POST` | `/api/v1/drivers/{id}/suspend` | Suspend a driver; requires `TENANT_ADMIN` |
 | `GET`, `PUT` | `/api/v1/drivers/me` | Read or update the authenticated driver profile |
+| `POST`, `GET` | `/api/v1/drivers/me/documents` | Submit or list the authenticated driver's document metadata |
+| `GET` | `/api/v1/drivers/{id}/documents` | List driver documents; requires `TENANT_ADMIN` |
+| `POST` | `/api/v1/drivers/{id}/documents/{documentId}/verify`, `/reject` | Review a pending document; requires `TENANT_ADMIN` |
 | `POST`, `GET` | `/api/v1/vehicles` | Create or list vehicles; requires `TENANT_ADMIN` |
 | `PUT` | `/api/v1/vehicles/{id}` | Versioned vehicle update; requires `TENANT_ADMIN` |
 | `POST`, `GET` | `/api/v1/driver/shifts` | Create or list the authenticated driver's shifts |
@@ -198,6 +202,7 @@ The HTTP API is versioned under `/api/v1`:
 | `PUT` | `/api/v1/driver/location` | Atomically publish a fresh location for the authenticated driver's available shift |
 | `POST`, `GET` | `/api/v1/rides` | Create a ride from an owned quote or list the authenticated rider's rides |
 | `GET`, `POST` | `/api/v1/rides/{id}` | Read an owned ride or cancel it at `/cancel` |
+| `GET` | `/api/v1/rides/{id}/events` | Stream authorized ride status events with SSE |
 | `POST` | `/api/v1/dispatch/rides/{id}/start` | Search bounded fresh supply and create expiring offers; requires `TENANT_ADMIN` or `DISPATCHER` |
 | `GET` | `/api/v1/driver/offers` | List the authenticated driver's pending, unexpired offers |
 | `POST` | `/api/v1/driver/offers/{id}/accept`, `/reject` | Accept or reject a dispatch offer |
@@ -248,8 +253,11 @@ Driver onboarding accepts an account UUID only after proving that account has an
 in the selected tenant, and grants its persisted membership the `DRIVER` role. Driver and rider
 operations resolve the account from the authenticated tenant context. Vehicle and shift mutations
 use optimistic versions and return stable `409 resource-conflict` errors for stale or invalid
-transitions. Driver document storage is metadata-only; document bytes and raw secrets are never
-stored in the marketplace database.
+transitions. Drivers submit bounded document type/reference/object-key/expiry metadata; admins can
+verify or reject it once, with verifier attribution and append-only history. Object keys reject URLs
+and traversal. Document bytes, fetchable URLs, and raw secrets are never accepted. A license remains
+valid through its `expiresOn` date; a null expiry has no stated expiration. Approval requires at
+least one verified, non-expired `DRIVING_LICENSE`.
 
 Live locations require an owned `AVAILABLE` shift and monotonically increasing sequence and device
 timestamp. Redis keys are tenant namespaced; a Lua script atomically updates GEO membership and
@@ -263,6 +271,13 @@ writes initial history, outbox, audit, and idempotency completion in the same tr
 shift transitions are optimistic. Offer acceptance locks only the chosen offer and conditionally
 reserves its shift; database partial unique constraints enforce one accepted offer per ride and one
 active ride per shift. Completion and allowed cancellations release the shift to `AVAILABLE`.
+
+Ride participants and `TENANT_ADMIN`, `DISPATCHER`, or `SUPPORT` members can stream status changes
+from `/api/v1/rides/{id}/events`. Events contain only ride ID, status, optimistic version, and event
+time; generic events never expose live location. Publication is registered after transaction commit,
+and connections have per-actor/per-ride bounds and timeouts. The registry is in-process and therefore
+per application instance. Multi-replica deployments require external pub/sub (or a future outbox
+poller bridge) so every instance can deliver events to its local connections.
 
 Ride completion creates a `CAPTURE_PENDING` payment and transactional
 `payment.capture_requested` outbox event. It never calls a provider inside the ride transaction.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,16 @@ Quote consumption, offer acceptance, ride assignment, shift reservation, history
 writes use database transactions and conditional updates. Fare and currency snapshots are never
 accepted from clients or recalculated during the lifecycle.
 
+Driver documents contain external object keys and bounded metadata only. Object bytes, fetchable
+URLs, and secrets are not accepted. Verification is tenant-admin-only, conditionally changes a
+pending document once, attributes the verifier, and writes append-only history. Driver approval
+requires a verified driving license that is valid on the approval date.
+
+Ride SSE streams require the rider, assigned driver, or an authorized operations role in the same
+tenant. Generic stream events contain status metadata only and are published after transaction
+commit, never from a transaction that later rolls back. Connections are bounded and removed on
+completion, error, or timeout.
+
 Payment APIs derive tenant, rider, driver, and finance authority from persisted memberships. The
 database stores opaque payment-method tokens and provider/configuration references only; PAN, CVV,
 bank credentials, API keys, and webhook secrets must never be persisted. Fake-provider callback

--- a/deploy/helm/cab-marketplace/README.md
+++ b/deploy/helm/cab-marketplace/README.md
@@ -36,3 +36,7 @@ migration credentials. Prefer an external migration job and set `FLYWAY_ENABLED=
 Deployment with `config.flywayEnabled=false` when your platform supports it; migration credential
 keys are then not mounted. Otherwise keep `replicaCount: 1` for a migration-bearing release and wait
 for readiness before scaling out. See `docs/runbooks/migrations.md`.
+
+Ride status SSE subscriptions are stored in-process. Keep ingress proxy buffering disabled for the
+SSE path and provide external pub/sub before scaling replicas when cross-instance delivery is
+required; the current registry only reaches clients connected to the publishing instance.

--- a/src/main/java/in/rsh/cab/dispatch/DispatchService.java
+++ b/src/main/java/in/rsh/cab/dispatch/DispatchService.java
@@ -12,6 +12,7 @@ import in.rsh.cab.operations.OutboxService;
 import in.rsh.cab.pricing.internal.persistence.PricingRepository;
 import in.rsh.cab.ride.Ride;
 import in.rsh.cab.ride.RideStatus;
+import in.rsh.cab.ride.RideEventStream;
 import in.rsh.cab.ride.internal.persistence.RideRepository;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import in.rsh.cab.tenancy.TenantContext;
@@ -44,6 +45,7 @@ public class DispatchService {
   private final int candidateLimit;
   private final Duration locationMaxAge;
   private final Duration offerTtl;
+  private final RideEventStream eventStream;
 
   public DispatchService(
       DispatchRepository dispatch, RideRepository rides, FleetRepository fleet,
@@ -52,7 +54,8 @@ public class DispatchService {
       @Value("${dispatch.search-radius-meters:5000}") int radiusMeters,
       @Value("${dispatch.candidate-limit:10}") int candidateLimit,
       @Value("${dispatch.location-max-age:PT2M}") Duration locationMaxAge,
-      @Value("${dispatch.offer-ttl:PT30S}") Duration offerTtl) {
+      @Value("${dispatch.offer-ttl:PT30S}") Duration offerTtl,
+      RideEventStream eventStream) {
     this.dispatch = dispatch;
     this.rides = rides;
     this.fleet = fleet;
@@ -66,6 +69,7 @@ public class DispatchService {
     this.candidateLimit = candidateLimit;
     this.locationMaxAge = locationMaxAge;
     this.offerTtl = offerTtl;
+    this.eventStream = eventStream;
   }
 
   @Transactional
@@ -170,6 +174,7 @@ public class DispatchService {
         json.valueToTree(new DispatchEvent(ride.id(), ride.status(), ride.driverId())), null);
     audit.record(context.tenantId(), context.accountId(), action, "ride", ride.id(), "SUCCESS",
         json.valueToTree(new DispatchAudit(ride.status())));
+    eventStream.afterCommit(context.tenantId(), ride);
   }
 
   private TenantContext requireAny(TenantRole... roles) {

--- a/src/main/java/in/rsh/cab/driver/DriverDocument.java
+++ b/src/main/java/in/rsh/cab/driver/DriverDocument.java
@@ -1,0 +1,19 @@
+package in.rsh.cab.driver;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record DriverDocument(
+    UUID id,
+    UUID driverId,
+    DriverDocumentType documentType,
+    String documentReference,
+    String objectKey,
+    LocalDate expiresOn,
+    DriverDocumentStatus verificationStatus,
+    UUID verifiedByAccountId,
+    Instant verifiedAt,
+    String rejectionReason,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/src/main/java/in/rsh/cab/driver/DriverDocumentService.java
+++ b/src/main/java/in/rsh/cab/driver/DriverDocumentService.java
@@ -1,0 +1,125 @@
+package in.rsh.cab.driver;
+
+import in.rsh.cab.driver.internal.persistence.DriverDocumentRepository;
+import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DriverDocumentService {
+
+  private static final Pattern OBJECT_KEY = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._/-]{0,511}$");
+  private final DriverDocumentRepository documents;
+  private final DriverProfileRepository drivers;
+  private final Clock clock;
+
+  public DriverDocumentService(
+      DriverDocumentRepository documents, DriverProfileRepository drivers, Clock clock) {
+    this.documents = documents;
+    this.drivers = drivers;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public DriverDocument submit(
+      DriverDocumentType type, String reference, String objectKey, java.time.LocalDate expiresOn) {
+    TenantContext context = require(TenantRole.DRIVER);
+    DriverProfile driver = drivers.findByTenantIdAndAccountId(context.tenantId(), context.accountId())
+        .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+    validateObjectKey(objectKey);
+    if (reference.contains("://")) {
+      throw new InvalidRequestException("Document reference must not be a URL");
+    }
+    Instant now = clock.instant();
+    java.time.LocalDate today = now.atZone(clock.getZone()).toLocalDate();
+    if (type == DriverDocumentType.DRIVING_LICENSE && expiresOn == null) {
+      throw new InvalidRequestException("Driving license expiry is required");
+    }
+    if (expiresOn != null && expiresOn.isBefore(today)) {
+      throw new InvalidRequestException("Document must not already be expired");
+    }
+    DriverDocument document = new DriverDocument(
+        UUID.randomUUID(), driver.id(), type, reference, objectKey, expiresOn,
+        DriverDocumentStatus.PENDING, null, null, null, now, now);
+    documents.insert(context.tenantId(), document);
+    documents.appendHistory(context.tenantId(), document.id(), null, DriverDocumentStatus.PENDING,
+        context.accountId(), null, now);
+    return document;
+  }
+
+  @Transactional(readOnly = true)
+  public List<DriverDocument> listOwn() {
+    TenantContext context = require(TenantRole.DRIVER);
+    DriverProfile driver = drivers.findByTenantIdAndAccountId(context.tenantId(), context.accountId())
+        .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+    return documents.findAll(context.tenantId(), driver.id());
+  }
+
+  @Transactional(readOnly = true)
+  public List<DriverDocument> list(UUID driverId) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    requireDriver(context.tenantId(), driverId);
+    return documents.findAll(context.tenantId(), driverId);
+  }
+
+  @Transactional
+  public DriverDocument verify(UUID driverId, UUID documentId) {
+    return review(driverId, documentId, DriverDocumentStatus.VERIFIED, null);
+  }
+
+  @Transactional
+  public DriverDocument reject(UUID driverId, UUID documentId, String reason) {
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidRequestException("Rejection reason is required");
+    }
+    return review(driverId, documentId, DriverDocumentStatus.REJECTED, reason);
+  }
+
+  private DriverDocument review(
+      UUID driverId, UUID documentId, DriverDocumentStatus status, String reason) {
+    TenantContext context = require(TenantRole.TENANT_ADMIN);
+    DriverDocument current = documents.find(context.tenantId(), driverId, documentId)
+        .orElseThrow(() -> new NotFoundException("Driver document not found"));
+    Instant now = clock.instant();
+    Instant verifiedAt = status == DriverDocumentStatus.VERIFIED ? now : null;
+    if (!documents.review(context.tenantId(), driverId, documentId, status, context.accountId(),
+        verifiedAt, reason, now)) {
+      throw new ConflictException("Driver document was already reviewed");
+    }
+    documents.appendHistory(context.tenantId(), documentId, current.verificationStatus(), status,
+        context.accountId(), reason, now);
+    return documents.find(context.tenantId(), driverId, documentId).orElseThrow();
+  }
+
+  private void validateObjectKey(String objectKey) {
+    if (!OBJECT_KEY.matcher(objectKey).matches() || objectKey.contains("../")
+        || objectKey.contains("/..") || objectKey.contains(":")) {
+      throw new InvalidRequestException(
+          "Document must use an external object key, not a URL or path traversal");
+    }
+  }
+
+  private void requireDriver(UUID tenantId, UUID driverId) {
+    drivers.findByTenantIdAndId(tenantId, driverId)
+        .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+  }
+
+  private TenantContext require(TenantRole role) {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(role)) {
+      throw new TenantAccessDeniedException(role + " role is required");
+    }
+    return context;
+  }
+}

--- a/src/main/java/in/rsh/cab/driver/DriverDocumentStatus.java
+++ b/src/main/java/in/rsh/cab/driver/DriverDocumentStatus.java
@@ -1,0 +1,7 @@
+package in.rsh.cab.driver;
+
+public enum DriverDocumentStatus {
+  PENDING,
+  VERIFIED,
+  REJECTED
+}

--- a/src/main/java/in/rsh/cab/driver/DriverDocumentType.java
+++ b/src/main/java/in/rsh/cab/driver/DriverDocumentType.java
@@ -1,0 +1,8 @@
+package in.rsh.cab.driver;
+
+public enum DriverDocumentType {
+  DRIVING_LICENSE,
+  IDENTITY_DOCUMENT,
+  VEHICLE_INSURANCE,
+  OTHER
+}

--- a/src/main/java/in/rsh/cab/driver/DriverService.java
+++ b/src/main/java/in/rsh/cab/driver/DriverService.java
@@ -3,6 +3,7 @@ package in.rsh.cab.driver;
 import in.rsh.cab.exception.ConflictException;
 import in.rsh.cab.exception.NotFoundException;
 import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.driver.internal.persistence.DriverDocumentRepository;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import in.rsh.cab.tenancy.TenantContext;
 import in.rsh.cab.tenancy.TenantRole;
@@ -19,11 +20,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class DriverService {
 
   private final DriverProfileRepository drivers;
+  private final DriverDocumentRepository documents;
   private final TenantService tenants;
   private final Clock clock;
 
-  public DriverService(DriverProfileRepository drivers, TenantService tenants, Clock clock) {
+  public DriverService(
+      DriverProfileRepository drivers, DriverDocumentRepository documents,
+      TenantService tenants, Clock clock) {
     this.drivers = drivers;
+    this.documents = documents;
     this.tenants = tenants;
     this.clock = clock;
   }
@@ -54,7 +59,12 @@ public class DriverService {
   public DriverProfile approve(UUID id) {
     TenantContext context = require(TenantRole.TENANT_ADMIN);
     DriverProfile current = find(context.tenantId(), id);
-    DriverProfile approved = current.approve(clock.instant());
+    Instant now = clock.instant();
+    DriverProfile approved = current.approve(now);
+    if (!documents.hasVerifiedDrivingLicense(
+        context.tenantId(), id, now.atZone(clock.getZone()).toLocalDate())) {
+      throw new ConflictException("A verified, non-expired driving license is required");
+    }
     if (!drivers.updateStatus(
         context.tenantId(), id, current.status(), approved.status(), approved.updatedAt())) {
       throw new ConflictException("Driver status changed concurrently");

--- a/src/main/java/in/rsh/cab/driver/internal/persistence/DriverDocumentRepository.java
+++ b/src/main/java/in/rsh/cab/driver/internal/persistence/DriverDocumentRepository.java
@@ -1,0 +1,39 @@
+package in.rsh.cab.driver.internal.persistence;
+
+import in.rsh.cab.driver.DriverDocument;
+import in.rsh.cab.driver.DriverDocumentStatus;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DriverDocumentRepository {
+
+  void insert(UUID tenantId, DriverDocument document);
+
+  Optional<DriverDocument> find(UUID tenantId, UUID driverId, UUID documentId);
+
+  List<DriverDocument> findAll(UUID tenantId, UUID driverId);
+
+  boolean review(
+      UUID tenantId,
+      UUID driverId,
+      UUID documentId,
+      DriverDocumentStatus status,
+      UUID verifierAccountId,
+      Instant verifiedAt,
+      String rejectionReason,
+      Instant updatedAt);
+
+  void appendHistory(
+      UUID tenantId,
+      UUID documentId,
+      DriverDocumentStatus from,
+      DriverDocumentStatus to,
+      UUID actorAccountId,
+      String reason,
+      Instant occurredAt);
+
+  boolean hasVerifiedDrivingLicense(UUID tenantId, UUID driverId, LocalDate onDate);
+}

--- a/src/main/java/in/rsh/cab/driver/internal/persistence/JdbcDriverDocumentRepository.java
+++ b/src/main/java/in/rsh/cab/driver/internal/persistence/JdbcDriverDocumentRepository.java
@@ -1,0 +1,119 @@
+package in.rsh.cab.driver.internal.persistence;
+
+import in.rsh.cab.driver.DriverDocument;
+import in.rsh.cab.driver.DriverDocumentStatus;
+import in.rsh.cab.driver.DriverDocumentType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcDriverDocumentRepository implements DriverDocumentRepository {
+
+  private static final String SELECT = """
+      SELECT id, driver_id, document_type, document_reference, object_key, expires_on,
+             verification_status, verified_by_account_id, verified_at, rejection_reason,
+             created_at, updated_at
+      FROM driver_documents
+      """;
+  private final JdbcClient jdbc;
+
+  public JdbcDriverDocumentRepository(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public void insert(UUID tenantId, DriverDocument document) {
+    jdbc.sql("""
+            INSERT INTO driver_documents
+              (id, tenant_id, driver_id, document_type, document_reference, object_key,
+               expires_on, verification_status, created_at, updated_at)
+            VALUES (:id, :tenantId, :driverId, :type, :reference, :objectKey,
+                    :expiresOn, :status, :createdAt, :updatedAt)
+            """)
+        .param("id", document.id()).param("tenantId", tenantId)
+        .param("driverId", document.driverId()).param("type", document.documentType().name())
+        .param("reference", document.documentReference()).param("objectKey", document.objectKey())
+        .param("expiresOn", document.expiresOn()).param("status", document.verificationStatus().name())
+        .param("createdAt", Timestamp.from(document.createdAt()))
+        .param("updatedAt", Timestamp.from(document.updatedAt())).update();
+  }
+
+  @Override
+  public Optional<DriverDocument> find(UUID tenantId, UUID driverId, UUID documentId) {
+    return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId AND driver_id = :driverId AND id = :id")
+        .param("tenantId", tenantId).param("driverId", driverId).param("id", documentId)
+        .query(this::map).optional();
+  }
+
+  @Override
+  public List<DriverDocument> findAll(UUID tenantId, UUID driverId) {
+    return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId AND driver_id = :driverId ORDER BY created_at, id")
+        .param("tenantId", tenantId).param("driverId", driverId).query(this::map).list();
+  }
+
+  @Override
+  public boolean review(
+      UUID tenantId, UUID driverId, UUID documentId, DriverDocumentStatus status,
+      UUID verifierAccountId, Instant verifiedAt, String rejectionReason, Instant updatedAt) {
+    return jdbc.sql("""
+            UPDATE driver_documents
+            SET verification_status = :status, verified_by_account_id = :verifier,
+                verified_at = :verifiedAt, rejection_reason = :reason, updated_at = :updatedAt
+            WHERE tenant_id = :tenantId AND driver_id = :driverId AND id = :id
+              AND verification_status = 'PENDING'
+            """)
+        .param("tenantId", tenantId).param("driverId", driverId).param("id", documentId)
+        .param("status", status.name()).param("verifier", verifierAccountId)
+        .param("verifiedAt", verifiedAt == null ? null : Timestamp.from(verifiedAt))
+        .param("reason", rejectionReason).param("updatedAt", Timestamp.from(updatedAt)).update() == 1;
+  }
+
+  @Override
+  public void appendHistory(
+      UUID tenantId, UUID documentId, DriverDocumentStatus from, DriverDocumentStatus to,
+      UUID actorAccountId, String reason, Instant occurredAt) {
+    jdbc.sql("""
+            INSERT INTO driver_document_verification_history
+              (id, tenant_id, document_id, from_status, to_status, actor_account_id, reason, occurred_at)
+            VALUES (:id, :tenantId, :documentId, :fromStatus, :toStatus, :actorId, :reason, :occurredAt)
+            """)
+        .param("id", UUID.randomUUID()).param("tenantId", tenantId)
+        .param("documentId", documentId).param("fromStatus", from == null ? null : from.name())
+        .param("toStatus", to.name()).param("actorId", actorAccountId).param("reason", reason)
+        .param("occurredAt", Timestamp.from(occurredAt)).update();
+  }
+
+  @Override
+  public boolean hasVerifiedDrivingLicense(UUID tenantId, UUID driverId, LocalDate onDate) {
+    return jdbc.sql("""
+            SELECT EXISTS (
+              SELECT 1 FROM driver_documents
+              WHERE tenant_id = :tenantId AND driver_id = :driverId
+                AND document_type = 'DRIVING_LICENSE' AND verification_status = 'VERIFIED'
+                AND (expires_on IS NULL OR expires_on >= :onDate))
+            """)
+        .param("tenantId", tenantId).param("driverId", driverId).param("onDate", onDate)
+        .query(Boolean.class).single();
+  }
+
+  private DriverDocument map(ResultSet rs, int rowNumber) throws SQLException {
+    Timestamp verifiedAt = rs.getTimestamp("verified_at");
+    return new DriverDocument(
+        rs.getObject("id", UUID.class), rs.getObject("driver_id", UUID.class),
+        DriverDocumentType.valueOf(rs.getString("document_type")),
+        rs.getString("document_reference"), rs.getString("object_key"),
+        rs.getObject("expires_on", LocalDate.class),
+        DriverDocumentStatus.valueOf(rs.getString("verification_status")),
+        rs.getObject("verified_by_account_id", UUID.class),
+        verifiedAt == null ? null : verifiedAt.toInstant(), rs.getString("rejection_reason"),
+        rs.getTimestamp("created_at").toInstant(), rs.getTimestamp("updated_at").toInstant());
+  }
+}

--- a/src/main/java/in/rsh/cab/driver/internal/web/DriverDocumentController.java
+++ b/src/main/java/in/rsh/cab/driver/internal/web/DriverDocumentController.java
@@ -1,0 +1,69 @@
+package in.rsh.cab.driver.internal.web;
+
+import in.rsh.cab.driver.DriverDocument;
+import in.rsh.cab.driver.DriverDocumentService;
+import in.rsh.cab.driver.DriverDocumentType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class DriverDocumentController {
+
+  private final DriverDocumentService documents;
+
+  public DriverDocumentController(DriverDocumentService documents) {
+    this.documents = documents;
+  }
+
+  @PostMapping("/drivers/me/documents")
+  public ResponseEntity<DriverDocument> submit(@Valid @RequestBody SubmitRequest request) {
+    DriverDocument document = documents.submit(request.documentType(), request.documentReference(),
+        request.objectKey(), request.expiresOn());
+    return ResponseEntity.created(URI.create("/api/v1/drivers/me/documents/" + document.id()))
+        .body(document);
+  }
+
+  @GetMapping("/drivers/me/documents")
+  public List<DriverDocument> listOwn() {
+    return documents.listOwn();
+  }
+
+  @GetMapping("/drivers/{driverId}/documents")
+  public List<DriverDocument> list(@PathVariable UUID driverId) {
+    return documents.list(driverId);
+  }
+
+  @PostMapping("/drivers/{driverId}/documents/{documentId}/verify")
+  public DriverDocument verify(@PathVariable UUID driverId, @PathVariable UUID documentId) {
+    return documents.verify(driverId, documentId);
+  }
+
+  @PostMapping("/drivers/{driverId}/documents/{documentId}/reject")
+  public DriverDocument reject(
+      @PathVariable UUID driverId, @PathVariable UUID documentId,
+      @Valid @RequestBody RejectRequest request) {
+    return documents.reject(driverId, documentId, request.reason());
+  }
+
+  public record SubmitRequest(
+      @NotNull DriverDocumentType documentType,
+      @NotBlank @Size(max = 255) String documentReference,
+      @NotBlank @Size(max = 512) String objectKey,
+      LocalDate expiresOn) {}
+
+  public record RejectRequest(@NotBlank @Size(max = 500) String reason) {}
+}

--- a/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -137,6 +138,11 @@ public class GlobalExceptionHandler {
         "Internal server error",
         "Unexpected error",
         "internal-error");
+  }
+
+  @ExceptionHandler(AsyncRequestNotUsableException.class)
+  public void handleDisconnectedClient() {
+    // The response is already committed; a disconnected streaming client needs no error body.
   }
 
   private ResponseEntity<ProblemDetail> problem(

--- a/src/main/java/in/rsh/cab/ride/RideEventStream.java
+++ b/src/main/java/in/rsh/cab/ride/RideEventStream.java
@@ -1,0 +1,168 @@
+package in.rsh.cab.ride;
+
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.ride.internal.persistence.RideRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.LongFunction;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class RideEventStream {
+
+  private static final Set<TenantRole> STAFF =
+      Set.of(TenantRole.TENANT_ADMIN, TenantRole.DISPATCHER, TenantRole.SUPPORT);
+  private final RideRepository rides;
+  private final long timeoutMillis;
+  private final int maxPerActor;
+  private final int maxPerRide;
+  private final LongFunction<SseEmitter> emitterFactory;
+  private final Map<ActorKey, Set<Subscription>> byActor = new HashMap<>();
+  private final Map<RideKey, Set<Subscription>> byRide = new HashMap<>();
+
+  @Autowired
+  public RideEventStream(
+      RideRepository rides,
+      @Value("${rides.events.timeout:PT5M}") Duration timeout,
+      @Value("${rides.events.max-per-actor:3}") int maxPerActor,
+      @Value("${rides.events.max-per-ride:20}") int maxPerRide) {
+    this(rides, timeout, maxPerActor, maxPerRide, SseEmitter::new);
+  }
+
+  RideEventStream(
+      RideRepository rides, Duration timeout, int maxPerActor, int maxPerRide,
+      LongFunction<SseEmitter> emitterFactory) {
+    this.rides = rides;
+    this.timeoutMillis = timeout.toMillis();
+    this.maxPerActor = maxPerActor;
+    this.maxPerRide = maxPerRide;
+    this.emitterFactory = emitterFactory;
+  }
+
+  @Transactional(readOnly = true)
+  public SseEmitter subscribe(UUID rideId) {
+    TenantContext context = TenantContext.require();
+    authorize(context, rideId);
+    ActorKey actorKey = new ActorKey(context.tenantId(), context.accountId());
+    RideKey rideKey = new RideKey(context.tenantId(), rideId);
+    SseEmitter emitter = emitterFactory.apply(timeoutMillis);
+    Subscription subscription = new Subscription(actorKey, rideKey, emitter);
+    synchronized (this) {
+      if (byActor.getOrDefault(actorKey, Set.of()).size() >= maxPerActor
+          || byRide.getOrDefault(rideKey, Set.of()).size() >= maxPerRide) {
+        throw new ConflictException("Too many active ride event streams");
+      }
+      byActor.computeIfAbsent(actorKey, ignored -> new HashSet<>()).add(subscription);
+      byRide.computeIfAbsent(rideKey, ignored -> new HashSet<>()).add(subscription);
+    }
+    emitter.onCompletion(() -> remove(subscription));
+    emitter.onTimeout(() -> remove(subscription));
+    emitter.onError(ignored -> remove(subscription));
+    try {
+      emitter.send(SseEmitter.event().name("ready").comment("ride status stream ready"));
+    } catch (IOException exception) {
+      remove(subscription);
+      throw new IllegalStateException("Could not open ride event stream", exception);
+    }
+    return emitter;
+  }
+
+  public void afterCommit(UUID tenantId, Ride ride) {
+    RideStatusEvent event =
+        new RideStatusEvent(ride.id(), ride.status(), ride.version(), ride.updatedAt());
+    if (!TransactionSynchronizationManager.isActualTransactionActive()
+        || !TransactionSynchronizationManager.isSynchronizationActive()) {
+      publish(tenantId, event);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            publish(tenantId, event);
+          }
+        });
+  }
+
+  void publish(UUID tenantId, RideStatusEvent event) {
+    RideKey key = new RideKey(tenantId, event.rideId());
+    ArrayList<Subscription> subscribers;
+    synchronized (this) {
+      subscribers = new ArrayList<>(byRide.getOrDefault(key, Set.of()));
+    }
+    for (Subscription subscription : subscribers) {
+      try {
+        subscription.emitter().send(
+            SseEmitter.event().name("ride-status").id(Long.toString(event.version())).data(event));
+      } catch (IOException | IllegalStateException exception) {
+        remove(subscription);
+      }
+    }
+  }
+
+  synchronized int subscriberCount(UUID tenantId, UUID rideId) {
+    return byRide.getOrDefault(new RideKey(tenantId, rideId), Set.of()).size();
+  }
+
+  private void authorize(TenantContext context, UUID rideId) {
+    boolean staff = context.roles().stream().anyMatch(STAFF::contains);
+    boolean visible;
+    if (staff) {
+      visible = rides.find(context.tenantId(), rideId).isPresent();
+    } else {
+      boolean rider = context.roles().contains(TenantRole.RIDER);
+      boolean driver = context.roles().contains(TenantRole.DRIVER);
+      if (!rider && !driver) {
+        throw new TenantAccessDeniedException("Ride event stream access is restricted");
+      }
+      visible = rider && rides.findOwn(context.tenantId(), context.accountId(), rideId).isPresent();
+      if (!visible && driver) {
+        visible = rides.findAssignedToDriver(context.tenantId(), context.accountId(), rideId).isPresent();
+      }
+    }
+    if (!visible) {
+      throw new NotFoundException("Ride not found");
+    }
+  }
+
+  private synchronized void remove(Subscription subscription) {
+    remove(byActor, subscription.actorKey(), subscription);
+    remove(byRide, subscription.rideKey(), subscription);
+  }
+
+  private <K> void remove(Map<K, Set<Subscription>> index, K key, Subscription subscription) {
+    Set<Subscription> subscriptions = index.get(key);
+    if (subscriptions != null) {
+      subscriptions.remove(subscription);
+      if (subscriptions.isEmpty()) {
+        index.remove(key);
+      }
+    }
+  }
+
+  public record RideStatusEvent(
+      UUID rideId, RideStatus status, long version, Instant occurredAt) {}
+
+  private record ActorKey(UUID tenantId, UUID accountId) {}
+
+  private record RideKey(UUID tenantId, UUID rideId) {}
+
+  private record Subscription(ActorKey actorKey, RideKey rideKey, SseEmitter emitter) {}
+}

--- a/src/main/java/in/rsh/cab/ride/RideService.java
+++ b/src/main/java/in/rsh/cab/ride/RideService.java
@@ -43,11 +43,12 @@ public class RideService {
   private final PaymentService payments;
   private final ObjectMapper json;
   private final Clock clock;
+  private final RideEventStream eventStream;
 
   public RideService(
       RideRepository rides, PricingRepository pricing, DispatchRepository dispatch, FleetRepository fleet,
       IdempotencyService idempotency, OutboxService outbox, AuditService audit, PaymentService payments,
-      ObjectMapper json, Clock clock) {
+      ObjectMapper json, Clock clock, RideEventStream eventStream) {
     this.rides = rides;
     this.pricing = pricing;
     this.dispatch = dispatch;
@@ -58,6 +59,7 @@ public class RideService {
     this.payments = payments;
     this.json = json;
     this.clock = clock;
+    this.eventStream = eventStream;
   }
 
   @Transactional
@@ -181,6 +183,7 @@ public class RideService {
         json.valueToTree(new RideEvent(ride.id(), ride.status(), ride.driverId())), null);
     audit.record(context.tenantId(), context.accountId(), action, "ride", ride.id(), "SUCCESS",
         json.valueToTree(new RideAudit(ride.status())));
+    eventStream.afterCommit(context.tenantId(), ride);
   }
 
   private TenantContext require(TenantRole role) {

--- a/src/main/java/in/rsh/cab/ride/internal/web/RideController.java
+++ b/src/main/java/in/rsh/cab/ride/internal/web/RideController.java
@@ -2,6 +2,7 @@ package in.rsh.cab.ride.internal.web;
 
 import in.rsh.cab.ride.Ride;
 import in.rsh.cab.ride.RideService;
+import in.rsh.cab.ride.RideEventStream;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,15 +20,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v1/rides")
 public class RideController {
 
   private final RideService rides;
+  private final RideEventStream events;
 
-  public RideController(RideService rides) {
+  public RideController(RideService rides, RideEventStream events) {
     this.rides = rides;
+    this.events = events;
   }
 
   @PostMapping
@@ -46,6 +51,11 @@ public class RideController {
   @GetMapping("/{id}")
   public Ride get(@PathVariable UUID id) {
     return rides.getOwn(id);
+  }
+
+  @GetMapping(value = "/{id}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter events(@PathVariable UUID id) {
+    return events.subscribe(id);
   }
 
   @PostMapping("/{id}/cancel")

--- a/src/main/java/in/rsh/cab/tenancy/internal/web/TenantSelectionInterceptor.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/web/TenantSelectionInterceptor.java
@@ -9,10 +9,10 @@ import java.util.UUID;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 @Component
-public class TenantSelectionInterceptor implements HandlerInterceptor {
+public class TenantSelectionInterceptor implements AsyncHandlerInterceptor {
 
   public static final String TENANT_HEADER = "X-Tenant-ID";
   private final TenantService tenantService;
@@ -40,6 +40,12 @@ public class TenantSelectionInterceptor implements HandlerInterceptor {
     TenantContext.set(
         tenantService.authorize(jwt.getIssuer().toString(), jwt.getSubject(), tenantId));
     return true;
+  }
+
+  @Override
+  public void afterConcurrentHandlingStarted(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    TenantContext.clear();
   }
 
   @Override

--- a/src/main/java/in/rsh/cab/web/RequestContextMdcInterceptor.java
+++ b/src/main/java/in/rsh/cab/web/RequestContextMdcInterceptor.java
@@ -11,10 +11,10 @@ import org.slf4j.MDC;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 @Component
-public class RequestContextMdcInterceptor implements HandlerInterceptor {
+public class RequestContextMdcInterceptor implements AsyncHandlerInterceptor {
 
   @Override
   public boolean preHandle(
@@ -36,11 +36,21 @@ public class RequestContextMdcInterceptor implements HandlerInterceptor {
   }
 
   @Override
+  public void afterConcurrentHandlingStarted(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    clear();
+  }
+
+  @Override
   public void afterCompletion(
       HttpServletRequest request,
       HttpServletResponse response,
       Object handler,
       Exception exception) {
+    clear();
+  }
+
+  private void clear() {
     MDC.remove("tenantId");
     MDC.remove("actorId");
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,6 +43,9 @@ dispatch.candidate-limit=${DISPATCH_CANDIDATE_LIMIT:10}
 dispatch.location-max-age=${DISPATCH_LOCATION_MAX_AGE:PT2M}
 dispatch.location-future-tolerance=${DISPATCH_LOCATION_FUTURE_TOLERANCE:PT30S}
 dispatch.offer-ttl=${DISPATCH_OFFER_TTL:PT30S}
+rides.events.timeout=${RIDE_EVENTS_TIMEOUT:PT5M}
+rides.events.max-per-actor=${RIDE_EVENTS_MAX_PER_ACTOR:3}
+rides.events.max-per-ride=${RIDE_EVENTS_MAX_PER_RIDE:20}
 
 payments.provider=${PAYMENT_PROVIDER:fake}
 payments.fake.config-reference=${FAKE_PAYMENT_CONFIG_REFERENCE:env:FAKE_PAYMENT_ACCOUNT}

--- a/src/main/resources/db/migration/V11__driver_document_verification.sql
+++ b/src/main/resources/db/migration/V11__driver_document_verification.sql
@@ -1,0 +1,67 @@
+ALTER TABLE driver_documents
+    ADD COLUMN verified_by_account_id uuid,
+    ADD COLUMN rejection_reason varchar(500),
+    ADD CONSTRAINT fk_driver_document_verifier
+        FOREIGN KEY (tenant_id, verified_by_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    ADD CONSTRAINT chk_driver_document_type CHECK (
+        document_type IN ('DRIVING_LICENSE', 'IDENTITY_DOCUMENT', 'VEHICLE_INSURANCE', 'OTHER')
+    ) NOT VALID,
+    ADD CONSTRAINT chk_driver_document_review CHECK (
+        (verification_status = 'PENDING'
+            AND verified_by_account_id IS NULL
+            AND verified_at IS NULL
+            AND rejection_reason IS NULL)
+        OR (verification_status = 'VERIFIED'
+            AND verified_by_account_id IS NOT NULL
+            AND verified_at IS NOT NULL
+            AND rejection_reason IS NULL)
+        OR (verification_status = 'REJECTED'
+            AND verified_by_account_id IS NOT NULL
+            AND verified_at IS NULL
+            AND rejection_reason IS NOT NULL)
+    ) NOT VALID;
+
+CREATE TABLE driver_document_verification_history (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL,
+    document_id uuid NOT NULL,
+    from_status varchar(32),
+    to_status varchar(32) NOT NULL,
+    actor_account_id uuid NOT NULL,
+    reason varchar(500),
+    occurred_at timestamptz NOT NULL,
+    CONSTRAINT uq_driver_document_history_tenant_id UNIQUE (tenant_id, id),
+    CONSTRAINT fk_driver_document_history_document
+        FOREIGN KEY (tenant_id, document_id)
+        REFERENCES driver_documents (tenant_id, id) ON DELETE CASCADE,
+    CONSTRAINT fk_driver_document_history_actor
+        FOREIGN KEY (tenant_id, actor_account_id)
+        REFERENCES tenant_memberships (tenant_id, user_account_id),
+    CONSTRAINT chk_driver_document_history_status CHECK (
+        (from_status IS NULL OR from_status IN ('PENDING', 'VERIFIED', 'REJECTED'))
+        AND to_status IN ('PENDING', 'VERIFIED', 'REJECTED')),
+    CONSTRAINT chk_driver_document_history_reason CHECK (
+        (to_status = 'REJECTED' AND reason IS NOT NULL)
+        OR (to_status <> 'REJECTED' AND reason IS NULL))
+);
+
+CREATE INDEX idx_driver_document_history_document
+    ON driver_document_verification_history (tenant_id, document_id, occurred_at, id);
+
+CREATE FUNCTION reject_driver_document_history_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'driver_document_verification_history is append-only';
+END;
+$$;
+
+CREATE TRIGGER driver_document_history_immutable
+BEFORE UPDATE OR DELETE ON driver_document_verification_history
+FOR EACH ROW EXECUTE FUNCTION reject_driver_document_history_mutation();
+
+ALTER TABLE driver_document_verification_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE driver_document_verification_history FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON driver_document_verification_history
+    USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);

--- a/src/test/java/in/rsh/cab/dispatch/DispatchServiceTest.java
+++ b/src/test/java/in/rsh/cab/dispatch/DispatchServiceTest.java
@@ -22,6 +22,7 @@ import in.rsh.cab.pricing.ServiceProduct;
 import in.rsh.cab.pricing.internal.persistence.PricingRepository;
 import in.rsh.cab.ride.Ride;
 import in.rsh.cab.ride.RideStatus;
+import in.rsh.cab.ride.RideEventStream;
 import in.rsh.cab.ride.internal.persistence.RideRepository;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
 import in.rsh.cab.tenancy.TenantContext;
@@ -51,13 +52,14 @@ class DispatchServiceTest {
   private final LiveLocationStore locations = mock(LiveLocationStore.class);
   private final OutboxService outbox = mock(OutboxService.class);
   private final AuditService audit = mock(AuditService.class);
+  private final RideEventStream eventStream = mock(RideEventStream.class);
   private DispatchService service;
 
   @BeforeEach
   void setUp() {
     service = new DispatchService(dispatch, rides, fleet, pricing, locations, outbox, audit,
         new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC), 5000, 10,
-        Duration.ofMinutes(2), Duration.ofSeconds(30));
+        Duration.ofMinutes(2), Duration.ofSeconds(30), eventStream);
     context(TenantRole.DISPATCHER);
   }
 
@@ -85,6 +87,7 @@ class DispatchServiceTest {
     assertEquals(1, offers.size());
     assertEquals(driver, offers.get(0).driverId());
     verify(dispatch).insertOffer(TENANT, offers.get(0));
+    verify(eventStream).afterCommit(eq(TENANT), any());
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/driver/DriverDocumentServiceTest.java
+++ b/src/test/java/in/rsh/cab/driver/DriverDocumentServiceTest.java
@@ -1,0 +1,141 @@
+package in.rsh.cab.driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.driver.internal.persistence.DriverDocumentRepository;
+import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DriverDocumentServiceTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final UUID ACCOUNT = UUID.randomUUID();
+  private static final UUID DRIVER = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
+  private final DriverDocumentRepository documents = mock(DriverDocumentRepository.class);
+  private final DriverProfileRepository drivers = mock(DriverProfileRepository.class);
+  private DriverDocumentService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new DriverDocumentService(documents, drivers, Clock.fixed(NOW, ZoneOffset.UTC));
+    context(TenantRole.DRIVER);
+    when(drivers.findByTenantIdAndAccountId(TENANT, ACCOUNT)).thenReturn(Optional.of(profile()));
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void driverSubmitsAndListsSafeMetadata() {
+    DriverDocument submitted = service.submit(DriverDocumentType.DRIVING_LICENSE, "license-42",
+        "drivers/42/license.pdf", LocalDate.parse("2026-08-08"));
+    assertEquals(DriverDocumentStatus.PENDING, submitted.verificationStatus());
+    assertEquals(LocalDate.parse("2026-08-08"), submitted.expiresOn());
+    verify(documents).insert(TENANT, submitted);
+    verify(documents).appendHistory(TENANT, submitted.id(), null, DriverDocumentStatus.PENDING,
+        ACCOUNT, null, NOW);
+
+    when(documents.findAll(TENANT, DRIVER)).thenReturn(List.of(submitted));
+    assertEquals(List.of(submitted), service.listOwn());
+  }
+
+  @Test
+  void rejectsUrlsAndTraversal() {
+    assertThrows(InvalidRequestException.class, () -> service.submit(
+        DriverDocumentType.DRIVING_LICENSE, "ref", "https://objects.example/license",
+        LocalDate.parse("2027-08-08")));
+    assertThrows(InvalidRequestException.class, () -> service.submit(
+        DriverDocumentType.DRIVING_LICENSE, "ref", "drivers/../secret",
+        LocalDate.parse("2027-08-08")));
+    assertThrows(InvalidRequestException.class, () -> service.submit(
+        DriverDocumentType.DRIVING_LICENSE, "https://provider.example/ref", "safe/key",
+        LocalDate.parse("2027-08-08")));
+  }
+
+  @Test
+  void requiresCurrentDrivingLicenseMetadata() {
+    assertThrows(InvalidRequestException.class, () -> service.submit(
+        DriverDocumentType.DRIVING_LICENSE, "license", "drivers/license", null));
+    assertThrows(InvalidRequestException.class, () -> service.submit(
+        DriverDocumentType.DRIVING_LICENSE, "license", "drivers/license",
+        LocalDate.parse("2026-08-07")));
+  }
+
+  @Test
+  void adminVerifiesOrRejectsPendingDocumentOnce() {
+    context(TenantRole.TENANT_ADMIN);
+    DriverDocument pending = document(DriverDocumentStatus.PENDING, null);
+    DriverDocument verified = reviewed(pending, DriverDocumentStatus.VERIFIED, null);
+    when(documents.find(TENANT, DRIVER, pending.id()))
+        .thenReturn(Optional.of(pending), Optional.of(verified));
+    when(documents.review(TENANT, DRIVER, pending.id(), DriverDocumentStatus.VERIFIED,
+        ACCOUNT, NOW, null, NOW)).thenReturn(true);
+    assertEquals(DriverDocumentStatus.VERIFIED,
+        service.verify(DRIVER, pending.id()).verificationStatus());
+
+    DriverDocument pendingRejection = document(DriverDocumentStatus.PENDING, null);
+    DriverDocument rejected = reviewed(pendingRejection, DriverDocumentStatus.REJECTED, "Unreadable");
+    when(documents.find(TENANT, DRIVER, pendingRejection.id()))
+        .thenReturn(Optional.of(pendingRejection), Optional.of(rejected));
+    when(documents.review(TENANT, DRIVER, pendingRejection.id(), DriverDocumentStatus.REJECTED,
+        ACCOUNT, null, "Unreadable", NOW)).thenReturn(true);
+    assertEquals("Unreadable",
+        service.reject(DRIVER, pendingRejection.id(), "Unreadable").rejectionReason());
+
+    when(documents.find(TENANT, DRIVER, pending.id())).thenReturn(Optional.of(pending));
+    when(documents.review(TENANT, DRIVER, pending.id(), DriverDocumentStatus.VERIFIED,
+        ACCOUNT, NOW, null, NOW)).thenReturn(false);
+    assertThrows(ConflictException.class, () -> service.verify(DRIVER, pending.id()));
+  }
+
+  @Test
+  void enforcesWorkflowRolesAndRejectionReason() {
+    assertThrows(TenantAccessDeniedException.class, () -> service.list(DRIVER));
+    context(TenantRole.TENANT_ADMIN);
+    assertThrows(InvalidRequestException.class,
+        () -> service.reject(DRIVER, UUID.randomUUID(), " "));
+  }
+
+  private DriverProfile profile() {
+    return new DriverProfile(DRIVER, ACCOUNT, "Driver", null, DriverStatus.PENDING, NOW, NOW);
+  }
+
+  private DriverDocument document(DriverDocumentStatus status, String reason) {
+    return new DriverDocument(UUID.randomUUID(), DRIVER, DriverDocumentType.DRIVING_LICENSE,
+        "license-42", "drivers/42/license.pdf", LocalDate.parse("2027-08-08"), status,
+        null, null, reason, NOW, NOW);
+  }
+
+  private DriverDocument reviewed(
+      DriverDocument document, DriverDocumentStatus status, String reason) {
+    return new DriverDocument(document.id(), document.driverId(), document.documentType(),
+        document.documentReference(), document.objectKey(), document.expiresOn(), status, ACCOUNT,
+        status == DriverDocumentStatus.VERIFIED ? NOW : null, reason, NOW, NOW);
+  }
+
+  private void context(TenantRole role) {
+    TenantContext.set(new TenantContext(TENANT, ACCOUNT, UUID.randomUUID(), Set.of(role)));
+  }
+}

--- a/src/test/java/in/rsh/cab/driver/DriverServiceTest.java
+++ b/src/test/java/in/rsh/cab/driver/DriverServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import in.rsh.cab.driver.internal.persistence.DriverProfileRepository;
+import in.rsh.cab.driver.internal.persistence.DriverDocumentRepository;
 import in.rsh.cab.exception.ConflictException;
 import in.rsh.cab.exception.NotFoundException;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
@@ -32,13 +33,14 @@ class DriverServiceTest {
   private static final UUID TENANT_ID = UUID.randomUUID();
   private static final UUID ACCOUNT_ID = UUID.randomUUID();
   private final DriverProfileRepository repository = mock(DriverProfileRepository.class);
+  private final DriverDocumentRepository documents = mock(DriverDocumentRepository.class);
   private final TenantService tenants = mock(TenantService.class);
   private DriverService service;
 
   @BeforeEach
   void setUp() {
     service = new DriverService(
-        repository, tenants,
+        repository, documents, tenants,
         Clock.fixed(Instant.parse("2026-08-08T10:00:00Z"), ZoneOffset.UTC));
     admin();
   }
@@ -58,8 +60,20 @@ class DriverServiceTest {
     when(repository.findAllByTenantId(TENANT_ID)).thenReturn(List.of(pending));
     assertEquals(List.of(pending), service.list());
     when(repository.findByTenantIdAndId(TENANT_ID, pending.id())).thenReturn(Optional.of(pending));
+    when(documents.hasVerifiedDrivingLicense(
+        TENANT_ID, pending.id(), java.time.LocalDate.parse("2026-08-08"))).thenReturn(true);
     when(repository.updateStatus(any(), any(), any(), any(), any())).thenReturn(true);
     assertEquals(DriverStatus.APPROVED, service.approve(pending.id()).status());
+  }
+
+  @Test
+  void approvalRequiresVerifiedLicenseThatHasNotExpired() {
+    DriverProfile pending = profile(DriverStatus.PENDING);
+    when(repository.findByTenantIdAndId(TENANT_ID, pending.id())).thenReturn(Optional.of(pending));
+
+    assertThrows(ConflictException.class, () -> service.approve(pending.id()));
+    verify(documents).hasVerifiedDrivingLicense(
+        TENANT_ID, pending.id(), java.time.LocalDate.parse("2026-08-08"));
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/in/rsh/cab/exception/GlobalExceptionHandlerTest.java
@@ -13,6 +13,7 @@ import in.rsh.cab.operations.IdempotencyConflictException;
 import in.rsh.cab.ratelimit.RateLimitExceededException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -125,6 +126,11 @@ class GlobalExceptionHandlerTest {
 
     assertProblem(
         response, HttpStatus.INTERNAL_SERVER_ERROR, "internal-error", "Unexpected error");
+  }
+
+  @Test
+  void ignoresDisconnectedStreamingClient() {
+    handler.handleDisconnectedClient();
   }
 
   private void assertProblem(

--- a/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
@@ -1,0 +1,105 @@
+package in.rsh.cab.ride;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.exception.ConflictException;
+import in.rsh.cab.exception.NotFoundException;
+import in.rsh.cab.geography.GeoPoint;
+import in.rsh.cab.ride.internal.persistence.RideRepository;
+import in.rsh.cab.tenancy.TenantAccessDeniedException;
+import in.rsh.cab.tenancy.TenantContext;
+import in.rsh.cab.tenancy.TenantRole;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class RideEventStreamTest {
+
+  private static final UUID TENANT = UUID.randomUUID();
+  private static final UUID ACCOUNT = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
+  private final RideRepository rides = mock(RideRepository.class);
+  private final SseEmitter emitter = mock(SseEmitter.class);
+  private final RideEventStream stream =
+      new RideEventStream(rides, Duration.ofMinutes(1), 1, 1, ignored -> emitter);
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+    TransactionSynchronizationManager.setActualTransactionActive(false);
+  }
+
+  @Test
+  void authorizesParticipantsAndStaffWithoutLeakingLocation() throws IOException {
+    Ride ride = ride();
+    context(TenantRole.RIDER);
+    when(rides.findOwn(TENANT, ACCOUNT, ride.id())).thenReturn(Optional.of(ride));
+    stream.subscribe(ride.id());
+    assertEquals(1, stream.subscriberCount(TENANT, ride.id()));
+
+    stream.publish(TENANT,
+        new RideEventStream.RideStatusEvent(ride.id(), RideStatus.DRIVER_ASSIGNED, 2, NOW));
+    verify(emitter, times(2))
+        .send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+    verify(rides, never()).findAssignedToDriver(TENANT, ACCOUNT, ride.id());
+
+    assertThrows(ConflictException.class, () -> stream.subscribe(ride.id()));
+  }
+
+  @Test
+  void deniesUnsupportedRolesAndHidesUnownedRides() {
+    Ride ride = ride();
+    context(TenantRole.FINANCE);
+    assertThrows(TenantAccessDeniedException.class, () -> stream.subscribe(ride.id()));
+
+    context(TenantRole.DRIVER);
+    assertThrows(NotFoundException.class, () -> stream.subscribe(ride.id()));
+  }
+
+  @Test
+  void publishesOnlyAfterTransactionCommit() throws IOException {
+    Ride ride = ride();
+    context(TenantRole.TENANT_ADMIN);
+    when(rides.find(TENANT, ride.id())).thenReturn(Optional.of(ride));
+    stream.subscribe(ride.id());
+    org.mockito.Mockito.clearInvocations(emitter);
+    TransactionSynchronizationManager.initSynchronization();
+    TransactionSynchronizationManager.setActualTransactionActive(true);
+
+    stream.afterCommit(TENANT, ride);
+    verify(emitter, never()).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+    TransactionSynchronization synchronization =
+        TransactionSynchronizationManager.getSynchronizations().get(0);
+    synchronization.afterCommit();
+    verify(emitter).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+    TransactionSynchronizationManager.setActualTransactionActive(false);
+  }
+
+  private Ride ride() {
+    return new Ride(UUID.randomUUID(), ACCOUNT, UUID.randomUUID(), UUID.randomUUID(),
+        new GeoPoint(12.95, 77.6), new GeoPoint(13.0, 77.65), 100, "USD",
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), RideStatus.DRIVER_ASSIGNED,
+        null, null, NOW, NOW, null, null, null, null, NOW, 2);
+  }
+
+  private void context(TenantRole role) {
+    TenantContext.set(new TenantContext(TENANT, ACCOUNT, UUID.randomUUID(), Set.of(role)));
+  }
+}

--- a/src/test/java/in/rsh/cab/ride/RideServiceTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideServiceTest.java
@@ -50,12 +50,13 @@ class RideServiceTest {
   private final OutboxService outbox = mock(OutboxService.class);
   private final AuditService audit = mock(AuditService.class);
   private final PaymentService payments = mock(PaymentService.class);
+  private final RideEventStream eventStream = mock(RideEventStream.class);
   private RideService service;
 
   @BeforeEach
   void setUp() {
     service = new RideService(rides, pricing, dispatch, fleet, idempotency, outbox, audit, payments,
-        new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC));
+        new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC), eventStream);
     context(TenantRole.RIDER);
     when(idempotency.reserve(any(), any(), any(), any(), any())).thenReturn(
         new IdempotencyReservation(IdempotencyReservation.Status.RESERVED,
@@ -82,6 +83,7 @@ class RideServiceTest {
     Ride cancelled = service.cancelOwn(created.id(), 0, "changed plans");
     assertEquals(RideStatus.CANCELLED, cancelled.status());
     verify(dispatch).cancelRide(TENANT, created.id(), NOW);
+    verify(eventStream).afterCommit(TENANT, cancelled);
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
@@ -23,10 +23,12 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -118,6 +120,8 @@ class MarketplaceHttpIT {
     JsonNode paths = openApi.get("paths");
     assertTrue(paths.has("/api/v1/tenants"));
     assertTrue(paths.has("/api/v1/rides"));
+    assertTrue(paths.has("/api/v1/rides/{id}/events"));
+    assertTrue(paths.has("/api/v1/drivers/me/documents"));
     assertTrue(paths.has("/api/v1/payment-providers/{provider}/accounts/{accountId}/events"));
     paths.propertyNames().forEach(path -> assertTrue(path.startsWith("/api/v1/"), path));
     assertTrue(openApi.get("components").get("securitySchemes").has("bearerAuth"));
@@ -198,6 +202,44 @@ class MarketplaceHttpIT {
                 + "\",\"legalName\":\"Admin Driver\",\"phoneNumber\":\"+1 555 0101\"}");
     assertEquals(201, driverCreated.statusCode());
     String driverId = JSON.readTree(driverCreated.body()).get("id").asText();
+    HttpResponse<String> expiredDocument =
+        postWithTenant(
+            "/api/v1/drivers/me/documents",
+            tenantId,
+            "{\"documentType\":\"DRIVING_LICENSE\",\"documentReference\":\"license-42\","
+                + "\"objectKey\":\"drivers/"
+                + driverId
+                + "/expired-license.pdf\",\"expiresOn\":\"2020-08-08\"}");
+    assertEquals(400, expiredDocument.statusCode(), expiredDocument.body());
+    assertEquals(
+        409, postWithTenant("/api/v1/drivers/" + driverId + "/approve", tenantId, "").statusCode());
+    String validExpiry = LocalDate.now().plusYears(2).toString();
+    HttpResponse<String> validDocumentCreated =
+        postWithTenant(
+            "/api/v1/drivers/me/documents",
+            tenantId,
+            "{\"documentType\":\"DRIVING_LICENSE\",\"documentReference\":\"license-43\","
+                + "\"objectKey\":\"drivers/"
+                + driverId
+                + "/license.pdf\",\"expiresOn\":\""
+                + validExpiry
+                + "\"}");
+    assertEquals(201, validDocumentCreated.statusCode(), validDocumentCreated.body());
+    String validDocumentId = JSON.readTree(validDocumentCreated.body()).get("id").asText();
+    assertEquals(
+        1,
+        JSON.readTree(
+                getWithTenant(
+                        "/api/v1/drivers/" + driverId + "/documents", tenantId, "platform-admin")
+                    .body())
+            .size());
+    assertEquals(
+        200,
+        postWithTenant(
+                "/api/v1/drivers/" + driverId + "/documents/" + validDocumentId + "/verify",
+                tenantId,
+                "")
+            .statusCode());
     assertEquals(
         200, postWithTenant("/api/v1/drivers/" + driverId + "/approve", tenantId, "").statusCode());
     assertEquals(
@@ -400,10 +442,49 @@ class MarketplaceHttpIT {
             .body());
     assertEquals(
         1, JSON.readTree(getWithTenant("/api/v1/rides", tenantId, "platform-admin").body()).size());
+    assertEquals(
+        404,
+        httpClient
+            .send(
+                tenantGetRequest(
+                    "/api/v1/rides/" + UUID.randomUUID() + "/events",
+                    tenantId,
+                    "platform-admin",
+                    MediaType.TEXT_EVENT_STREAM_VALUE),
+                HttpResponse.BodyHandlers.ofString())
+            .statusCode());
+    assertEquals(
+        403,
+        httpClient
+            .send(
+                tenantGetRequest(
+                    "/api/v1/rides/" + rideId + "/events",
+                    tenantId,
+                    "unknown-user",
+                    MediaType.TEXT_EVENT_STREAM_VALUE),
+                HttpResponse.BodyHandlers.ofString())
+            .statusCode());
+    HttpRequest eventRequest =
+        HttpRequest.newBuilder(uri("/api/v1/rides/" + rideId + "/events"))
+            .header("Accept", MediaType.TEXT_EVENT_STREAM_VALUE)
+            .header("Authorization", "Bearer platform-admin")
+            .header("X-Tenant-ID", tenantId)
+            .GET()
+            .build();
+    CompletableFuture<HttpResponse<java.util.stream.Stream<String>>> eventResponse =
+        httpClient.sendAsync(eventRequest, HttpResponse.BodyHandlers.ofLines());
+    HttpResponse<java.util.stream.Stream<String>> streamResponse =
+        eventResponse.get(5, TimeUnit.SECONDS);
+    assertEquals(200, streamResponse.statusCode());
 
     HttpResponse<String> offersCreated =
         postWithTenant("/api/v1/dispatch/rides/" + rideId + "/start", tenantId, "{\"version\":0}");
     assertEquals(200, offersCreated.statusCode(), offersCreated.body());
+    String statusEvent =
+        streamResponse.body().filter(line -> line.contains("MATCHING")).findFirst().orElseThrow();
+    assertTrue(statusEvent.contains("rideId"));
+    assertFalse(statusEvent.contains("latitude"));
+    streamResponse.body().close();
     JsonNode offers = JSON.readTree(offersCreated.body());
     assertEquals(1, offers.size());
     String offerId = offers.get(0).get("id").asText();
@@ -591,7 +672,7 @@ class MarketplaceHttpIT {
   @Test
   void databaseRoleEnforcesTransactionLocalTenantIsolation() {
     assertEquals(
-        41,
+        42,
         jdbc.sql(
                 """
                 SELECT count(*)
@@ -851,6 +932,15 @@ class MarketplaceHttpIT {
             .GET()
             .build();
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpRequest tenantGetRequest(String path, String tenantId, String token, String accept) {
+    return HttpRequest.newBuilder(uri(path))
+        .header("Accept", accept)
+        .header("Authorization", "Bearer " + token)
+        .header("X-Tenant-ID", tenantId)
+        .GET()
+        .build();
   }
 
   private URI uri(String path) {


### PR DESCRIPTION
## Summary
- Delivers `feat(drivers): add compliance documents and ride events` as part 16 of 26 in the production marketplace stack.
- Contains 27 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/113`
- Head: `stack/16-compliance-events`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.