### PR TITLE
feat(operations): run fenced outbox delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Read the operations runbooks before deployment:
 - [Incident response and rollback](docs/runbooks/incident-rollback.md)
 - [OSRM data preparation](docs/runbooks/osrm-data.md)
 
+The embedded outbox dispatcher is enabled by default. Every replica polls active tenants, while
+PostgreSQL `SKIP LOCKED` leases and UUID fencing tokens ensure one coordinator owns an event or
+delivery attempt at a time. Payment, notification, and webhook consumers run synchronously before
+the outbox event is acknowledged; replay is at-least-once and relies on stable provider idempotency
+keys plus unique delivery constraints. Configure cadence, batch sizes, leases, retry limits, and
+backoff with the `OUTBOX_DISPATCHER_*`, `NOTIFICATION_*`, and `WEBHOOK_*` environment variables in
+`application.properties`. Disable it only for maintenance with `OUTBOX_DISPATCHER_ENABLED=false`.
+
 ## API
 
 The HTTP API is versioned under `/api/v1`:

--- a/deploy/helm/cab-marketplace/templates/configmap.yaml
+++ b/deploy/helm/cab-marketplace/templates/configmap.yaml
@@ -16,3 +16,4 @@ data:
   FLYWAY_ENABLED: {{ .Values.config.flywayEnabled | quote }}
   API_DOCS_ENABLED: {{ .Values.config.apiDocsEnabled | quote }}
   SWAGGER_UI_ENABLED: {{ .Values.config.swaggerUiEnabled | quote }}
+  OUTBOX_DISPATCHER_ENABLED: {{ .Values.config.outboxDispatcherEnabled | quote }}

--- a/deploy/helm/cab-marketplace/values.yaml
+++ b/deploy/helm/cab-marketplace/values.yaml
@@ -59,6 +59,7 @@ config:
   flywayEnabled: "true"
   apiDocsEnabled: "false"
   swaggerUiEnabled: "false"
+  outboxDispatcherEnabled: "true"
 
 # Create this Secret outside Helm. This chart never stores credential values.
 existingSecret:

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -18,6 +18,19 @@
 5. Exercise an authenticated read and a low-risk write using a synthetic tenant.
 6. Scale out or enable HPA only after the first pod is ready and Flyway has completed.
 
+## Outbox Operations
+
+The API process also runs the outbox dispatcher. It polls active tenant IDs from the control plane,
+then enters tenant-qualified transactions for all RLS-protected data. Outbox, notification, and
+webhook rows use expiring UUID-fenced leases, so replicas can safely compete and recover work after
+a crash. Provider calls happen outside database transactions; completion is rejected if the lease
+has since been reassigned.
+
+Delivery is at-least-once. Payment calls use stable operation idempotency keys, and notification and
+webhook providers must deduplicate by their stable delivery IDs. Alert on increasing `FAILED` rows,
+old `PENDING`/`RETRY` rows, exhausted outbox attempts, and repeated provider-unavailable errors.
+`OUTBOX_DISPATCHER_ENABLED=false` pauses new dispatch without deleting durable work.
+
 The chart deploys the API only. Treat PostgreSQL, Redis, Keycloak/OIDC, OSRM, MinIO/S3, ingress,
 certificates, and monitoring as separately managed production services.
 

--- a/src/main/java/in/rsh/cab/CabApplication.java
+++ b/src/main/java/in/rsh/cab/CabApplication.java
@@ -2,8 +2,10 @@ package in.rsh.cab;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CabApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/in/rsh/cab/notification/NotificationDeliveryWorker.java
+++ b/src/main/java/in/rsh/cab/notification/NotificationDeliveryWorker.java
@@ -2,7 +2,6 @@ package in.rsh.cab.notification;
 
 import in.rsh.cab.notification.internal.persistence.NotificationRepository;
 import in.rsh.cab.notification.internal.persistence.NotificationRepository.Delivery;
-import in.rsh.cab.operations.InboxService;
 import in.rsh.cab.operations.OutboxEvent;
 import in.rsh.cab.tenancy.TenantExecution;
 import java.time.Clock;
@@ -18,26 +17,30 @@ import org.springframework.stereotype.Service;
 public class NotificationDeliveryWorker {
 
   private final NotificationRepository notifications;
-  private final InboxService inbox;
   private final Map<String, NotificationProvider> providers;
   private final TenantExecution tenantExecution;
   private final Clock clock;
+  private final java.time.Duration leaseDuration;
+  private final int maxAttempts;
 
   public NotificationDeliveryWorker(
-      NotificationRepository notifications, InboxService inbox, List<NotificationProvider> providers,
-      TenantExecution tenantExecution, Clock clock) {
+      NotificationRepository notifications, List<NotificationProvider> providers,
+      TenantExecution tenantExecution, Clock clock,
+      @org.springframework.beans.factory.annotation.Value("${notifications.lease-duration:PT30S}")
+      java.time.Duration leaseDuration,
+      @org.springframework.beans.factory.annotation.Value("${notifications.max-attempts:6}")
+      int maxAttempts) {
     this.notifications = notifications;
-    this.inbox = inbox;
     this.providers = providers.stream().collect(Collectors.toUnmodifiableMap(
         NotificationProvider::channel, Function.identity()));
     this.tenantExecution = tenantExecution;
     this.clock = clock;
+    this.leaseDuration = leaseDuration;
+    this.maxAttempts = maxAttempts;
   }
 
   public boolean process(OutboxEvent event, UUID recipientId, String channel,
       String templateKey, int templateVersion, String body) {
-    String consumer = "notification:" + recipientId + ":" + channel + ":" + templateKey
-        + ":" + templateVersion;
     Instant now = clock.instant();
     boolean bypass = event.eventType().startsWith("safety.")
         || event.eventType().startsWith("payment.")
@@ -48,39 +51,61 @@ public class NotificationDeliveryWorker {
     Delivery delivery = tenantExecution.inTransaction(event.tenantId(),
         () -> notifications.getOrCreateDelivery(UUID.randomUUID(), event.tenantId(),
             recipientId, event.id(), event.eventType(), channel, templateKey, templateVersion,
-            enabled ? "PENDING" : "SKIPPED", now));
+            body, enabled ? "PENDING" : "SKIPPED", now));
     if (!enabled) {
-      tenantExecution.inTransaction(
-          event.tenantId(), () -> inbox.receive(event.tenantId(), consumer, event.id()));
       return false;
     }
-    if (!tenantExecution.inTransaction(event.tenantId(),
-        () -> notifications.claimDelivery(event.tenantId(), delivery.id()))) {
+    UUID leaseToken = UUID.randomUUID();
+    Delivery claimed = tenantExecution.inTransaction(event.tenantId(),
+        () -> notifications.claimDelivery(event.tenantId(), delivery.id(), now,
+            now.plus(leaseDuration), leaseToken).orElse(null));
+    if (claimed == null) {
       return false;
     }
+    return deliver(claimed);
+  }
+
+  public int retryDue(UUID tenantId, int limit) {
+    if (limit < 1 || limit > 200) {
+      throw new IllegalArgumentException("Notification retry limit must be between 1 and 200");
+    }
+    Instant now = clock.instant();
+    List<Delivery> due = tenantExecution.inTransaction(tenantId,
+        () -> notifications.claimDue(tenantId, limit, now, now.plus(leaseDuration),
+            UUID.randomUUID()));
+    int delivered = 0;
+    for (Delivery delivery : due) {
+      if (deliver(delivery)) {
+        delivered++;
+      }
+    }
+    return delivered;
+  }
+
+  private boolean deliver(Delivery delivery) {
     UUID deliveryId = delivery.id();
     int attempt = delivery.attempts() + 1;
+    String channel = delivery.channel();
     NotificationProvider provider = providers.get(channel);
     if (provider == null) {
       throw new IllegalStateException("Notification provider is not configured: " + channel);
     }
     try {
       String providerId = provider.send(new NotificationProvider.Message(deliveryId,
-          event.tenantId(), recipientId, event.eventType(), templateKey, templateVersion, body));
-      tenantExecution.inTransaction(event.tenantId(), () -> {
-        notifications.insertAttempt(event.tenantId(), deliveryId, attempt, "SUCCEEDED", providerId,
-            null, clock.instant());
-        notifications.markDelivery(event.tenantId(), deliveryId, "DELIVERED", clock.instant());
-        inbox.receive(event.tenantId(), consumer, event.id());
-      });
+          delivery.tenantId(), delivery.recipientId(), delivery.eventType(), delivery.templateKey(),
+          delivery.templateVersion(), delivery.body()));
+      tenantExecution.inTransaction(delivery.tenantId(), () -> notifications.complete(
+          delivery.tenantId(), deliveryId, delivery.leaseToken(), attempt, providerId,
+          clock.instant()));
       return true;
     } catch (RuntimeException exception) {
-      tenantExecution.inTransaction(event.tenantId(), () -> {
-        notifications.insertAttempt(event.tenantId(), deliveryId, attempt, "FAILED", null,
-            "PROVIDER_UNAVAILABLE", clock.instant());
-        notifications.markDelivery(event.tenantId(), deliveryId, "FAILED", null);
-      });
-      throw exception;
+      Instant now = clock.instant();
+      boolean failed = attempt >= maxAttempts;
+      long delaySeconds = Math.min(3600, 1L << Math.min(attempt, 12));
+      tenantExecution.inTransaction(delivery.tenantId(), () -> notifications.retry(
+          delivery.tenantId(), deliveryId, delivery.leaseToken(), attempt, "PROVIDER_UNAVAILABLE",
+          now.plusSeconds(delaySeconds), failed, now));
+      return false;
     }
   }
 }

--- a/src/main/java/in/rsh/cab/notification/NotificationProvider.java
+++ b/src/main/java/in/rsh/cab/notification/NotificationProvider.java
@@ -8,6 +8,8 @@ public interface NotificationProvider {
 
   String send(Message message);
 
+  // Providers must deduplicate retries by the stable deliveryId.
+
   record Message(
       UUID deliveryId,
       UUID tenantId,

--- a/src/main/java/in/rsh/cab/notification/NotificationRecipientResolver.java
+++ b/src/main/java/in/rsh/cab/notification/NotificationRecipientResolver.java
@@ -1,0 +1,52 @@
+package in.rsh.cab.notification;
+
+import in.rsh.cab.operations.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationRecipientResolver {
+
+  private final JdbcClient jdbc;
+
+  public NotificationRecipientResolver(JdbcClient jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  public List<UUID> resolve(OutboxEvent event) {
+    if (event.eventType().startsWith("ride.")) {
+      return jdbc.sql("""
+              SELECT recipient_id FROM (
+                SELECT ride.rider_account_id recipient_id
+                FROM rides ride
+                WHERE ride.tenant_id = :tenantId AND ride.id = :rideId
+                UNION
+                SELECT driver.account_id recipient_id
+                FROM rides ride JOIN driver_profiles driver
+                  ON driver.tenant_id = ride.tenant_id AND driver.id = ride.driver_id
+                WHERE ride.tenant_id = :tenantId AND ride.id = :rideId
+              ) recipients ORDER BY recipient_id
+              """)
+          .param("tenantId", event.tenantId()).param("rideId", event.aggregateId())
+          .query(UUID.class).list();
+    }
+    if (event.eventType().startsWith("payment.")) {
+      String sql = "refund".equals(event.aggregateType())
+          ? """
+              SELECT payment.rider_account_id
+              FROM refunds refund JOIN payments payment
+                ON payment.tenant_id = refund.tenant_id AND payment.id = refund.payment_id
+              WHERE refund.tenant_id = :tenantId AND refund.id = :aggregateId
+              """
+          : """
+              SELECT rider_account_id FROM payments
+              WHERE tenant_id = :tenantId AND id = :aggregateId
+              """;
+      return jdbc.sql(sql).param("tenantId", event.tenantId())
+          .param("aggregateId", event.aggregateId()).query(UUID.class).list();
+    }
+    return List.of();
+  }
+}

--- a/src/main/java/in/rsh/cab/notification/internal/persistence/JdbcNotificationRepository.java
+++ b/src/main/java/in/rsh/cab/notification/internal/persistence/JdbcNotificationRepository.java
@@ -4,6 +4,7 @@ import in.rsh.cab.notification.NotificationPreference;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
@@ -64,47 +65,50 @@ public class JdbcNotificationRepository implements NotificationRepository {
   @Override
   public Delivery getOrCreateDelivery(
       UUID id, UUID tenantId, UUID recipientId, UUID eventId, String eventType, String channel,
-      String templateKey, int templateVersion, String status, Instant now) {
+      String templateKey, int templateVersion, String body, String status, Instant now) {
     jdbc.sql("""
             INSERT INTO notification_deliveries
               (id, tenant_id, recipient_account_id, event_id, event_type, channel,
-               template_key, template_version, status, created_at)
-            VALUES (:id, :tenantId, :recipientId, :eventId, :eventType, :channel,
-                    :templateKey, :templateVersion, :status, :now)
+               template_key, template_version, body, status, next_attempt_at, created_at)
+             VALUES (:id, :tenantId, :recipientId, :eventId, :eventType, :channel,
+                     :templateKey, :templateVersion, :body, :status, :now, :now)
             ON CONFLICT (tenant_id, recipient_account_id, event_id, channel,
                          template_key, template_version) DO NOTHING
             """)
         .param("id", id).param("tenantId", tenantId).param("recipientId", recipientId)
         .param("eventId", eventId).param("eventType", eventType).param("channel", channel)
         .param("templateKey", templateKey).param("templateVersion", templateVersion)
-        .param("status", status).param("now", Timestamp.from(now)).update();
+        .param("body", body).param("status", status).param("now", Timestamp.from(now)).update();
     return jdbc.sql("""
-            SELECT d.id, d.status, count(a.id) attempts
+            SELECT d.id, d.tenant_id, d.recipient_account_id, d.event_id, d.event_type,
+                   d.channel, d.template_key, d.template_version, d.body, d.status,
+                   count(a.id) attempts, d.lease_token
             FROM notification_deliveries d LEFT JOIN notification_attempts a
               ON a.tenant_id = d.tenant_id AND a.delivery_id = d.id
             WHERE d.tenant_id = :tenantId AND d.recipient_account_id = :recipientId
               AND d.event_id = :eventId AND d.channel = :channel
               AND d.template_key = :templateKey AND d.template_version = :templateVersion
-            GROUP BY d.id, d.status
+            GROUP BY d.id
             """)
         .param("tenantId", tenantId).param("recipientId", recipientId).param("eventId", eventId)
         .param("channel", channel).param("templateKey", templateKey)
         .param("templateVersion", templateVersion)
-        .query((rs, row) -> new Delivery(rs.getObject("id", UUID.class), rs.getString("status"),
-            rs.getInt("attempts"))).single();
+        .query(this::mapDelivery).single();
   }
 
   @Override
-  public boolean claimDelivery(UUID tenantId, UUID deliveryId) {
-    return jdbc.sql("""
-            UPDATE notification_deliveries SET status = 'PROCESSING'
-            WHERE tenant_id = :tenantId AND id = :id AND status IN ('PENDING', 'FAILED')
-            """)
-        .param("tenantId", tenantId).param("id", deliveryId).update() == 1;
+  public Optional<Delivery> claimDelivery(
+      UUID tenantId, UUID deliveryId, Instant now, Instant leaseExpiresAt, UUID leaseToken) {
+    return claim(tenantId, deliveryId, null, now, leaseExpiresAt, leaseToken).stream().findFirst();
   }
 
   @Override
-  public void insertAttempt(UUID tenantId, UUID deliveryId, int number, String status,
+  public List<Delivery> claimDue(
+      UUID tenantId, int limit, Instant now, Instant leaseExpiresAt, UUID leaseToken) {
+    return claim(tenantId, null, limit, now, leaseExpiresAt, leaseToken);
+  }
+
+  private void insertAttempt(UUID tenantId, UUID deliveryId, int number, String status,
       String providerMessageId, String errorCode, Instant now) {
     jdbc.sql("""
             INSERT INTO notification_attempts
@@ -118,12 +122,83 @@ public class JdbcNotificationRepository implements NotificationRepository {
   }
 
   @Override
-  public void markDelivery(UUID tenantId, UUID deliveryId, String status, Instant deliveredAt) {
-    jdbc.sql("""
-            UPDATE notification_deliveries SET status = :status, delivered_at = :deliveredAt
-            WHERE tenant_id = :tenantId AND id = :id
+  public void complete(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber,
+      String providerMessageId, Instant now) {
+    requireClaim(jdbc.sql("""
+            UPDATE notification_deliveries
+            SET status = 'DELIVERED', delivered_at = :now, lease_token = NULL,
+                lease_started_at = NULL, lease_expires_at = NULL
+            WHERE tenant_id = :tenantId AND id = :id AND status = 'PROCESSING'
+              AND lease_token = :leaseToken
             """)
-        .param("status", status).param("deliveredAt", deliveredAt == null ? null : Timestamp.from(deliveredAt))
-        .param("tenantId", tenantId).param("id", deliveryId).update();
+        .param("now", Timestamp.from(now)).param("tenantId", tenantId).param("id", deliveryId)
+        .param("leaseToken", leaseToken).update());
+    insertAttempt(tenantId, deliveryId, attemptNumber, "SUCCEEDED", providerMessageId, null, now);
+  }
+
+  @Override
+  public void retry(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber,
+      String errorCode, Instant nextAttemptAt, boolean failed, Instant now) {
+    requireClaim(jdbc.sql("""
+            UPDATE notification_deliveries
+            SET status = :status, next_attempt_at = :nextAttemptAt, lease_token = NULL,
+                lease_started_at = NULL, lease_expires_at = NULL
+            WHERE tenant_id = :tenantId AND id = :id AND status = 'PROCESSING'
+              AND lease_token = :leaseToken
+            """)
+        .param("status", failed ? "FAILED" : "RETRY")
+        .param("nextAttemptAt", Timestamp.from(nextAttemptAt)).param("tenantId", tenantId)
+        .param("id", deliveryId).param("leaseToken", leaseToken).update());
+    insertAttempt(tenantId, deliveryId, attemptNumber, "FAILED", null, errorCode, now);
+  }
+
+  private List<Delivery> claim(
+      UUID tenantId, UUID deliveryId, Integer limit, Instant now, Instant leaseExpiresAt,
+      UUID leaseToken) {
+    return jdbc.sql("""
+            WITH candidates AS (
+              SELECT id FROM notification_deliveries
+              WHERE tenant_id = :tenantId
+                AND (:deliveryId IS NULL OR id = :deliveryId)
+                AND next_attempt_at <= :now
+                AND (status IN ('PENDING', 'RETRY')
+                  OR (status = 'PROCESSING' AND lease_expires_at <= :now))
+              ORDER BY next_attempt_at, id
+              FOR UPDATE SKIP LOCKED
+              LIMIT :limit
+            )
+            UPDATE notification_deliveries delivery
+            SET status = 'PROCESSING', lease_token = :leaseToken,
+                lease_started_at = :now, lease_expires_at = :leaseExpiresAt
+            FROM candidates
+            WHERE delivery.tenant_id = :tenantId AND delivery.id = candidates.id
+            RETURNING delivery.id, delivery.tenant_id, delivery.recipient_account_id,
+              delivery.event_id, delivery.event_type, delivery.channel, delivery.template_key,
+              delivery.template_version, delivery.body, delivery.status,
+              (SELECT count(*) FROM notification_attempts attempt
+                WHERE attempt.tenant_id = delivery.tenant_id
+                  AND attempt.delivery_id = delivery.id) attempts,
+              delivery.lease_token
+            """)
+        .param("tenantId", tenantId).param("deliveryId", deliveryId)
+        .param("now", Timestamp.from(now)).param("leaseExpiresAt", Timestamp.from(leaseExpiresAt))
+        .param("leaseToken", leaseToken).param("limit", limit == null ? 1 : limit)
+        .query(this::mapDelivery).list();
+  }
+
+  private Delivery mapDelivery(java.sql.ResultSet rs, int row) throws java.sql.SQLException {
+    return new Delivery(rs.getObject("id", UUID.class), rs.getObject("tenant_id", UUID.class),
+        rs.getObject("recipient_account_id", UUID.class), rs.getObject("event_id", UUID.class),
+        rs.getString("event_type"), rs.getString("channel"), rs.getString("template_key"),
+        rs.getInt("template_version"), rs.getString("body"), rs.getString("status"),
+        rs.getInt("attempts"), rs.getObject("lease_token", UUID.class));
+  }
+
+  private void requireClaim(int updated) {
+    if (updated != 1) {
+      throw new IllegalStateException("Notification delivery lease is no longer owned");
+    }
   }
 }

--- a/src/main/java/in/rsh/cab/notification/internal/persistence/NotificationRepository.java
+++ b/src/main/java/in/rsh/cab/notification/internal/persistence/NotificationRepository.java
@@ -3,6 +3,7 @@ package in.rsh.cab.notification.internal.persistence;
 import in.rsh.cab.notification.NotificationPreference;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface NotificationRepository {
@@ -15,14 +16,24 @@ public interface NotificationRepository {
   boolean preferenceEnabled(UUID tenantId, UUID recipientId, String eventType, String channel);
 
   Delivery getOrCreateDelivery(UUID id, UUID tenantId, UUID recipientId, UUID eventId, String eventType,
-      String channel, String templateKey, int templateVersion, String status, Instant now);
+      String channel, String templateKey, int templateVersion, String body, String status, Instant now);
 
-  boolean claimDelivery(UUID tenantId, UUID deliveryId);
+  Optional<Delivery> claimDelivery(
+      UUID tenantId, UUID deliveryId, Instant now, Instant leaseExpiresAt, UUID leaseToken);
 
-  void insertAttempt(UUID tenantId, UUID deliveryId, int number, String status,
-      String providerMessageId, String errorCode, Instant now);
+  List<Delivery> claimDue(
+      UUID tenantId, int limit, Instant now, Instant leaseExpiresAt, UUID leaseToken);
 
-  void markDelivery(UUID tenantId, UUID deliveryId, String status, Instant deliveredAt);
+  void complete(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber,
+      String providerMessageId, Instant now);
 
-  record Delivery(UUID id, String status, int attempts) {}
+  void retry(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber,
+      String errorCode, Instant nextAttemptAt, boolean failed, Instant now);
+
+  record Delivery(
+      UUID id, UUID tenantId, UUID recipientId, UUID eventId, String eventType, String channel,
+      String templateKey, int templateVersion, String body, String status, int attempts,
+      UUID leaseToken) {}
 }

--- a/src/main/java/in/rsh/cab/operations/NotificationOutboxConsumer.java
+++ b/src/main/java/in/rsh/cab/operations/NotificationOutboxConsumer.java
@@ -1,0 +1,37 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.notification.NotificationDeliveryWorker;
+import in.rsh.cab.notification.NotificationRecipientResolver;
+import in.rsh.cab.tenancy.TenantExecution;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(30)
+public class NotificationOutboxConsumer implements OutboxConsumer {
+
+  private final NotificationRecipientResolver recipients;
+  private final NotificationDeliveryWorker worker;
+  private final TenantExecution tenantExecution;
+
+  public NotificationOutboxConsumer(
+      NotificationRecipientResolver recipients, NotificationDeliveryWorker worker,
+      TenantExecution tenantExecution) {
+    this.recipients = recipients;
+    this.worker = worker;
+    this.tenantExecution = tenantExecution;
+  }
+
+  @Override
+  public boolean process(OutboxEvent event) {
+    List<UUID> routed = tenantExecution.inTransaction(
+        event.tenantId(), () -> recipients.resolve(event));
+    String template = event.eventType().replace('.', '_');
+    for (UUID recipient : routed) {
+      worker.process(event, recipient, "LOCAL", template, event.eventVersion(), event.eventType());
+    }
+    return !routed.isEmpty();
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/OutboxConsumer.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxConsumer.java
@@ -1,0 +1,6 @@
+package in.rsh.cab.operations;
+
+public interface OutboxConsumer {
+
+  boolean process(OutboxEvent event);
+}

--- a/src/main/java/in/rsh/cab/operations/OutboxDispatcher.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxDispatcher.java
@@ -1,0 +1,116 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.notification.NotificationDeliveryWorker;
+import in.rsh.cab.tenancy.internal.persistence.TenantRepository;
+import in.rsh.cab.webhook.WebhookDeliveryWorker;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "outbox.dispatcher.enabled", matchIfMissing = true)
+public class OutboxDispatcher {
+
+  private static final Logger log = LoggerFactory.getLogger(OutboxDispatcher.class);
+  private final OutboxPoller poller;
+  private final TenantRepository tenants;
+  private final List<OutboxConsumer> consumers;
+  private final NotificationDeliveryWorker notifications;
+  private final WebhookDeliveryWorker webhooks;
+  private final Clock clock;
+  private final int batchSize;
+  private final int deliveryBatchSize;
+  private final int maxAttempts;
+  private final Duration leaseDuration;
+  private final Duration initialBackoff;
+  private final Duration maxBackoff;
+
+  public OutboxDispatcher(
+      OutboxPoller poller, TenantRepository tenants, List<OutboxConsumer> consumers,
+      NotificationDeliveryWorker notifications, WebhookDeliveryWorker webhooks, Clock clock,
+      @Value("${outbox.dispatcher.batch-size:50}") int batchSize,
+      @Value("${outbox.dispatcher.delivery-batch-size:50}") int deliveryBatchSize,
+      @Value("${outbox.dispatcher.max-attempts:10}") int maxAttempts,
+      @Value("${outbox.dispatcher.lease-duration:PT1M}") Duration leaseDuration,
+      @Value("${outbox.dispatcher.initial-backoff:PT2S}") Duration initialBackoff,
+      @Value("${outbox.dispatcher.max-backoff:PT5M}") Duration maxBackoff) {
+    this.poller = poller;
+    this.tenants = tenants;
+    this.consumers = consumers;
+    this.notifications = notifications;
+    this.webhooks = webhooks;
+    this.clock = clock;
+    this.batchSize = batchSize;
+    this.deliveryBatchSize = deliveryBatchSize;
+    this.maxAttempts = maxAttempts;
+    this.leaseDuration = leaseDuration;
+    this.initialBackoff = initialBackoff;
+    this.maxBackoff = maxBackoff;
+  }
+
+  @Scheduled(fixedDelayString = "${outbox.dispatcher.fixed-delay:1000}")
+  public void dispatch() {
+    for (UUID tenantId : tenants.findActiveIds()) {
+      try {
+        recoverDeliveries(tenantId);
+        for (OutboxEvent event : poller.lease(tenantId, batchSize, leaseDuration)) {
+          process(event);
+        }
+      } catch (RuntimeException exception) {
+        log.warn("Outbox dispatch cycle failed for tenant={}", tenantId, exception);
+      }
+    }
+  }
+
+  private void recoverDeliveries(UUID tenantId) {
+    try {
+      notifications.retryDue(tenantId, deliveryBatchSize);
+    } catch (RuntimeException exception) {
+      log.warn("Notification recovery failed for tenant={}", tenantId, exception);
+    }
+    try {
+      webhooks.retryDue(tenantId, deliveryBatchSize);
+    } catch (RuntimeException exception) {
+      log.warn("Webhook recovery failed for tenant={}", tenantId, exception);
+    }
+  }
+
+  void process(OutboxEvent event) {
+    try {
+      for (OutboxConsumer consumer : consumers) {
+        consumer.process(event);
+      }
+      poller.published(event);
+    } catch (RuntimeException exception) {
+      try {
+        if (event.attempts() >= maxAttempts) {
+          poller.failed(event, exception.getMessage());
+        } else {
+          poller.retry(event, clock.instant().plus(backoff(event.attempts())),
+              exception.getMessage());
+        }
+      } catch (IllegalStateException leaseLost) {
+        log.info("Outbox lease lost before failure was recorded event={}", event.id());
+      }
+    }
+  }
+
+  private Duration backoff(int attempts) {
+    long multiplier = 1L << Math.min(Math.max(attempts - 1, 0), 20);
+    Duration delay;
+    try {
+      delay = initialBackoff.multipliedBy(multiplier);
+    } catch (ArithmeticException exception) {
+      delay = maxBackoff;
+    }
+    return delay.compareTo(maxBackoff) > 0 ? maxBackoff : delay;
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/OutboxEvent.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxEvent.java
@@ -16,4 +16,5 @@ public record OutboxEvent(
     Instant occurredAt,
     String correlationId,
     UUID causationId,
-    int attempts) {}
+    int attempts,
+    UUID leaseToken) {}

--- a/src/main/java/in/rsh/cab/operations/OutboxPoller.java
+++ b/src/main/java/in/rsh/cab/operations/OutboxPoller.java
@@ -28,22 +28,28 @@ public class OutboxPoller {
     }
     Instant now = clock.instant();
     return tenantExecution.inTransaction(
-        tenantId, () -> events.lease(tenantId, limit, now, now.plus(leaseDuration)));
+        tenantId,
+        () -> events.lease(tenantId, limit, now, now.plus(leaseDuration), UUID.randomUUID()));
   }
 
-  public void published(UUID tenantId, UUID eventId) {
+  public void published(OutboxEvent event) {
     tenantExecution.inTransaction(
-        tenantId, () -> events.markPublished(tenantId, eventId, clock.instant()));
+        event.tenantId(),
+        () -> events.markPublished(event.tenantId(), event.id(), event.leaseToken(), clock.instant()));
   }
 
-  public void retry(UUID tenantId, UUID eventId, Instant availableAt, String error) {
+  public void retry(OutboxEvent event, Instant availableAt, String error) {
     tenantExecution.inTransaction(
-        tenantId, () -> events.markRetry(tenantId, eventId, availableAt, sanitizeError(error)));
+        event.tenantId(),
+        () -> events.markRetry(event.tenantId(), event.id(), event.leaseToken(), availableAt,
+            sanitizeError(error)));
   }
 
-  public void failed(UUID tenantId, UUID eventId, String error) {
+  public void failed(OutboxEvent event, String error) {
     tenantExecution.inTransaction(
-        tenantId, () -> events.markFailed(tenantId, eventId, sanitizeError(error)));
+        event.tenantId(),
+        () -> events.markFailed(event.tenantId(), event.id(), event.leaseToken(),
+            sanitizeError(error)));
   }
 
   private String sanitizeError(String error) {

--- a/src/main/java/in/rsh/cab/operations/PaymentOutboxConsumer.java
+++ b/src/main/java/in/rsh/cab/operations/PaymentOutboxConsumer.java
@@ -1,0 +1,21 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.payment.PaymentOperationWorker;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(10)
+public class PaymentOutboxConsumer implements OutboxConsumer {
+
+  private final PaymentOperationWorker worker;
+
+  public PaymentOutboxConsumer(PaymentOperationWorker worker) {
+    this.worker = worker;
+  }
+
+  @Override
+  public boolean process(OutboxEvent event) {
+    return worker.process(event);
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/WebhookOutboxConsumer.java
+++ b/src/main/java/in/rsh/cab/operations/WebhookOutboxConsumer.java
@@ -1,0 +1,26 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.webhook.WebhookDeliveryWorker;
+import in.rsh.cab.webhook.WebhookService;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(20)
+public class WebhookOutboxConsumer implements OutboxConsumer {
+
+  private final WebhookDeliveryWorker worker;
+
+  public WebhookOutboxConsumer(WebhookDeliveryWorker worker) {
+    this.worker = worker;
+  }
+
+  @Override
+  public boolean process(OutboxEvent event) {
+    if (!WebhookService.EVENT_ALLOWLIST.contains(event.eventType())) {
+      return false;
+    }
+    worker.process(event);
+    return true;
+  }
+}

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcOutboxRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/JdbcOutboxRepository.java
@@ -48,7 +48,8 @@ public class JdbcOutboxRepository implements OutboxRepository {
   }
 
   @Override
-  public List<OutboxEvent> lease(UUID tenantId, int limit, Instant now, Instant leaseExpiresAt) {
+  public List<OutboxEvent> lease(
+      UUID tenantId, int limit, Instant now, Instant leaseExpiresAt, UUID leaseToken) {
     return jdbc.sql("""
             WITH candidates AS (
               SELECT id
@@ -61,53 +62,63 @@ public class JdbcOutboxRepository implements OutboxRepository {
               LIMIT :limit
             )
             UPDATE outbox_events event
-            SET status = 'PROCESSING', attempts = event.attempts + 1,
-                lease_started_at = :now, lease_expires_at = :leaseExpiresAt,
-                published_at = NULL, last_error = NULL
+             SET status = 'PROCESSING', attempts = event.attempts + 1,
+                 lease_started_at = :now, lease_expires_at = :leaseExpiresAt,
+                 lease_token = :leaseToken, published_at = NULL, last_error = NULL
             FROM candidates
             WHERE event.tenant_id = :tenantId AND event.id = candidates.id
             RETURNING event.id, event.tenant_id, event.aggregate_type, event.aggregate_id,
                       event.aggregate_version, event.event_type, event.event_version, event.payload,
-                      event.occurred_at, event.correlation_id, event.causation_id, event.attempts
+                      event.occurred_at, event.correlation_id, event.causation_id, event.attempts,
+                      event.lease_token
             """)
         .param("tenantId", tenantId).param("now", Timestamp.from(now))
         .param("leaseExpiresAt", Timestamp.from(leaseExpiresAt))
+        .param("leaseToken", leaseToken)
         .param("limit", limit).query(this::map).list();
   }
 
   @Override
-  public void markPublished(UUID tenantId, UUID eventId, Instant publishedAt) {
+  public void markPublished(UUID tenantId, UUID eventId, UUID leaseToken, Instant publishedAt) {
     requireOne(jdbc.sql("""
             UPDATE outbox_events
-            SET status = 'PUBLISHED', published_at = :publishedAt,
-                lease_started_at = NULL, lease_expires_at = NULL, last_error = NULL
-            WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+             SET status = 'PUBLISHED', published_at = :publishedAt,
+                 lease_token = NULL, lease_started_at = NULL, lease_expires_at = NULL,
+                 last_error = NULL
+             WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+               AND lease_token = :leaseToken
             """)
         .param("publishedAt", Timestamp.from(publishedAt)).param("tenantId", tenantId)
-        .param("eventId", eventId).update());
+        .param("eventId", eventId).param("leaseToken", leaseToken).update());
   }
 
   @Override
-  public void markRetry(UUID tenantId, UUID eventId, Instant availableAt, String error) {
+  public void markRetry(
+      UUID tenantId, UUID eventId, UUID leaseToken, Instant availableAt, String error) {
     requireOne(jdbc.sql("""
             UPDATE outbox_events
-            SET status = 'PENDING', available_at = :availableAt,
-                lease_started_at = NULL, lease_expires_at = NULL, last_error = :error
-            WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+             SET status = 'PENDING', available_at = :availableAt,
+                 lease_token = NULL, lease_started_at = NULL, lease_expires_at = NULL,
+                 last_error = :error
+             WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+               AND lease_token = :leaseToken
             """)
         .param("availableAt", Timestamp.from(availableAt)).param("error", error)
-        .param("tenantId", tenantId).param("eventId", eventId).update());
+        .param("tenantId", tenantId).param("eventId", eventId).param("leaseToken", leaseToken)
+        .update());
   }
 
   @Override
-  public void markFailed(UUID tenantId, UUID eventId, String error) {
+  public void markFailed(UUID tenantId, UUID eventId, UUID leaseToken, String error) {
     requireOne(jdbc.sql("""
             UPDATE outbox_events
-            SET status = 'FAILED', lease_started_at = NULL, lease_expires_at = NULL,
-                last_error = :error
-            WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+             SET status = 'FAILED', lease_token = NULL, lease_started_at = NULL,
+                 lease_expires_at = NULL, last_error = :error
+             WHERE tenant_id = :tenantId AND id = :eventId AND status = 'PROCESSING'
+               AND lease_token = :leaseToken
             """)
-        .param("error", error).param("tenantId", tenantId).param("eventId", eventId).update());
+        .param("error", error).param("tenantId", tenantId).param("eventId", eventId)
+        .param("leaseToken", leaseToken).update());
   }
 
   private OutboxEvent map(ResultSet resultSet, int rowNumber) throws SQLException {
@@ -118,7 +129,8 @@ public class JdbcOutboxRepository implements OutboxRepository {
           resultSet.getLong("aggregate_version"), resultSet.getString("event_type"),
           resultSet.getInt("event_version"), objectMapper.readTree(resultSet.getString("payload")),
           resultSet.getTimestamp("occurred_at").toInstant(), resultSet.getString("correlation_id"),
-          resultSet.getObject("causation_id", UUID.class), resultSet.getInt("attempts"));
+          resultSet.getObject("causation_id", UUID.class), resultSet.getInt("attempts"),
+          resultSet.getObject("lease_token", UUID.class));
     } catch (JacksonException exception) {
       throw new SQLException("Stored outbox payload is invalid", exception);
     }

--- a/src/main/java/in/rsh/cab/operations/internal/persistence/OutboxRepository.java
+++ b/src/main/java/in/rsh/cab/operations/internal/persistence/OutboxRepository.java
@@ -13,11 +13,12 @@ public interface OutboxRepository {
       String eventType, int eventVersion, JsonNode payload, Instant occurredAt, Instant availableAt,
       String correlationId, UUID causationId);
 
-  List<OutboxEvent> lease(UUID tenantId, int limit, Instant now, Instant leaseExpiresAt);
+  List<OutboxEvent> lease(
+      UUID tenantId, int limit, Instant now, Instant leaseExpiresAt, UUID leaseToken);
 
-  void markPublished(UUID tenantId, UUID eventId, Instant publishedAt);
+  void markPublished(UUID tenantId, UUID eventId, UUID leaseToken, Instant publishedAt);
 
-  void markRetry(UUID tenantId, UUID eventId, Instant availableAt, String error);
+  void markRetry(UUID tenantId, UUID eventId, UUID leaseToken, Instant availableAt, String error);
 
-  void markFailed(UUID tenantId, UUID eventId, String error);
+  void markFailed(UUID tenantId, UUID eventId, UUID leaseToken, String error);
 }

--- a/src/main/java/in/rsh/cab/payment/PaymentOperationWorker.java
+++ b/src/main/java/in/rsh/cab/payment/PaymentOperationWorker.java
@@ -54,8 +54,8 @@ public class PaymentOperationWorker {
           event.tenantId(), payment.id(), submitted.providerObjectId(), submitted.providerRequestId()));
       return true;
     } catch (RuntimeException exception) {
-      tenantExecution.inTransaction(event.tenantId(), () -> payments.markCaptureSubmissionFailed(
-          event.tenantId(), payment.id(), "PROVIDER_UNAVAILABLE", clock.instant()));
+      tenantExecution.inTransaction(event.tenantId(), () -> payments.markCaptureSubmissionRetryable(
+          event.tenantId(), payment.id(), "PROVIDER_UNAVAILABLE"));
       throw exception;
     }
   }
@@ -71,12 +71,16 @@ public class PaymentOperationWorker {
         () -> payments.find(event.tenantId(), refund.paymentId()).orElseThrow());
     PaymentAccount account = tenantExecution.inTransaction(event.tenantId(),
         () -> payments.findAccountForPayment(event.tenantId(), payment.id()).orElseThrow());
-    PaymentProvider.Submission submitted = provider(account).refund(account, payment.id(),
-        refund.id(), payment.providerPaymentId(), refund.amountMinor(), refund.currency(),
-        "refund:" + refund.id());
-    tenantExecution.inTransaction(event.tenantId(), () -> payments.markRefundSubmitted(
-        event.tenantId(), refund.id(), submitted.providerObjectId(), clock.instant()));
-    return true;
+    try {
+      PaymentProvider.Submission submitted = provider(account).refund(account, payment.id(),
+          refund.id(), payment.providerPaymentId(), refund.amountMinor(), refund.currency(),
+          "refund:" + refund.id());
+      tenantExecution.inTransaction(event.tenantId(), () -> payments.markRefundSubmitted(
+          event.tenantId(), refund.id(), submitted.providerObjectId(), clock.instant()));
+      return true;
+    } catch (RuntimeException exception) {
+      throw exception;
+    }
   }
 
   private PaymentProvider provider(PaymentAccount account) {

--- a/src/main/java/in/rsh/cab/payment/internal/persistence/JdbcPaymentRepository.java
+++ b/src/main/java/in/rsh/cab/payment/internal/persistence/JdbcPaymentRepository.java
@@ -135,6 +135,7 @@ public class JdbcPaymentRepository implements PaymentRepository {
             UPDATE payment_attempts SET state = 'PROCESSING'
             WHERE tenant_id = :tenantId AND payment_id = :paymentId
               AND operation = 'CAPTURE' AND state IN ('PENDING', 'PROCESSING')
+              AND provider_request_id IS NULL
             """)
         .param("tenantId", tenantId).param("paymentId", paymentId).update() == 1;
   }
@@ -158,21 +159,16 @@ public class JdbcPaymentRepository implements PaymentRepository {
   }
 
   @Override
-  public void markCaptureSubmissionFailed(
-      UUID tenantId, UUID paymentId, String failureCode, Instant now) {
+  public void markCaptureSubmissionRetryable(
+      UUID tenantId, UUID paymentId, String failureCode) {
     jdbc.sql("""
-            UPDATE payments SET state = 'FAILED', failure_code = :failure, version = version + 1,
-              updated_at = :now WHERE tenant_id = :tenantId AND id = :paymentId
-              AND state = 'CAPTURE_PENDING'
-            """)
-        .param("tenantId", tenantId).param("paymentId", paymentId).param("failure", failureCode)
-        .param("now", Timestamp.from(now)).update();
-    jdbc.sql("""
-            UPDATE payment_attempts SET state = 'FAILED', failure_code = :failure, completed_at = :now
+            UPDATE payment_attempts SET state = 'PENDING', failure_code = :failure,
+              completed_at = NULL
             WHERE tenant_id = :tenantId AND payment_id = :paymentId AND operation = 'CAPTURE'
+              AND state = 'PROCESSING' AND provider_request_id IS NULL
             """)
         .param("tenantId", tenantId).param("paymentId", paymentId).param("failure", failureCode)
-        .param("now", Timestamp.from(now)).update();
+        .update();
   }
 
   @Override

--- a/src/main/java/in/rsh/cab/payment/internal/persistence/PaymentRepository.java
+++ b/src/main/java/in/rsh/cab/payment/internal/persistence/PaymentRepository.java
@@ -35,7 +35,7 @@ public interface PaymentRepository {
   void markCaptureSubmitted(UUID tenantId, UUID paymentId, String providerPaymentId,
       String providerRequestId);
 
-  void markCaptureSubmissionFailed(UUID tenantId, UUID paymentId, String failureCode, Instant now);
+  void markCaptureSubmissionRetryable(UUID tenantId, UUID paymentId, String failureCode);
 
   void insertRefund(UUID tenantId, Refund refund, UUID requesterId);
 

--- a/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantRepository.java
+++ b/src/main/java/in/rsh/cab/tenancy/internal/persistence/TenantRepository.java
@@ -1,8 +1,13 @@
 package in.rsh.cab.tenancy.internal.persistence;
 
 import java.util.UUID;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TenantRepository extends JpaRepository<TenantEntity, UUID> {
   boolean existsBySlug(String slug);
+
+  @Query("select tenant.id from TenantEntity tenant where tenant.status = 'ACTIVE' order by tenant.id")
+  List<UUID> findActiveIds();
 }

--- a/src/main/java/in/rsh/cab/webhook/WebhookDeliveryWorker.java
+++ b/src/main/java/in/rsh/cab/webhook/WebhookDeliveryWorker.java
@@ -33,13 +33,16 @@ public class WebhookDeliveryWorker {
   private final Clock clock;
   private final Duration requestTimeout;
   private final int maxAttempts;
+  private final Duration leaseDuration;
   private final TenantExecution tenantExecution;
 
   public WebhookDeliveryWorker(
       WebhookRepository webhooks, WebhookSecurity security, WebhookTransport transport,
       SecretResolver secrets, ObjectMapper json, Clock clock,
       @Value("${webhooks.request-timeout:PT10S}") Duration requestTimeout,
-      @Value("${webhooks.max-attempts:6}") int maxAttempts, TenantExecution tenantExecution) {
+      @Value("${webhooks.max-attempts:6}") int maxAttempts,
+      @Value("${webhooks.lease-duration:PT30S}") Duration leaseDuration,
+      TenantExecution tenantExecution) {
     this.webhooks = webhooks;
     this.security = security;
     this.transport = transport;
@@ -48,6 +51,7 @@ public class WebhookDeliveryWorker {
     this.clock = clock;
     this.requestTimeout = requestTimeout;
     this.maxAttempts = maxAttempts;
+    this.leaseDuration = leaseDuration;
     this.tenantExecution = tenantExecution;
   }
 
@@ -55,20 +59,16 @@ public class WebhookDeliveryWorker {
     if (!WebhookService.EVENT_ALLOWLIST.contains(event.eventType())) {
       return 0;
     }
-    int delivered = 0;
     List<WebhookSubscription> subscriptions = tenantExecution.inTransaction(event.tenantId(),
         () -> webhooks.matching(event.tenantId(), event.eventType()));
     for (WebhookSubscription subscription : subscriptions) {
       Instant now = clock.instant();
       String payload = envelope(event);
-      Delivery delivery = tenantExecution.inTransaction(event.tenantId(),
+      tenantExecution.inTransaction(event.tenantId(),
           () -> webhooks.createDelivery(subscription, event.tenantId(), event, payload,
-              now, now).orElse(null));
-      if (delivery != null && deliver(delivery)) {
-        delivered++;
-      }
+              now, now));
     }
-    return delivered;
+    return retryDue(event.tenantId(), 200);
   }
 
   public boolean deliver(Delivery delivery) {
@@ -90,7 +90,8 @@ public class WebhookDeliveryWorker {
       if (response.statusCode() >= 200 && response.statusCode() < 300) {
         tenantExecution.inTransaction(delivery.tenantId(),
             () -> webhooks.complete(
-                delivery.tenantId(), delivery.id(), attempt, response.statusCode(), now));
+                delivery.tenantId(), delivery.id(), delivery.leaseToken(), attempt,
+                response.statusCode(), now));
         return true;
       }
       retry(delivery, attempt, response.statusCode(), "HTTP_STATUS", now);
@@ -107,7 +108,10 @@ public class WebhookDeliveryWorker {
     }
     int delivered = 0;
     List<Delivery> due = tenantExecution.inTransaction(
-        tenantId, () -> webhooks.findDue(tenantId, limit, clock.instant()));
+        tenantId, () -> {
+          Instant now = clock.instant();
+          return webhooks.claimDue(tenantId, limit, now, now.plus(leaseDuration), UUID.randomUUID());
+        });
     for (Delivery delivery : due) {
       if (deliver(delivery)) {
         delivered++;
@@ -120,8 +124,8 @@ public class WebhookDeliveryWorker {
     boolean failed = attempt >= maxAttempts;
     long delaySeconds = Math.min(3600, 1L << Math.min(attempt, 12));
     tenantExecution.inTransaction(delivery.tenantId(),
-        () -> webhooks.retry(delivery.tenantId(), delivery.id(), attempt, responseStatus, error,
-            now.plusSeconds(delaySeconds), failed, now));
+        () -> webhooks.retry(delivery.tenantId(), delivery.id(), delivery.leaseToken(), attempt,
+            responseStatus, error, now.plusSeconds(delaySeconds), failed, now));
   }
 
   private String envelope(OutboxEvent event) {

--- a/src/main/java/in/rsh/cab/webhook/internal/persistence/JdbcWebhookRepository.java
+++ b/src/main/java/in/rsh/cab/webhook/internal/persistence/JdbcWebhookRepository.java
@@ -115,53 +115,85 @@ public class JdbcWebhookRepository implements WebhookRepository {
         .param("signatureTimestamp", Timestamp.from(signatureTimestamp))
         .param("now", Timestamp.from(now)).update();
     return inserted == 0 ? Optional.empty() : Optional.of(new Delivery(id, tenantId, subscription,
-        event.id(), event.eventType(), event.eventVersion(), payload, signatureTimestamp, 0));
+        event.id(), event.eventType(), event.eventVersion(), payload, signatureTimestamp, 0, null));
   }
 
   @Override
-  public List<Delivery> findDue(UUID tenantId, int limit, Instant now) {
+  public List<Delivery> claimDue(
+      UUID tenantId, int limit, Instant now, Instant leaseExpiresAt, UUID leaseToken) {
     return jdbc.sql("""
+            WITH candidates AS (
+              SELECT d.id
+              FROM webhook_deliveries d JOIN webhook_subscriptions s
+                ON s.tenant_id = d.tenant_id AND s.id = d.subscription_id
+              WHERE d.tenant_id = :tenantId AND d.next_attempt_at <= :now
+                AND (d.status IN ('PENDING', 'RETRY')
+                  OR (d.status = 'PROCESSING' AND d.lease_expires_at <= :now))
+                AND s.enabled AND s.deleted_at IS NULL
+              ORDER BY d.next_attempt_at, d.id
+              FOR UPDATE OF d SKIP LOCKED
+              LIMIT :limit
+            ), claimed AS (
+              UPDATE webhook_deliveries d
+              SET status = 'PROCESSING', lease_token = :leaseToken,
+                  lease_started_at = :now, lease_expires_at = :leaseExpiresAt,
+                  signature_timestamp = :now
+              FROM candidates
+              WHERE d.tenant_id = :tenantId AND d.id = candidates.id
+              RETURNING d.*
+            )
             SELECT d.id delivery_id, d.tenant_id, d.event_id, d.event_type, d.event_version,
-                   d.payload, d.signature_timestamp, d.attempt_count,
+                   d.payload, d.signature_timestamp, d.attempt_count, d.lease_token,
                    s.id, s.url, s.secret_reference, s.event_filters, s.enabled,
                    s.created_at, s.updated_at, s.version
-            FROM webhook_deliveries d JOIN webhook_subscriptions s
+            FROM claimed d JOIN webhook_subscriptions s
               ON s.tenant_id = d.tenant_id AND s.id = d.subscription_id
-            WHERE d.tenant_id = :tenantId AND d.status = 'RETRY'
-              AND d.next_attempt_at <= :now AND s.enabled AND s.deleted_at IS NULL
-            ORDER BY d.next_attempt_at, d.id LIMIT :limit
+            ORDER BY d.next_attempt_at, d.id
             """)
-        .param("tenantId", tenantId).param("now", Timestamp.from(now)).param("limit", limit)
+        .param("tenantId", tenantId).param("now", Timestamp.from(now))
+        .param("leaseExpiresAt", Timestamp.from(leaseExpiresAt)).param("leaseToken", leaseToken)
+        .param("limit", limit)
         .query((rs, row) -> new Delivery(rs.getObject("delivery_id", UUID.class),
             rs.getObject("tenant_id", UUID.class), map(rs, row),
             rs.getObject("event_id", UUID.class), rs.getString("event_type"),
             rs.getInt("event_version"), rs.getString("payload"),
-            rs.getTimestamp("signature_timestamp").toInstant(), rs.getInt("attempt_count")))
+            rs.getTimestamp("signature_timestamp").toInstant(), rs.getInt("attempt_count"),
+            rs.getObject("lease_token", UUID.class)))
         .list();
   }
 
   @Override
-  public void complete(UUID tenantId, UUID deliveryId, int attemptNumber, int responseStatus, Instant now) {
-    attempt(tenantId, deliveryId, attemptNumber, "SUCCEEDED", responseStatus, null, now);
-    jdbc.sql("""
-            UPDATE webhook_deliveries SET status = 'DELIVERED', attempt_count = :attempt,
-              delivered_at = :now WHERE tenant_id = :tenantId AND id = :id
-            """)
+  public void complete(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber,
+      int responseStatus, Instant now) {
+    requireClaim(jdbc.sql("""
+             UPDATE webhook_deliveries SET status = 'DELIVERED', attempt_count = :attempt,
+               delivered_at = :now, lease_token = NULL, lease_started_at = NULL,
+               lease_expires_at = NULL
+             WHERE tenant_id = :tenantId AND id = :id AND status = 'PROCESSING'
+               AND lease_token = :leaseToken
+             """)
         .param("attempt", attemptNumber).param("now", Timestamp.from(now))
-        .param("tenantId", tenantId).param("id", deliveryId).update();
+        .param("tenantId", tenantId).param("id", deliveryId).param("leaseToken", leaseToken)
+        .update());
+    attempt(tenantId, deliveryId, attemptNumber, "SUCCEEDED", responseStatus, null, now);
   }
 
   @Override
-  public void retry(UUID tenantId, UUID deliveryId, int attemptNumber, Integer responseStatus,
+  public void retry(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber, Integer responseStatus,
       String errorCode, Instant nextAttemptAt, boolean failed, Instant now) {
-    attempt(tenantId, deliveryId, attemptNumber, "FAILED", responseStatus, errorCode, now);
-    jdbc.sql("""
-            UPDATE webhook_deliveries SET status = :status, attempt_count = :attempt,
-              next_attempt_at = :nextAttempt WHERE tenant_id = :tenantId AND id = :id
-            """)
+    requireClaim(jdbc.sql("""
+             UPDATE webhook_deliveries SET status = :status, attempt_count = :attempt,
+               next_attempt_at = :nextAttempt, lease_token = NULL, lease_started_at = NULL,
+               lease_expires_at = NULL
+             WHERE tenant_id = :tenantId AND id = :id AND status = 'PROCESSING'
+               AND lease_token = :leaseToken
+             """)
         .param("status", failed ? "FAILED" : "RETRY").param("attempt", attemptNumber)
         .param("nextAttempt", Timestamp.from(nextAttemptAt)).param("tenantId", tenantId)
-        .param("id", deliveryId).update();
+        .param("id", deliveryId).param("leaseToken", leaseToken).update());
+    attempt(tenantId, deliveryId, attemptNumber, "FAILED", responseStatus, errorCode, now);
   }
 
   private void attempt(UUID tenantId, UUID deliveryId, int number, String status,
@@ -194,6 +226,12 @@ public class JdbcWebhookRepository implements WebhookRepository {
       return json.writeValueAsString(values);
     } catch (JacksonException exception) {
       throw new IllegalArgumentException("Webhook filters are invalid", exception);
+    }
+  }
+
+  private void requireClaim(int updated) {
+    if (updated != 1) {
+      throw new IllegalStateException("Webhook delivery lease is no longer owned");
     }
   }
 }

--- a/src/main/java/in/rsh/cab/webhook/internal/persistence/WebhookRepository.java
+++ b/src/main/java/in/rsh/cab/webhook/internal/persistence/WebhookRepository.java
@@ -24,14 +24,19 @@ public interface WebhookRepository {
   Optional<Delivery> createDelivery(WebhookSubscription subscription, UUID tenantId,
       OutboxEvent event, String payload, Instant signatureTimestamp, Instant now);
 
-  List<Delivery> findDue(UUID tenantId, int limit, Instant now);
+  List<Delivery> claimDue(
+      UUID tenantId, int limit, Instant now, Instant leaseExpiresAt, UUID leaseToken);
 
-  void complete(UUID tenantId, UUID deliveryId, int attemptNumber, int responseStatus, Instant now);
+  void complete(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber,
+      int responseStatus, Instant now);
 
-  void retry(UUID tenantId, UUID deliveryId, int attemptNumber, Integer responseStatus,
+  void retry(
+      UUID tenantId, UUID deliveryId, UUID leaseToken, int attemptNumber, Integer responseStatus,
       String errorCode, Instant nextAttemptAt, boolean failed, Instant now);
 
   record Delivery(
       UUID id, UUID tenantId, WebhookSubscription subscription, UUID eventId, String eventType,
-      int eventVersion, String payload, Instant signatureTimestamp, int attemptCount) {}
+      int eventVersion, String payload, Instant signatureTimestamp, int attemptCount,
+      UUID leaseToken) {}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,15 @@ payments.platform-commission-basis-points=${PAYMENTS_PLATFORM_COMMISSION_BASIS_P
 webhooks.connect-timeout=${WEBHOOK_CONNECT_TIMEOUT:PT5S}
 webhooks.request-timeout=${WEBHOOK_REQUEST_TIMEOUT:PT10S}
 webhooks.max-attempts=${WEBHOOK_MAX_ATTEMPTS:6}
+webhooks.lease-duration=${WEBHOOK_LEASE_DURATION:PT30S}
+notifications.max-attempts=${NOTIFICATION_MAX_ATTEMPTS:6}
+notifications.lease-duration=${NOTIFICATION_LEASE_DURATION:PT30S}
+
+outbox.dispatcher.enabled=${OUTBOX_DISPATCHER_ENABLED:true}
+outbox.dispatcher.fixed-delay=${OUTBOX_DISPATCHER_FIXED_DELAY:1000}
+outbox.dispatcher.batch-size=${OUTBOX_DISPATCHER_BATCH_SIZE:50}
+outbox.dispatcher.delivery-batch-size=${OUTBOX_DELIVERY_BATCH_SIZE:50}
+outbox.dispatcher.max-attempts=${OUTBOX_DISPATCHER_MAX_ATTEMPTS:10}
+outbox.dispatcher.lease-duration=${OUTBOX_DISPATCHER_LEASE_DURATION:PT1M}
+outbox.dispatcher.initial-backoff=${OUTBOX_DISPATCHER_INITIAL_BACKOFF:PT2S}
+outbox.dispatcher.max-backoff=${OUTBOX_DISPATCHER_MAX_BACKOFF:PT5M}

--- a/src/main/resources/db/migration/V12__fenced_delivery_leases.sql
+++ b/src/main/resources/db/migration/V12__fenced_delivery_leases.sql
@@ -1,0 +1,67 @@
+ALTER TABLE outbox_events ADD COLUMN lease_token uuid;
+
+ALTER TABLE outbox_events DROP CONSTRAINT chk_outbox_lease;
+ALTER TABLE outbox_events ADD CONSTRAINT chk_outbox_lease CHECK (
+    (status = 'PROCESSING' AND lease_token IS NOT NULL
+        AND lease_started_at IS NOT NULL AND lease_expires_at > lease_started_at)
+    OR (status <> 'PROCESSING' AND lease_token IS NULL
+        AND lease_started_at IS NULL AND lease_expires_at IS NULL)
+);
+
+ALTER TABLE notification_deliveries
+    ADD COLUMN lease_token uuid,
+    ADD COLUMN lease_started_at timestamptz,
+    ADD COLUMN lease_expires_at timestamptz,
+    ADD COLUMN next_attempt_at timestamptz,
+    ADD COLUMN body text;
+
+UPDATE notification_deliveries
+SET status = CASE WHEN status IN ('PROCESSING', 'FAILED') THEN 'RETRY' ELSE status END,
+    next_attempt_at = created_at,
+    body = event_type;
+
+ALTER TABLE notification_deliveries ALTER COLUMN next_attempt_at SET NOT NULL;
+ALTER TABLE notification_deliveries ALTER COLUMN body SET NOT NULL;
+ALTER TABLE notification_deliveries DROP CONSTRAINT chk_notification_delivery_status;
+ALTER TABLE notification_deliveries ADD CONSTRAINT chk_notification_delivery_status
+    CHECK (status IN ('PENDING', 'PROCESSING', 'DELIVERED', 'SKIPPED', 'RETRY', 'FAILED'));
+ALTER TABLE notification_deliveries ADD CONSTRAINT chk_notification_delivery_lease CHECK (
+    (status = 'PROCESSING' AND lease_token IS NOT NULL
+        AND lease_started_at IS NOT NULL AND lease_expires_at > lease_started_at)
+    OR (status <> 'PROCESSING' AND lease_token IS NULL
+        AND lease_started_at IS NULL AND lease_expires_at IS NULL)
+);
+DROP INDEX idx_notification_delivery_status;
+CREATE INDEX idx_notification_delivery_due
+    ON notification_deliveries (tenant_id, status, next_attempt_at, lease_expires_at);
+
+ALTER TABLE webhook_deliveries
+    ADD COLUMN lease_token uuid,
+    ADD COLUMN lease_started_at timestamptz,
+    ADD COLUMN lease_expires_at timestamptz;
+
+UPDATE webhook_deliveries
+SET status = 'RETRY'
+WHERE status = 'PROCESSING';
+
+ALTER TABLE webhook_deliveries ADD CONSTRAINT chk_webhook_delivery_lease CHECK (
+    (status = 'PROCESSING' AND lease_token IS NOT NULL
+        AND lease_started_at IS NOT NULL AND lease_expires_at > lease_started_at)
+    OR (status <> 'PROCESSING' AND lease_token IS NULL
+        AND lease_started_at IS NULL AND lease_expires_at IS NULL)
+);
+
+CREATE OR REPLACE FUNCTION reject_webhook_snapshot_mutation() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       OR NEW.subscription_id IS DISTINCT FROM OLD.subscription_id
+       OR NEW.event_id IS DISTINCT FROM OLD.event_id
+       OR NEW.event_type IS DISTINCT FROM OLD.event_type
+       OR NEW.event_version IS DISTINCT FROM OLD.event_version
+       OR NEW.payload IS DISTINCT FROM OLD.payload
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'webhook delivery event snapshot is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/src/test/java/in/rsh/cab/notification/NotificationDeliveryWorkerTest.java
+++ b/src/test/java/in/rsh/cab/notification/NotificationDeliveryWorkerTest.java
@@ -1,7 +1,6 @@
 package in.rsh.cab.notification;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import in.rsh.cab.notification.internal.persistence.NotificationRepository;
 import in.rsh.cab.notification.internal.persistence.NotificationRepository.Delivery;
-import in.rsh.cab.operations.InboxService;
 import in.rsh.cab.operations.OutboxEvent;
 import in.rsh.cab.tenancy.TenantDatabaseContext;
 import in.rsh.cab.tenancy.TenantExecution;
@@ -35,31 +33,31 @@ class NotificationDeliveryWorkerTest {
   private static final UUID RECIPIENT = UUID.randomUUID();
   private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
   private final NotificationRepository repository = mock(NotificationRepository.class);
-  private final InboxService inbox = mock(InboxService.class);
   private final NotificationProvider provider = mock(NotificationProvider.class);
   private NotificationDeliveryWorker worker;
 
   @BeforeEach
   void setUp() {
     when(provider.channel()).thenReturn("LOCAL");
-    worker = new NotificationDeliveryWorker(repository, inbox, List.of(provider),
+    worker = new NotificationDeliveryWorker(repository, List.of(provider),
         new TenantExecution(new TransactionTemplate(new TestTransactionManager()),
-            mock(TenantDatabaseContext.class)), Clock.fixed(NOW, ZoneOffset.UTC));
+            mock(TenantDatabaseContext.class)), Clock.fixed(NOW, ZoneOffset.UTC),
+        java.time.Duration.ofSeconds(30), 3);
   }
 
   @Test
   void deduplicatesAndRespectsOrdinaryPreferences() {
     OutboxEvent event = event("rating.created");
     when(repository.getOrCreateDelivery(any(), eq(TENANT), eq(RECIPIENT), eq(event.id()),
-        eq(event.eventType()), eq("LOCAL"), eq("rating"), eq(1), eq("PENDING"), eq(NOW)))
-        .thenReturn(new Delivery(UUID.randomUUID(), "DELIVERED", 1));
+        eq(event.eventType()), eq("LOCAL"), eq("rating"), eq(1), eq("body"), eq("PENDING"), eq(NOW)))
+        .thenReturn(delivery("DELIVERED", 1, null));
     assertFalse(worker.process(event, RECIPIENT, "LOCAL", "rating", 1, "body"));
 
     when(repository.preferenceEnabled(TENANT, RECIPIENT, event.eventType(), "LOCAL"))
         .thenReturn(false);
     when(repository.getOrCreateDelivery(any(), eq(TENANT), eq(RECIPIENT), eq(event.id()),
-        eq(event.eventType()), eq("LOCAL"), eq("rating"), eq(1), eq("SKIPPED"), eq(NOW)))
-        .thenReturn(new Delivery(UUID.randomUUID(), "SKIPPED", 0));
+        eq(event.eventType()), eq("LOCAL"), eq("rating"), eq(1), eq("body"), eq("SKIPPED"), eq(NOW)))
+        .thenReturn(delivery("SKIPPED", 0, null));
     assertFalse(worker.process(event, RECIPIENT, "LOCAL", "rating", 1, "body"));
     verify(provider, never()).send(any());
   }
@@ -69,14 +67,16 @@ class NotificationDeliveryWorkerTest {
     OutboxEvent event = event("safety.incident_reported");
     UUID deliveryId = UUID.randomUUID();
     when(repository.getOrCreateDelivery(any(), eq(TENANT), eq(RECIPIENT), eq(event.id()),
-        eq(event.eventType()), eq("LOCAL"), eq("safety"), eq(1), eq("PENDING"), eq(NOW)))
-        .thenReturn(new Delivery(deliveryId, "PENDING", 0));
-    when(repository.claimDelivery(TENANT, deliveryId)).thenReturn(true);
+        eq(event.eventType()), eq("LOCAL"), eq("safety"), eq(1), eq("body"), eq("PENDING"), eq(NOW)))
+        .thenReturn(delivery(deliveryId, "PENDING", 0, null));
+    when(repository.claimDelivery(eq(TENANT), eq(deliveryId), eq(NOW),
+        eq(NOW.plusSeconds(30)), any())).thenAnswer(invocation -> java.util.Optional.of(
+            delivery(deliveryId, "PROCESSING", 0, invocation.getArgument(4))));
     when(provider.send(any())).thenReturn("provider-id");
     assertTrue(worker.process(event, RECIPIENT, "LOCAL", "safety", 1, "body"));
     verify(repository, never()).preferenceEnabled(any(), any(), any(), any());
-    verify(repository).insertAttempt(eq(TENANT), org.mockito.ArgumentMatchers.any(), eq(1),
-        eq("SUCCEEDED"), eq("provider-id"), eq(null), eq(NOW));
+    verify(repository).complete(eq(TENANT), eq(deliveryId), any(), eq(1),
+        eq("provider-id"), eq(NOW));
   }
 
   @Test
@@ -86,19 +86,29 @@ class NotificationDeliveryWorkerTest {
         .thenReturn(true);
     UUID deliveryId = UUID.randomUUID();
     when(repository.getOrCreateDelivery(any(), eq(TENANT), eq(RECIPIENT), eq(event.id()),
-        eq(event.eventType()), eq("LOCAL"), eq("ride"), eq(1), eq("PENDING"), eq(NOW)))
-        .thenReturn(new Delivery(deliveryId, "FAILED", 1));
-    when(repository.claimDelivery(TENANT, deliveryId)).thenReturn(true);
+        eq(event.eventType()), eq("LOCAL"), eq("ride"), eq(1), eq("body"), eq("PENDING"), eq(NOW)))
+        .thenReturn(delivery(deliveryId, "RETRY", 1, null));
+    when(repository.claimDelivery(eq(TENANT), eq(deliveryId), eq(NOW),
+        eq(NOW.plusSeconds(30)), any())).thenAnswer(invocation -> java.util.Optional.of(
+            delivery(deliveryId, "PROCESSING", 1, invocation.getArgument(4))));
     when(provider.send(any())).thenThrow(new IllegalStateException("secret detail"));
-    assertThrows(IllegalStateException.class,
-        () -> worker.process(event, RECIPIENT, "LOCAL", "ride", 1, "body"));
-    verify(repository).insertAttempt(eq(TENANT), org.mockito.ArgumentMatchers.any(), eq(2),
-        eq("FAILED"), eq(null), eq("PROVIDER_UNAVAILABLE"), eq(NOW));
+    assertFalse(worker.process(event, RECIPIENT, "LOCAL", "ride", 1, "body"));
+    verify(repository).retry(eq(TENANT), eq(deliveryId), any(), eq(2),
+        eq("PROVIDER_UNAVAILABLE"), eq(NOW.plusSeconds(4)), eq(false), eq(NOW));
   }
 
   private OutboxEvent event(String type) {
     return new OutboxEvent(UUID.randomUUID(), TENANT, "event", UUID.randomUUID(), 1, type, 1,
-        new ObjectMapper().createObjectNode(), NOW, null, null, 1);
+        new ObjectMapper().createObjectNode(), NOW, null, null, 1, UUID.randomUUID());
+  }
+
+  private Delivery delivery(String status, int attempts, UUID token) {
+    return delivery(UUID.randomUUID(), status, attempts, token);
+  }
+
+  private Delivery delivery(UUID id, String status, int attempts, UUID token) {
+    return new Delivery(id, TENANT, RECIPIENT, UUID.randomUUID(), "ride.completed", "LOCAL",
+        "ride", 1, "body", status, attempts, token);
   }
 
   private static final class TestTransactionManager extends AbstractPlatformTransactionManager {

--- a/src/test/java/in/rsh/cab/notification/NotificationRecipientResolverTest.java
+++ b/src/test/java/in/rsh/cab/notification/NotificationRecipientResolverTest.java
@@ -1,0 +1,27 @@
+package in.rsh.cab.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import in.rsh.cab.operations.OutboxEvent;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import tools.jackson.databind.ObjectMapper;
+
+class NotificationRecipientResolverTest {
+
+  @Test
+  void unrelatedEventsDoNotQueryTenantData() {
+    JdbcClient jdbc = mock(JdbcClient.class);
+    NotificationRecipientResolver resolver = new NotificationRecipientResolver(jdbc);
+    assertEquals(java.util.List.of(), resolver.resolve(new OutboxEvent(UUID.randomUUID(),
+        UUID.randomUUID(), "quote", UUID.randomUUID(), 1, "quote.created", 1,
+        new ObjectMapper().createObjectNode(), Instant.now(), null, null, 1, UUID.randomUUID())));
+    verify(jdbc, never()).sql(anyString());
+  }
+}

--- a/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
@@ -1,0 +1,66 @@
+package in.rsh.cab.operations;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.notification.NotificationDeliveryWorker;
+import in.rsh.cab.notification.NotificationRecipientResolver;
+import in.rsh.cab.payment.PaymentOperationWorker;
+import in.rsh.cab.tenancy.TenantExecution;
+import in.rsh.cab.webhook.WebhookDeliveryWorker;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class OutboxConsumerTest {
+
+  @Test
+  void paymentConsumerPreservesHandledResult() {
+    PaymentOperationWorker worker = mock(PaymentOperationWorker.class);
+    OutboxEvent event = event("payment.capture_requested");
+    when(worker.process(event)).thenReturn(true);
+    assertTrue(new PaymentOutboxConsumer(worker).process(event));
+  }
+
+  @Test
+  void webhookConsumerIgnoresUnallowedEventsAndProcessesAllowedEvents() {
+    WebhookDeliveryWorker worker = mock(WebhookDeliveryWorker.class);
+    WebhookOutboxConsumer consumer = new WebhookOutboxConsumer(worker);
+    assertFalse(consumer.process(event("payment.captured")));
+    verify(worker, never()).process(any());
+    OutboxEvent allowed = event("ride.completed");
+    assertTrue(consumer.process(allowed));
+    verify(worker).process(allowed);
+  }
+
+  @Test
+  void notificationConsumerRoutesEveryResolvedRecipient() {
+    NotificationRecipientResolver resolver = mock(NotificationRecipientResolver.class);
+    NotificationDeliveryWorker worker = mock(NotificationDeliveryWorker.class);
+    TenantExecution execution = mock(TenantExecution.class);
+    when(execution.inTransaction(any(), org.mockito.ArgumentMatchers
+        .<java.util.function.Supplier<List<UUID>>>any())).thenAnswer(invocation ->
+            ((java.util.function.Supplier<?>) invocation.getArgument(1)).get());
+    OutboxEvent event = event("ride.completed");
+    UUID first = UUID.randomUUID();
+    UUID second = UUID.randomUUID();
+    when(resolver.resolve(event)).thenReturn(List.of(first, second));
+    NotificationOutboxConsumer consumer = new NotificationOutboxConsumer(resolver, worker, execution);
+    assertTrue(consumer.process(event));
+    verify(worker).process(event, first, "LOCAL", "ride_completed", 1, "ride.completed");
+    verify(worker).process(event, second, "LOCAL", "ride_completed", 1, "ride.completed");
+  }
+
+  private OutboxEvent event(String type) {
+    return new OutboxEvent(UUID.randomUUID(), UUID.randomUUID(), "ride", UUID.randomUUID(), 1,
+        type, 1, new ObjectMapper().createObjectNode(), Instant.parse("2026-08-09T10:00:00Z"),
+        null, null, 1, UUID.randomUUID());
+  }
+}

--- a/src/test/java/in/rsh/cab/operations/OutboxDispatcherTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxDispatcherTest.java
@@ -1,0 +1,72 @@
+package in.rsh.cab.operations;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.notification.NotificationDeliveryWorker;
+import in.rsh.cab.tenancy.internal.persistence.TenantRepository;
+import in.rsh.cab.webhook.WebhookDeliveryWorker;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class OutboxDispatcherTest {
+
+  private static final Instant NOW = Instant.parse("2026-08-09T10:00:00Z");
+  private final OutboxPoller poller = mock(OutboxPoller.class);
+  private final TenantRepository tenants = mock(TenantRepository.class);
+  private final NotificationDeliveryWorker notifications = mock(NotificationDeliveryWorker.class);
+  private final WebhookDeliveryWorker webhooks = mock(WebhookDeliveryWorker.class);
+  private final OutboxConsumer first = mock(OutboxConsumer.class);
+  private final OutboxConsumer second = mock(OutboxConsumer.class);
+  private final OutboxDispatcher dispatcher = new OutboxDispatcher(poller,
+      tenants, List.of(first, second), notifications, webhooks, Clock.fixed(NOW, ZoneOffset.UTC), 10, 10, 3,
+      Duration.ofMinutes(1), Duration.ofSeconds(2), Duration.ofMinutes(5));
+
+  @Test
+  void acknowledgesOnlyAfterAllConsumersRun() {
+    OutboxEvent event = event(1);
+    dispatcher.process(event);
+    verify(first).process(event);
+    verify(second).process(event);
+    verify(poller).published(event);
+  }
+
+  @Test
+  void retriesPartialFanoutWithBackoffAndEventuallyFails() {
+    OutboxEvent retry = event(2);
+    doThrow(new IllegalStateException("temporary")).when(second).process(retry);
+    dispatcher.process(retry);
+    verify(poller).retry(retry, NOW.plusSeconds(4), "temporary");
+
+    OutboxEvent failed = event(3);
+    doThrow(new IllegalStateException("still down")).when(first).process(failed);
+    dispatcher.process(failed);
+    verify(poller).failed(failed, "still down");
+  }
+
+  @Test
+  void scheduledCyclePollsEachActiveTenantAndRunsDeliveryRecovery() {
+    UUID tenant = UUID.randomUUID();
+    OutboxEvent event = event(1);
+    when(tenants.findActiveIds()).thenReturn(List.of(tenant));
+    when(poller.lease(tenant, 10, Duration.ofMinutes(1))).thenReturn(List.of(event));
+    dispatcher.dispatch();
+    verify(notifications).retryDue(tenant, 10);
+    verify(webhooks).retryDue(tenant, 10);
+    verify(poller).published(event);
+  }
+
+  private OutboxEvent event(int attempts) {
+    return new OutboxEvent(UUID.randomUUID(), UUID.randomUUID(), "ride", UUID.randomUUID(), 1,
+        "ride.completed", 1, new ObjectMapper().createObjectNode(), NOW, null, null, attempts,
+        UUID.randomUUID());
+  }
+}

--- a/src/test/java/in/rsh/cab/operations/OutboxServiceTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxServiceTest.java
@@ -3,6 +3,8 @@ package in.rsh.cab.operations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,24 +67,26 @@ class OutboxServiceTest {
 
     OutboxEvent event = new OutboxEvent(
         eventId, TENANT, "quote", aggregateId, 0, "quote.created", 1,
-        payload, NOW, null, null, 1);
-    when(repository.lease(TENANT, 10, NOW, NOW.plusSeconds(30))).thenReturn(List.of(event));
+        payload, NOW, null, null, 1, UUID.randomUUID());
+    when(repository.lease(eq(TENANT), eq(10), eq(NOW), eq(NOW.plusSeconds(30)), any()))
+        .thenReturn(List.of(event));
     assertEquals(List.of(event), poller.lease(TENANT, 10, Duration.ofSeconds(30)));
   }
 
   @Test
   void completesRetryAndPermanentFailureWithBoundedErrors() {
-    UUID eventId = UUID.randomUUID();
-    poller.published(TENANT, eventId);
-    verify(repository).markPublished(TENANT, eventId, NOW);
+    OutboxEvent event = event();
+    poller.published(event);
+    verify(repository).markPublished(TENANT, event.id(), event.leaseToken(), NOW);
 
-    poller.retry(TENANT, eventId, NOW.plusSeconds(10), "temporary");
-    verify(repository).markRetry(TENANT, eventId, NOW.plusSeconds(10), "temporary");
+    poller.retry(event, NOW.plusSeconds(10), "temporary");
+    verify(repository).markRetry(
+        TENANT, event.id(), event.leaseToken(), NOW.plusSeconds(10), "temporary");
 
-    poller.failed(TENANT, eventId, "x".repeat(600));
-    verify(repository).markFailed(TENANT, eventId, "x".repeat(500));
-    poller.failed(TENANT, eventId, null);
-    verify(repository).markFailed(TENANT, eventId, null);
+    poller.failed(event, "x".repeat(600));
+    verify(repository).markFailed(TENANT, event.id(), event.leaseToken(), "x".repeat(500));
+    poller.failed(event, null);
+    verify(repository).markFailed(TENANT, event.id(), event.leaseToken(), null);
   }
 
   @Test
@@ -91,5 +95,11 @@ class OutboxServiceTest {
         () -> poller.lease(TENANT, 0, Duration.ofSeconds(1)));
     assertThrows(IllegalArgumentException.class,
         () -> poller.lease(TENANT, 1, Duration.ZERO));
+  }
+
+  private OutboxEvent event() {
+    return new OutboxEvent(UUID.randomUUID(), TENANT, "quote", UUID.randomUUID(), 0,
+        "quote.created", 1, new ObjectMapper().createObjectNode(), NOW, null, null, 1,
+        UUID.randomUUID());
   }
 }

--- a/src/test/java/in/rsh/cab/payment/PaymentOperationWorkerTest.java
+++ b/src/test/java/in/rsh/cab/payment/PaymentOperationWorkerTest.java
@@ -70,8 +70,8 @@ class PaymentOperationWorkerTest {
 
     assertThrows(IllegalStateException.class,
         () -> worker.process(event("payment.capture_requested", payment.id())));
-    verify(repository).markCaptureSubmissionFailed(
-        TENANT, payment.id(), "PROVIDER_UNAVAILABLE", NOW);
+    verify(repository).markCaptureSubmissionRetryable(
+        TENANT, payment.id(), "PROVIDER_UNAVAILABLE");
   }
 
   private Payment payment() {
@@ -85,7 +85,7 @@ class PaymentOperationWorkerTest {
 
   private OutboxEvent event(String type, UUID id) {
     return new OutboxEvent(UUID.randomUUID(), TENANT, "payment", id, 0, type, 1,
-        new ObjectMapper().createObjectNode(), NOW, null, null, 1);
+        new ObjectMapper().createObjectNode(), NOW, null, null, 1, UUID.randomUUID());
   }
 
   private static final class TestTransactionManager extends AbstractPlatformTransactionManager {

--- a/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
@@ -99,6 +99,7 @@ class MarketplaceHttpIT {
     registry.add("springdoc.api-docs.enabled", () -> "true");
     registry.add("springdoc.swagger-ui.enabled", () -> "true");
     registry.add("rate-limit.requests", () -> "70");
+    registry.add("outbox.dispatcher.enabled", () -> "false");
     registry.add("routing.osrm.base-url", () -> "http://localhost:" + OSRM.getAddress().getPort());
   }
 
@@ -376,10 +377,10 @@ class MarketplaceHttpIT {
     List<OutboxEvent> leased = outboxPoller.lease(tenantUuid, 10, Duration.ofSeconds(30));
     assertEquals(1, leased.size());
     assertEquals("marketplace-http-it", leased.get(0).correlationId());
-    outboxPoller.retry(tenantUuid, leased.get(0).id(), Instant.now().minusSeconds(1), "temporary");
+    outboxPoller.retry(leased.get(0), Instant.now().minusSeconds(1), "temporary");
     List<OutboxEvent> retried = outboxPoller.lease(tenantUuid, 10, Duration.ofSeconds(30));
     assertEquals(2, retried.get(0).attempts());
-    outboxPoller.published(tenantUuid, retried.get(0).id());
+    outboxPoller.published(retried.get(0));
     assertTrue(outboxPoller.lease(tenantUuid, 10, Duration.ofSeconds(30)).isEmpty());
 
     UUID incomingEvent = UUID.randomUUID();
@@ -590,7 +591,7 @@ class MarketplaceHttpIT {
             .findFirst()
             .orElseThrow();
     assertTrue(paymentWorker.process(captureRequest));
-    paymentEvents.forEach(event -> outboxPoller.published(tenantUuid, event.id()));
+    paymentEvents.forEach(outboxPoller::published);
 
     PaymentAccount paymentAccount =
         tenantExecution.inTransaction(
@@ -640,7 +641,7 @@ class MarketplaceHttpIT {
             .findFirst()
             .orElseThrow();
     assertTrue(paymentWorker.process(refundRequest));
-    refundEvents.forEach(event -> outboxPoller.published(tenantUuid, event.id()));
+    refundEvents.forEach(outboxPoller::published);
 
     Instant refundTimestamp = Instant.now();
     String refundBody =

--- a/src/test/java/in/rsh/cab/webhook/WebhookDeliveryWorkerTest.java
+++ b/src/test/java/in/rsh/cab/webhook/WebhookDeliveryWorkerTest.java
@@ -51,7 +51,7 @@ class WebhookDeliveryWorkerTest {
     }).when(tenantExecution).inTransaction(any(), any(Runnable.class));
     worker = new WebhookDeliveryWorker(repository, security, transport, secrets,
         new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofSeconds(10), 6,
-        tenantExecution);
+        Duration.ofSeconds(30), tenantExecution);
   }
 
   @Test
@@ -59,9 +59,14 @@ class WebhookDeliveryWorkerTest {
     OutboxEvent event = event("ride.completed");
     WebhookSubscription subscription = subscription();
     when(repository.matching(TENANT, event.eventType())).thenReturn(List.of(subscription));
+    final String[] envelope = new String[1];
     when(repository.createDelivery(eq(subscription), eq(TENANT), eq(event), any(), eq(NOW), eq(NOW)))
-        .thenAnswer(invocation -> Optional.of(new Delivery(UUID.randomUUID(), TENANT, subscription,
-            event.id(), event.eventType(), 1, invocation.getArgument(3), NOW, 0)));
+        .thenAnswer(invocation -> {
+          envelope[0] = invocation.getArgument(3);
+          return Optional.of(delivery(subscription, event.id(), envelope[0], 0));
+        });
+    when(repository.claimDue(eq(TENANT), eq(200), eq(NOW), eq(NOW.plusSeconds(30)), any()))
+        .thenAnswer(invocation -> List.of(delivery(subscription, event.id(), envelope[0], 0)));
     when(transport.post(any(), any(), any(), eq(Duration.ofSeconds(10))))
         .thenAnswer(invocation -> {
           Map<String, String> headers = invocation.getArgument(2);
@@ -73,7 +78,7 @@ class WebhookDeliveryWorkerTest {
         });
 
     assertEquals(1, worker.process(event));
-    verify(repository).complete(eq(TENANT), any(), eq(1), eq(204), eq(NOW));
+    verify(repository).complete(eq(TENANT), any(), any(), eq(1), eq(204), eq(NOW));
   }
 
   @Test
@@ -82,10 +87,10 @@ class WebhookDeliveryWorkerTest {
     verify(repository, never()).matching(any(), any());
 
     Delivery delivery = new Delivery(UUID.randomUUID(), TENANT, subscription(), UUID.randomUUID(),
-        "ride.completed", 1, "{}", NOW, 2);
+        "ride.completed", 1, "{}", NOW, 2, UUID.randomUUID());
     when(transport.post(any(), any(), any(), any())).thenReturn(new WebhookTransport.Response(503));
     assertFalse(worker.deliver(delivery));
-    verify(repository).retry(TENANT, delivery.id(), 3, 503, "HTTP_STATUS",
+    verify(repository).retry(TENANT, delivery.id(), delivery.leaseToken(), 3, 503, "HTTP_STATUS",
         NOW.plusSeconds(8), false, NOW);
   }
 
@@ -94,20 +99,21 @@ class WebhookDeliveryWorkerTest {
     WebhookSecurity rebinding = new WebhookSecurity(host -> List.of(InetAddress.getByName("127.0.0.1")));
     WebhookDeliveryWorker blocked = new WebhookDeliveryWorker(repository, rebinding, transport,
         secrets, new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofSeconds(10), 6,
-        tenantExecution);
+        Duration.ofSeconds(30), tenantExecution);
     Delivery delivery = new Delivery(UUID.randomUUID(), TENANT, subscription(), UUID.randomUUID(),
-        "ride.completed", 1, "{}", NOW, 0);
+        "ride.completed", 1, "{}", NOW, 0, UUID.randomUUID());
     assertFalse(blocked.deliver(delivery));
     verify(transport, never()).post(any(), any(), any(), any());
-    verify(repository).retry(TENANT, delivery.id(), 1, null, "DELIVERY_FAILED",
+    verify(repository).retry(TENANT, delivery.id(), delivery.leaseToken(), 1, null, "DELIVERY_FAILED",
         NOW.plusSeconds(2), false, NOW);
   }
 
   @Test
   void processesBoundedDueRetries() {
     Delivery delivery = new Delivery(UUID.randomUUID(), TENANT, subscription(), UUID.randomUUID(),
-        "ride.completed", 1, "{}", NOW, 1);
-    when(repository.findDue(TENANT, 10, NOW)).thenReturn(List.of(delivery));
+        "ride.completed", 1, "{}", NOW, 1, UUID.randomUUID());
+    when(repository.claimDue(eq(TENANT), eq(10), eq(NOW), eq(NOW.plusSeconds(30)), any()))
+        .thenReturn(List.of(delivery));
     when(transport.post(any(), any(), any(), any())).thenReturn(new WebhookTransport.Response(200));
     assertEquals(1, worker.retryDue(TENANT, 10));
     assertThrows(IllegalArgumentException.class, () -> worker.retryDue(TENANT, 0));
@@ -120,6 +126,12 @@ class WebhookDeliveryWorkerTest {
 
   private OutboxEvent event(String type) {
     return new OutboxEvent(UUID.randomUUID(), TENANT, "ride", UUID.randomUUID(), 6, type, 1,
-        new ObjectMapper().createObjectNode(), NOW, null, null, 1);
+        new ObjectMapper().createObjectNode(), NOW, null, null, 1, UUID.randomUUID());
+  }
+
+  private Delivery delivery(
+      WebhookSubscription subscription, UUID eventId, String payload, int attempts) {
+    return new Delivery(UUID.randomUUID(), TENANT, subscription, eventId, "ride.completed", 1,
+        payload, NOW, attempts, UUID.randomUUID());
   }
 }


### PR DESCRIPTION
## Summary
- Delivers `feat(operations): run fenced outbox delivery` as part 17 of 26 in the production marketplace stack.
- Contains 36 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/114`
- Head: `stack/17-outbox-delivery`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.