### PR TITLE
fix(platform): enforce domain readiness contracts

### DIFF
--- a/docs/runbooks/privacy-retention.md
+++ b/docs/runbooks/privacy-retention.md
@@ -1,0 +1,32 @@
+# Privacy and data retention
+
+## Automated location purge
+
+Driver location checkpoints are operational telemetry, not a permanent ride record. The scheduled
+purge removes checkpoints older than `LOCATION_RETENTION_DURATION` (default `P30D`) in bounded,
+tenant-isolated batches. Configure `LOCATION_RETENTION_FIXED_DELAY` in milliseconds and
+`LOCATION_RETENTION_BATCH_SIZE`; set `LOCATION_RETENTION_ENABLED=false` only during controlled
+maintenance. Redis live-location entries remain short-lived dispatch state and are not an archive.
+
+Monitor purge failures in application logs and database growth. A legal hold that covers location
+data must be approved and documented before disabling the purge, with an owner and expiry date.
+
+## Delivery attempts
+
+Notification and webhook attempt metadata has operator-configurable policy values
+`NOTIFICATION_ATTEMPT_RETENTION` and `WEBHOOK_ATTEMPT_RETENTION` (defaults `P90D`). Attempts are
+append-only evidence and are not deleted by the application scheduler. Operators must implement an
+approved archival/deletion job against these values, preserving delivery audit requirements and
+tenant isolation. Do not delete parent delivery or outbox records while retained attempts refer to
+them.
+
+## Support and safety records
+
+Support cases/messages and safety incidents/evidence/actions are retained according to the
+operator's documented legal, regulatory, insurance, and litigation-hold policy. The application
+does not automatically purge these records. Evidence object lifecycle rules must match the database
+metadata policy. Access and deletion requests require legal review, audit recording, and coordinated
+removal of external evidence objects, backups, and derived exports.
+
+Review all durations at least annually and whenever the operating jurisdiction or product purpose
+changes. Test purge and restore procedures in a non-production environment before policy changes.

--- a/src/main/java/in/rsh/cab/driver/DriverDocumentService.java
+++ b/src/main/java/in/rsh/cab/driver/DriverDocumentService.java
@@ -67,6 +67,15 @@ public class DriverDocumentService {
   }
 
   @Transactional(readOnly = true)
+  public DriverDocument getOwn(UUID documentId) {
+    TenantContext context = require(TenantRole.DRIVER);
+    DriverProfile driver = drivers.findByTenantIdAndAccountId(context.tenantId(), context.accountId())
+        .orElseThrow(() -> new NotFoundException("Driver profile not found"));
+    return documents.find(context.tenantId(), driver.id(), documentId)
+        .orElseThrow(() -> new NotFoundException("Driver document not found"));
+  }
+
+  @Transactional(readOnly = true)
   public List<DriverDocument> list(UUID driverId) {
     TenantContext context = require(TenantRole.TENANT_ADMIN);
     requireDriver(context.tenantId(), driverId);

--- a/src/main/java/in/rsh/cab/driver/internal/web/DriverController.java
+++ b/src/main/java/in/rsh/cab/driver/internal/web/DriverController.java
@@ -33,7 +33,7 @@ public class DriverController {
   public ResponseEntity<DriverProfile> create(@Valid @RequestBody CreateDriverRequest request) {
     DriverProfile driver =
         drivers.create(request.accountId(), request.legalName(), request.phoneNumber());
-    return ResponseEntity.created(URI.create("/api/v1/drivers/" + driver.id())).body(driver);
+    return ResponseEntity.created(URI.create("/api/v1/drivers")).body(driver);
   }
 
   @GetMapping

--- a/src/main/java/in/rsh/cab/driver/internal/web/DriverDocumentController.java
+++ b/src/main/java/in/rsh/cab/driver/internal/web/DriverDocumentController.java
@@ -42,6 +42,11 @@ public class DriverDocumentController {
     return documents.listOwn();
   }
 
+  @GetMapping("/drivers/me/documents/{documentId}")
+  public DriverDocument getOwn(@PathVariable UUID documentId) {
+    return documents.getOwn(documentId);
+  }
+
   @GetMapping("/drivers/{driverId}/documents")
   public List<DriverDocument> list(@PathVariable UUID driverId) {
     return documents.list(driverId);

--- a/src/main/java/in/rsh/cab/fleet/internal/web/DriverShiftController.java
+++ b/src/main/java/in/rsh/cab/fleet/internal/web/DriverShiftController.java
@@ -29,7 +29,7 @@ public class DriverShiftController {
   @PostMapping
   public ResponseEntity<DriverShift> create(@Valid @RequestBody CreateShiftRequest request) {
     DriverShift shift = fleet.createShift(request.driverId(), request.vehicleId());
-    return ResponseEntity.created(URI.create("/api/v1/driver/shifts/" + shift.id())).body(shift);
+    return ResponseEntity.created(URI.create("/api/v1/driver/shifts")).body(shift);
   }
 
   @GetMapping

--- a/src/main/java/in/rsh/cab/fleet/internal/web/VehicleController.java
+++ b/src/main/java/in/rsh/cab/fleet/internal/web/VehicleController.java
@@ -36,7 +36,7 @@ public class VehicleController {
   @PostMapping
   public ResponseEntity<Vehicle> create(@Valid @RequestBody CreateVehicleRequest request) {
     Vehicle vehicle = fleet.createVehicle(request.registration(), request.serviceClass(), request.capacity());
-    return ResponseEntity.created(URI.create("/api/v1/vehicles/" + vehicle.id())).body(vehicle);
+    return ResponseEntity.created(URI.create("/api/v1/vehicles")).body(vehicle);
   }
 
   @GetMapping

--- a/src/main/java/in/rsh/cab/geography/internal/web/ServiceAreaController.java
+++ b/src/main/java/in/rsh/cab/geography/internal/web/ServiceAreaController.java
@@ -32,7 +32,7 @@ public class ServiceAreaController {
     ServiceArea serviceArea =
         serviceAreaService.create(
             request.slug(), request.name(), request.timezone(), request.boundary());
-    return ResponseEntity.created(URI.create("/api/v1/service-areas/" + serviceArea.id()))
+    return ResponseEntity.created(URI.create("/api/v1/service-areas"))
         .body(serviceArea);
   }
 

--- a/src/main/java/in/rsh/cab/location/LocationRetention.java
+++ b/src/main/java/in/rsh/cab/location/LocationRetention.java
@@ -1,0 +1,57 @@
+package in.rsh.cab.location;
+
+import in.rsh.cab.location.internal.persistence.LocationCheckpointRepository;
+import in.rsh.cab.tenancy.TenantExecution;
+import in.rsh.cab.tenancy.internal.persistence.TenantRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "retention.location.enabled", matchIfMissing = true)
+public class LocationRetention {
+
+  private static final Logger log = LoggerFactory.getLogger(LocationRetention.class);
+  private final TenantRepository tenants;
+  private final TenantExecution tenantExecution;
+  private final LocationCheckpointRepository checkpoints;
+  private final Clock clock;
+  private final Duration retention;
+  private final int batchSize;
+
+  public LocationRetention(
+      TenantRepository tenants,
+      TenantExecution tenantExecution,
+      LocationCheckpointRepository checkpoints,
+      Clock clock,
+      @Value("${retention.location.duration:P30D}") Duration retention,
+      @Value("${retention.location.batch-size:1000}") int batchSize) {
+    if (retention.isNegative() || retention.isZero()) {
+      throw new IllegalArgumentException("Location retention duration must be positive");
+    }
+    this.tenants = tenants;
+    this.tenantExecution = tenantExecution;
+    this.checkpoints = checkpoints;
+    this.clock = clock;
+    this.retention = retention;
+    this.batchSize = batchSize;
+  }
+
+  @Scheduled(fixedDelayString = "${retention.location.fixed-delay:3600000}")
+  public void purge() {
+    for (UUID tenantId : tenants.findActiveIds()) {
+      try {
+        tenantExecution.inTransaction(tenantId,
+            () -> checkpoints.deleteCreatedBefore(tenantId, clock.instant().minus(retention), batchSize));
+      } catch (RuntimeException exception) {
+        log.warn("Location retention purge failed tenant={}", tenantId, exception);
+      }
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/location/internal/persistence/JdbcLocationCheckpointRepository.java
+++ b/src/main/java/in/rsh/cab/location/internal/persistence/JdbcLocationCheckpointRepository.java
@@ -75,4 +75,20 @@ public class JdbcLocationCheckpointRepository implements LocationCheckpointRepos
             rs.getTimestamp("recorded_at").toInstant(), rs.getLong("sequence")))
         .list();
   }
+
+  @Override
+  public int deleteCreatedBefore(UUID tenantId, Instant cutoff, int limit) {
+    return jdbc.sql("""
+            DELETE FROM driver_location_checkpoints checkpoint
+            USING (
+              SELECT id FROM driver_location_checkpoints
+              WHERE tenant_id = :tenantId AND created_at < :cutoff
+              ORDER BY created_at, id
+              LIMIT :limit
+            ) expired
+            WHERE checkpoint.tenant_id = :tenantId AND checkpoint.id = expired.id
+            """)
+        .param("tenantId", tenantId).param("cutoff", Timestamp.from(cutoff))
+        .param("limit", Math.max(1, Math.min(limit, 10_000))).update();
+  }
 }

--- a/src/main/java/in/rsh/cab/location/internal/persistence/LocationCheckpointRepository.java
+++ b/src/main/java/in/rsh/cab/location/internal/persistence/LocationCheckpointRepository.java
@@ -12,4 +12,6 @@ public interface LocationCheckpointRepository {
 
   List<DriverLocation> findLatestEligible(
       UUID tenantId, Instant recordedSince, LocalDate currentDate, int limit);
+
+  int deleteCreatedBefore(UUID tenantId, Instant cutoff, int limit);
 }

--- a/src/main/java/in/rsh/cab/payment/internal/persistence/JdbcPaymentRepository.java
+++ b/src/main/java/in/rsh/cab/payment/internal/persistence/JdbcPaymentRepository.java
@@ -570,7 +570,15 @@ public class JdbcPaymentRepository implements PaymentRepository {
             """)
         .param("tenantId", tenantId).query((rs, row) -> new SettlementBatch(
             rs.getObject("id", UUID.class), rs.getString("currency"), rs.getString("state"),
-            rs.getLong("total_minor"), rs.getTimestamp("created_at").toInstant(), List.of())).list();
+            rs.getLong("total_minor"), rs.getTimestamp("created_at").toInstant(), List.of())).list()
+        .stream().map(batch -> new SettlementBatch(batch.id(), batch.currency(), batch.state(),
+            batch.totalMinor(), batch.createdAt(), jdbc.sql("""
+                SELECT id, driver_id, amount_minor, currency, state, payment_account_id,
+                       provider_payout_id, provider_version, failure_code
+                FROM payouts WHERE tenant_id = :tenantId AND settlement_batch_id = :batchId
+                ORDER BY created_at, id
+                """).param("tenantId", tenantId).param("batchId", batch.id())
+                .query(this::mapPayout).list())).toList();
   }
 
   private void postMarketplaceLedger(

--- a/src/main/java/in/rsh/cab/payment/internal/web/PaymentController.java
+++ b/src/main/java/in/rsh/cab/payment/internal/web/PaymentController.java
@@ -53,8 +53,8 @@ public class PaymentController {
     PaymentService.RefundCreation result = payments.refund(
         idempotencyKey, paymentId, request.amountMinor(), request.reason());
     Refund refund = result.refund();
-    return ResponseEntity.created(URI.create("/api/v1/payments/" + paymentId + "/refunds/"
-        + refund.id())).header("Idempotent-Replayed", Boolean.toString(result.replayed())).body(refund);
+    return ResponseEntity.created(URI.create("/api/v1/finance/refunds/" + refund.id()))
+        .header("Idempotent-Replayed", Boolean.toString(result.replayed())).body(refund);
   }
 
   @GetMapping("/api/v1/finance/refunds/{refundId}")
@@ -71,7 +71,7 @@ public class PaymentController {
   public ResponseEntity<SettlementBatch> settle(
       @Valid @RequestBody SettlementRequest request) {
     SettlementBatch batch = payments.settle(request.currency());
-    return ResponseEntity.created(URI.create("/api/v1/finance/settlements/" + batch.id()))
+    return ResponseEntity.created(URI.create("/api/v1/finance/settlements"))
         .body(batch);
   }
 

--- a/src/main/java/in/rsh/cab/pricing/PricingService.java
+++ b/src/main/java/in/rsh/cab/pricing/PricingService.java
@@ -209,13 +209,30 @@ public class PricingService {
   public FareQuote getOwnQuote(UUID quoteId) {
     TenantContext context = require(TenantRole.RIDER);
     return pricing.findQuote(context.tenantId(), context.accountId(), quoteId)
+        .map(this::withDerivedStatus)
         .orElseThrow(() -> new NotFoundException("Fare quote not found"));
   }
 
   @Transactional(readOnly = true)
   public List<FareQuote> listOwnQuotes() {
     TenantContext context = require(TenantRole.RIDER);
-    return pricing.findQuotes(context.tenantId(), context.accountId());
+    return pricing.findQuotes(context.tenantId(), context.accountId()).stream()
+        .map(this::withDerivedStatus).toList();
+  }
+
+  private FareQuote withDerivedStatus(FareQuote quote) {
+    if (quote.status() != QuoteStatus.ACTIVE || clock.instant().isBefore(quote.expiresAt())) {
+      return quote;
+    }
+    return new FareQuote(quote.id(), quote.productId(), quote.pricingRuleId(),
+        quote.pricingRuleVersion(), quote.pickup(), quote.dropoff(), quote.routeDistanceMeters(),
+        quote.routeDurationSeconds(), quote.baseRateMinor(), quote.perKmRateMinor(),
+        quote.perMinuteRateMinor(), quote.minimumFareMinor(), quote.surgeBasisPoints(),
+        quote.taxBasisPoints(), quote.baseFareMinor(), quote.distanceFareMinor(),
+        quote.timeFareMinor(), quote.minimumAdjustmentMinor(), quote.subtotalMinor(),
+        quote.surgeMinor(), quote.taxMinor(), quote.totalMinor(), quote.currency(),
+        QuoteStatus.EXPIRED, quote.expiresAt(), quote.requestFingerprint(), quote.createdAt(),
+        quote.updatedAt(), quote.version());
   }
 
   private FareQuote calculateQuote(

--- a/src/main/java/in/rsh/cab/pricing/internal/web/PricingRuleController.java
+++ b/src/main/java/in/rsh/cab/pricing/internal/web/PricingRuleController.java
@@ -35,7 +35,7 @@ public class PricingRuleController {
         request.productId(), request.effectiveFrom(), request.effectiveTo(), request.baseFareMinor(),
         request.perKmMinor(), request.perMinuteMinor(), request.minimumFareMinor(), request.currency(),
         request.surgeBasisPoints(), request.taxBasisPoints(), request.active());
-    return ResponseEntity.created(URI.create("/api/v1/pricing-rules/" + rule.id())).body(rule);
+    return ResponseEntity.created(URI.create("/api/v1/pricing-rules")).body(rule);
   }
 
   @GetMapping

--- a/src/main/java/in/rsh/cab/pricing/internal/web/ProductController.java
+++ b/src/main/java/in/rsh/cab/pricing/internal/web/ProductController.java
@@ -33,7 +33,7 @@ public class ProductController {
   public ResponseEntity<ServiceProduct> create(@Valid @RequestBody CreateProductRequest request) {
     ServiceProduct product = pricing.createProduct(
         request.slug(), request.name(), request.status(), request.capacity(), request.serviceClass());
-    return ResponseEntity.created(URI.create("/api/v1/products/" + product.id())).body(product);
+    return ResponseEntity.created(URI.create("/api/v1/products")).body(product);
   }
 
   @GetMapping

--- a/src/main/java/in/rsh/cab/rating/RatingService.java
+++ b/src/main/java/in/rsh/cab/rating/RatingService.java
@@ -74,6 +74,17 @@ public class RatingService {
     return rating;
   }
 
+  @Transactional(readOnly = true)
+  public Rating getOwn(UUID ratingId) {
+    TenantContext context = TenantContext.require();
+    if (!context.roles().contains(TenantRole.RIDER)
+        && !context.roles().contains(TenantRole.DRIVER)) {
+      throw new TenantAccessDeniedException("RIDER or DRIVER role is required");
+    }
+    return ratings.findOwn(context.tenantId(), context.accountId(), ratingId)
+        .orElseThrow(() -> new NotFoundException("Rating not found"));
+  }
+
   private record RatingEvent(UUID ratingId, UUID rideId, UUID revieweeAccountId, int score) {}
 
   private record RatingAudit(UUID rideId, int score) {}

--- a/src/main/java/in/rsh/cab/rating/internal/persistence/JdbcRatingRepository.java
+++ b/src/main/java/in/rsh/cab/rating/internal/persistence/JdbcRatingRepository.java
@@ -2,6 +2,8 @@ package in.rsh.cab.rating.internal.persistence;
 
 import in.rsh.cab.rating.Rating;
 import java.sql.Timestamp;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -47,5 +49,26 @@ public class JdbcRatingRepository implements RatingRepository {
         .param("score", rating.score()).param("comment", rating.comment())
         .param("status", rating.moderationStatus())
         .param("createdAt", Timestamp.from(rating.createdAt())).update();
+  }
+
+  @Override
+  public Optional<Rating> findOwn(UUID tenantId, UUID accountId, UUID ratingId) {
+    return jdbc.sql("""
+            SELECT id, ride_id, reviewer_account_id, reviewee_account_id, reviewer_role,
+                   reviewee_role, score, comment, moderation_status, created_at
+            FROM ratings
+            WHERE tenant_id = :tenantId AND id = :ratingId
+              AND (reviewer_account_id = :accountId OR reviewee_account_id = :accountId)
+            """)
+        .param("tenantId", tenantId).param("ratingId", ratingId).param("accountId", accountId)
+        .query(this::map).optional();
+  }
+
+  private Rating map(ResultSet rs, int row) throws SQLException {
+    return new Rating(rs.getObject("id", UUID.class), rs.getObject("ride_id", UUID.class),
+        rs.getObject("reviewer_account_id", UUID.class),
+        rs.getObject("reviewee_account_id", UUID.class), rs.getString("reviewer_role"),
+        rs.getString("reviewee_role"), rs.getInt("score"), rs.getString("comment"),
+        rs.getString("moderation_status"), rs.getTimestamp("created_at").toInstant());
   }
 }

--- a/src/main/java/in/rsh/cab/rating/internal/persistence/RatingRepository.java
+++ b/src/main/java/in/rsh/cab/rating/internal/persistence/RatingRepository.java
@@ -10,5 +10,7 @@ public interface RatingRepository {
 
   void insert(UUID tenantId, Rating rating);
 
+  Optional<Rating> findOwn(UUID tenantId, UUID accountId, UUID ratingId);
+
   record RideParticipants(UUID riderAccountId, UUID driverAccountId) {}
 }

--- a/src/main/java/in/rsh/cab/rating/internal/web/RatingController.java
+++ b/src/main/java/in/rsh/cab/rating/internal/web/RatingController.java
@@ -10,13 +10,14 @@ import java.net.URI;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/rides/{rideId}/ratings")
+@RequestMapping("/api/v1")
 public class RatingController {
 
   private final RatingService ratings;
@@ -25,11 +26,16 @@ public class RatingController {
     this.ratings = ratings;
   }
 
-  @PostMapping
+  @PostMapping("/rides/{rideId}/ratings")
   public ResponseEntity<Rating> create(
       @PathVariable UUID rideId, @Valid @RequestBody RatingRequest request) {
     Rating rating = ratings.create(rideId, request.score(), request.comment());
     return ResponseEntity.created(URI.create("/api/v1/ratings/" + rating.id())).body(rating);
+  }
+
+  @GetMapping("/ratings/{ratingId}")
+  public Rating getOwn(@PathVariable UUID ratingId) {
+    return ratings.getOwn(ratingId);
   }
 
   public record RatingRequest(@Min(1) @Max(5) int score, @Size(max = 1000) String comment) {}

--- a/src/main/java/in/rsh/cab/ride/RideEventStream.java
+++ b/src/main/java/in/rsh/cab/ride/RideEventStream.java
@@ -57,31 +57,41 @@ public class RideEventStream {
   }
 
   @Transactional(readOnly = true)
-  public SseEmitter subscribe(UUID rideId) {
+  public SseEmitter subscribe(UUID rideId, Long lastEventId) {
     TenantContext context = TenantContext.require();
-    authorize(context, rideId);
+    visibleRide(context, rideId);
     ActorKey actorKey = new ActorKey(context.tenantId(), context.accountId());
     RideKey rideKey = new RideKey(context.tenantId(), rideId);
     SseEmitter emitter = emitterFactory.apply(timeoutMillis);
     Subscription subscription = new Subscription(actorKey, rideKey, emitter);
+    emitter.onCompletion(() -> remove(subscription));
+    emitter.onTimeout(() -> remove(subscription));
+    emitter.onError(ignored -> remove(subscription));
     synchronized (this) {
       if (byActor.getOrDefault(actorKey, Set.of()).size() >= maxPerActor
           || byRide.getOrDefault(rideKey, Set.of()).size() >= maxPerRide) {
         throw new ConflictException("Too many active ride event streams");
       }
-      byActor.computeIfAbsent(actorKey, ignored -> new HashSet<>()).add(subscription);
-      byRide.computeIfAbsent(rideKey, ignored -> new HashSet<>()).add(subscription);
-    }
-    emitter.onCompletion(() -> remove(subscription));
-    emitter.onTimeout(() -> remove(subscription));
-    emitter.onError(ignored -> remove(subscription));
-    try {
-      emitter.send(SseEmitter.event().name("ready").comment("ride status stream ready"));
-    } catch (IOException exception) {
-      remove(subscription);
-      throw new IllegalStateException("Could not open ride event stream", exception);
+      Ride current = visibleRide(context, rideId);
+      try {
+        // Always establish the stream with a full current snapshot. A newer version than the
+        // resume hint therefore also supplies the minimal Last-Event-ID catch-up behavior.
+        if (lastEventId != null && current.version() <= lastEventId) {
+          emitter.send(SseEmitter.event().comment("current ride version already observed"));
+        }
+        emitter.send(statusEvent(current));
+        byActor.computeIfAbsent(actorKey, ignored -> new HashSet<>()).add(subscription);
+        byRide.computeIfAbsent(rideKey, ignored -> new HashSet<>()).add(subscription);
+      } catch (IOException | IllegalStateException exception) {
+        remove(subscription);
+        throw new IllegalStateException("Could not open ride event stream", exception);
+      }
     }
     return emitter;
+  }
+
+  public SseEmitter subscribe(UUID rideId) {
+    return subscribe(rideId, null);
   }
 
   public void afterCommit(UUID tenantId, Ride ride) {
@@ -109,8 +119,7 @@ public class RideEventStream {
     }
     for (Subscription subscription : subscribers) {
       try {
-        subscription.emitter().send(
-            SseEmitter.event().name("ride-status").id(Long.toString(event.version())).data(event));
+        subscription.emitter().send(statusEvent(event));
       } catch (IOException | IllegalStateException exception) {
         remove(subscription);
       }
@@ -121,30 +130,43 @@ public class RideEventStream {
     return byRide.getOrDefault(new RideKey(tenantId, rideId), Set.of()).size();
   }
 
-  private void authorize(TenantContext context, UUID rideId) {
+  private Ride visibleRide(TenantContext context, UUID rideId) {
     boolean staff = context.roles().stream().anyMatch(STAFF::contains);
-    boolean visible;
+    Ride visible = null;
     if (staff) {
-      visible = rides.find(context.tenantId(), rideId).isPresent();
+      visible = rides.find(context.tenantId(), rideId).orElse(null);
     } else {
       boolean rider = context.roles().contains(TenantRole.RIDER);
       boolean driver = context.roles().contains(TenantRole.DRIVER);
       if (!rider && !driver) {
         throw new TenantAccessDeniedException("Ride event stream access is restricted");
       }
-      visible = rider && rides.findOwn(context.tenantId(), context.accountId(), rideId).isPresent();
-      if (!visible && driver) {
-        visible = rides.findAssignedToDriver(context.tenantId(), context.accountId(), rideId).isPresent();
+      if (rider) {
+        visible = rides.findOwn(context.tenantId(), context.accountId(), rideId).orElse(null);
+      }
+      if (visible == null && driver) {
+        visible = rides.findAssignedToDriver(context.tenantId(), context.accountId(), rideId)
+            .orElse(null);
       }
     }
-    if (!visible) {
+    if (visible == null) {
       throw new NotFoundException("Ride not found");
     }
+    return visible;
   }
 
   private synchronized void remove(Subscription subscription) {
     remove(byActor, subscription.actorKey(), subscription);
     remove(byRide, subscription.rideKey(), subscription);
+  }
+
+  private SseEmitter.SseEventBuilder statusEvent(Ride ride) {
+    return statusEvent(new RideStatusEvent(
+        ride.id(), ride.status(), ride.version(), ride.updatedAt()));
+  }
+
+  private SseEmitter.SseEventBuilder statusEvent(RideStatusEvent event) {
+    return SseEmitter.event().name("ride-status").id(Long.toString(event.version())).data(event);
   }
 
   private <K> void remove(Map<K, Set<Subscription>> index, K key, Subscription subscription) {

--- a/src/main/java/in/rsh/cab/ride/internal/web/RideController.java
+++ b/src/main/java/in/rsh/cab/ride/internal/web/RideController.java
@@ -54,8 +54,10 @@ public class RideController {
   }
 
   @GetMapping(value = "/{id}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter events(@PathVariable UUID id) {
-    return events.subscribe(id);
+  public SseEmitter events(
+      @PathVariable UUID id,
+      @RequestHeader(value = "Last-Event-ID", required = false) Long lastEventId) {
+    return events.subscribe(id, lastEventId);
   }
 
   @PostMapping("/{id}/cancel")

--- a/src/main/java/in/rsh/cab/safety/SafetyIncident.java
+++ b/src/main/java/in/rsh/cab/safety/SafetyIncident.java
@@ -14,6 +14,7 @@ public record SafetyIncident(
     String severity,
     Instant createdAt,
     Instant updatedAt,
+    long version,
     List<Evidence> evidence) {
 
   public record Evidence(

--- a/src/main/java/in/rsh/cab/safety/SafetyService.java
+++ b/src/main/java/in/rsh/cab/safety/SafetyService.java
@@ -1,6 +1,7 @@
 package in.rsh.cab.safety;
 
 import in.rsh.cab.audit.AuditService;
+import in.rsh.cab.exception.ConflictException;
 import in.rsh.cab.exception.InvalidRequestException;
 import in.rsh.cab.exception.NotFoundException;
 import in.rsh.cab.operations.OutboxService;
@@ -11,6 +12,7 @@ import in.rsh.cab.tenancy.TenantRole;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -21,8 +23,12 @@ import tools.jackson.databind.ObjectMapper;
 @Service
 public class SafetyService {
 
-  private static final Set<String> STATES =
-      Set.of("REPORTED", "TRIAGED", "INVESTIGATING", "RESOLVED", "CLOSED");
+  private static final Map<String, Set<String>> TRANSITIONS = Map.of(
+      "REPORTED", Set.of("TRIAGED", "CLOSED"),
+      "TRIAGED", Set.of("INVESTIGATING", "RESOLVED", "CLOSED"),
+      "INVESTIGATING", Set.of("RESOLVED", "CLOSED"),
+      "RESOLVED", Set.of("INVESTIGATING", "CLOSED"),
+      "CLOSED", Set.of());
   private static final Set<String> SEVERITIES =
       Set.of("UNASSESSED", "LOW", "MEDIUM", "HIGH", "CRITICAL");
   private static final Pattern OBJECT_KEY =
@@ -51,7 +57,7 @@ public class SafetyService {
     }
     Instant now = clock.instant();
     SafetyIncident incident = new SafetyIncident(UUID.randomUUID(), rideId, context.accountId(),
-        category, description, "REPORTED", "UNASSESSED", now, now, List.of());
+        category, description, "REPORTED", "UNASSESSED", now, now, 0, List.of());
     incidents.insert(context.tenantId(), incident);
     incidents.appendAction(context.tenantId(), incident.id(), context.accountId(), "REPORTED",
         null, "REPORTED", null, now);
@@ -69,6 +75,21 @@ public class SafetyService {
   public List<SafetyIncident> listRestricted() {
     TenantContext context = requireRestricted();
     return incidents.findAll(context.tenantId());
+  }
+
+  @Transactional(readOnly = true)
+  public SafetyIncident get(UUID incidentId) {
+    TenantContext context = TenantContext.require();
+    SafetyIncident incident = incidents.find(context.tenantId(), incidentId)
+        .orElseThrow(() -> new NotFoundException("Safety incident not found"));
+    if (!isRestricted(context)) {
+      requireAny(TenantRole.RIDER, TenantRole.DRIVER);
+    }
+    if (!isRestricted(context) && !incidents.isRideParticipant(
+        context.tenantId(), incident.rideId(), context.accountId())) {
+      throw new NotFoundException("Safety incident not found");
+    }
+    return incident;
   }
 
   @Transactional
@@ -95,15 +116,27 @@ public class SafetyService {
 
   @Transactional
   public SafetyIncident action(
-      UUID incidentId, String action, String state, String severity, String note) {
+      UUID incidentId, String action, String expectedState, String state, String severity,
+      long expectedVersion, String note) {
     TenantContext context = requireRestricted();
-    if (!STATES.contains(state) || !SEVERITIES.contains(severity)) {
+    if (!TRANSITIONS.containsKey(expectedState) || !TRANSITIONS.containsKey(state)
+        || !SEVERITIES.contains(severity)) {
       throw new InvalidRequestException("Unsupported safety state or severity");
     }
     SafetyIncident current = incidents.find(context.tenantId(), incidentId)
         .orElseThrow(() -> new NotFoundException("Safety incident not found"));
+    if (current.version() != expectedVersion || !current.state().equals(expectedState)) {
+      throw new ConflictException("Safety incident state or version is stale");
+    }
+    if (!TRANSITIONS.get(current.state()).contains(state)) {
+      throw new ConflictException(
+          "Safety incident cannot transition from " + current.state() + " to " + state);
+    }
     Instant now = clock.instant();
-    incidents.update(context.tenantId(), incidentId, state, severity, now);
+    if (!incidents.update(context.tenantId(), incidentId, expectedState, state, severity,
+        expectedVersion, now)) {
+      throw new ConflictException("Safety incident changed concurrently");
+    }
     incidents.appendAction(context.tenantId(), incidentId, context.accountId(), action,
         current.state(), state, note, now);
     audit.record(context.tenantId(), context.accountId(), "safety_incident.action",

--- a/src/main/java/in/rsh/cab/safety/internal/persistence/JdbcSafetyRepository.java
+++ b/src/main/java/in/rsh/cab/safety/internal/persistence/JdbcSafetyRepository.java
@@ -16,7 +16,7 @@ public class JdbcSafetyRepository implements SafetyRepository {
 
   private static final String SELECT = """
       SELECT id, ride_id, reported_by_account_id, category, description, state, severity,
-             created_at, updated_at FROM safety_incidents
+             created_at, updated_at, version FROM safety_incidents
       """;
   private final JdbcClient jdbc;
 
@@ -55,13 +55,15 @@ public class JdbcSafetyRepository implements SafetyRepository {
   @Override
   public Optional<SafetyIncident> find(UUID tenantId, UUID incidentId) {
     return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId AND id = :id")
-        .param("tenantId", tenantId).param("id", incidentId).query(this::map).optional();
+        .param("tenantId", tenantId).param("id", incidentId).query(this::map).optional()
+        .map(incident -> withEvidence(tenantId, incident));
   }
 
   @Override
   public List<SafetyIncident> findAll(UUID tenantId) {
     return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId ORDER BY created_at DESC, id")
-        .param("tenantId", tenantId).query(this::map).list();
+        .param("tenantId", tenantId).query(this::map).list().stream()
+        .map(incident -> withEvidence(tenantId, incident)).toList();
   }
 
   @Override
@@ -81,13 +83,18 @@ public class JdbcSafetyRepository implements SafetyRepository {
   }
 
   @Override
-  public boolean update(UUID tenantId, UUID incidentId, String state, String severity, Instant now) {
+  public boolean update(
+      UUID tenantId, UUID incidentId, String expectedState, String state, String severity,
+      long expectedVersion, Instant now) {
     return jdbc.sql("""
-            UPDATE safety_incidents SET state = :state, severity = :severity, updated_at = :now
-            WHERE tenant_id = :tenantId AND id = :id
+            UPDATE safety_incidents
+            SET state = :state, severity = :severity, updated_at = :now, version = version + 1
+            WHERE tenant_id = :tenantId AND id = :id AND state = :expectedState
+              AND version = :expectedVersion
             """)
         .param("state", state).param("severity", severity).param("now", Timestamp.from(now))
-        .param("tenantId", tenantId).param("id", incidentId).update() == 1;
+        .param("tenantId", tenantId).param("id", incidentId).param("expectedState", expectedState)
+        .param("expectedVersion", expectedVersion).update() == 1;
   }
 
   @Override
@@ -112,6 +119,25 @@ public class JdbcSafetyRepository implements SafetyRepository {
         rs.getObject("reported_by_account_id", UUID.class), rs.getString("category"),
         rs.getString("description"), rs.getString("state"), rs.getString("severity"),
         rs.getTimestamp("created_at").toInstant(), rs.getTimestamp("updated_at").toInstant(),
-        List.of());
+        rs.getLong("version"), List.of());
+  }
+
+  private SafetyIncident withEvidence(UUID tenantId, SafetyIncident incident) {
+    List<SafetyIncident.Evidence> evidence = jdbc.sql("""
+            SELECT id, submitted_by_account_id, object_key, media_type, size_bytes,
+                   checksum_sha256, created_at
+            FROM safety_evidence
+            WHERE tenant_id = :tenantId AND incident_id = :incidentId
+            ORDER BY created_at, id
+            """)
+        .param("tenantId", tenantId).param("incidentId", incident.id())
+        .query((rs, row) -> new SafetyIncident.Evidence(rs.getObject("id", UUID.class),
+            rs.getObject("submitted_by_account_id", UUID.class), rs.getString("object_key"),
+            rs.getString("media_type"), rs.getObject("size_bytes", Long.class),
+            rs.getString("checksum_sha256"), rs.getTimestamp("created_at").toInstant()))
+        .list();
+    return new SafetyIncident(incident.id(), incident.rideId(), incident.reportedByAccountId(),
+        incident.category(), incident.description(), incident.state(), incident.severity(),
+        incident.createdAt(), incident.updatedAt(), incident.version(), evidence);
   }
 }

--- a/src/main/java/in/rsh/cab/safety/internal/persistence/SafetyRepository.java
+++ b/src/main/java/in/rsh/cab/safety/internal/persistence/SafetyRepository.java
@@ -18,7 +18,9 @@ public interface SafetyRepository {
 
   void insertEvidence(UUID tenantId, UUID incidentId, SafetyIncident.Evidence evidence);
 
-  boolean update(UUID tenantId, UUID incidentId, String state, String severity, Instant now);
+  boolean update(
+      UUID tenantId, UUID incidentId, String expectedState, String state, String severity,
+      long expectedVersion, Instant now);
 
   void appendAction(UUID tenantId, UUID incidentId, UUID actorId, String action,
       String fromState, String toState, String note, Instant now);

--- a/src/main/java/in/rsh/cab/safety/internal/web/SafetyController.java
+++ b/src/main/java/in/rsh/cab/safety/internal/web/SafetyController.java
@@ -41,18 +41,23 @@ public class SafetyController {
     return safety.listRestricted();
   }
 
+  @GetMapping("/{id}")
+  public SafetyIncident get(@PathVariable UUID id) {
+    return safety.get(id);
+  }
+
   @PostMapping("/{id}/evidence")
   public ResponseEntity<SafetyIncident.Evidence> evidence(
       @PathVariable UUID id, @Valid @RequestBody EvidenceRequest request) {
     SafetyIncident.Evidence evidence = safety.addEvidence(id, request.objectKey(),
         request.mediaType(), request.sizeBytes(), request.checksumSha256());
-    return ResponseEntity.created(URI.create("/api/v1/safety/incidents/" + id + "/evidence/"
-        + evidence.id())).body(evidence);
+    return ResponseEntity.created(URI.create("/api/v1/safety/incidents/" + id)).body(evidence);
   }
 
   @PostMapping("/{id}/actions")
   public SafetyIncident action(@PathVariable UUID id, @Valid @RequestBody ActionRequest request) {
-    return safety.action(id, request.action(), request.state(), request.severity(), request.note());
+    return safety.action(id, request.action(), request.expectedState(), request.state(),
+        request.severity(), request.version(), request.note());
   }
 
   public record ReportRequest(
@@ -68,7 +73,10 @@ public class SafetyController {
 
   public record ActionRequest(
       @NotBlank @Size(max = 64) String action,
+      @NotBlank @Pattern(regexp = "REPORTED|TRIAGED|INVESTIGATING|RESOLVED|CLOSED")
+          String expectedState,
       @NotBlank @Pattern(regexp = "REPORTED|TRIAGED|INVESTIGATING|RESOLVED|CLOSED") String state,
       @NotBlank @Pattern(regexp = "UNASSESSED|LOW|MEDIUM|HIGH|CRITICAL") String severity,
+      @PositiveOrZero long version,
       @Size(max = 500) String note) {}
 }

--- a/src/main/java/in/rsh/cab/support/SupportCase.java
+++ b/src/main/java/in/rsh/cab/support/SupportCase.java
@@ -13,6 +13,7 @@ public record SupportCase(
     String priority,
     Instant createdAt,
     Instant updatedAt,
+    long version,
     List<Message> messages) {
 
   public record Message(

--- a/src/main/java/in/rsh/cab/support/SupportService.java
+++ b/src/main/java/in/rsh/cab/support/SupportService.java
@@ -1,6 +1,7 @@
 package in.rsh.cab.support;
 
 import in.rsh.cab.audit.AuditService;
+import in.rsh.cab.exception.ConflictException;
 import in.rsh.cab.exception.InvalidRequestException;
 import in.rsh.cab.exception.NotFoundException;
 import in.rsh.cab.operations.OutboxService;
@@ -11,6 +12,7 @@ import in.rsh.cab.tenancy.TenantRole;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,12 @@ import tools.jackson.databind.ObjectMapper;
 @Service
 public class SupportService {
 
-  private static final Set<String> STATES =
-      Set.of("OPEN", "IN_PROGRESS", "WAITING", "RESOLVED", "CLOSED");
+  private static final Map<String, Set<String>> TRANSITIONS = Map.of(
+      "OPEN", Set.of("IN_PROGRESS", "WAITING", "RESOLVED", "CLOSED"),
+      "IN_PROGRESS", Set.of("WAITING", "RESOLVED", "CLOSED"),
+      "WAITING", Set.of("IN_PROGRESS", "RESOLVED", "CLOSED"),
+      "RESOLVED", Set.of("IN_PROGRESS", "CLOSED"),
+      "CLOSED", Set.of());
   private final SupportRepository cases;
   private final OutboxService outbox;
   private final AuditService audit;
@@ -48,7 +54,7 @@ public class SupportService {
     SupportCase.Message first = new SupportCase.Message(
         UUID.randomUUID(), context.accountId(), message, false, now);
     SupportCase supportCase = new SupportCase(UUID.randomUUID(), context.accountId(), rideId,
-        subject, "OPEN", "NORMAL", now, now, List.of(first));
+        subject, "OPEN", "NORMAL", now, now, 0, List.of(first));
     cases.insert(context.tenantId(), supportCase, first);
     outbox.append(context.tenantId(), "support_case", supportCase.id(), 0,
         "support.case_created", 1,
@@ -65,7 +71,23 @@ public class SupportService {
       return cases.findAll(context.tenantId());
     }
     requireAny(TenantRole.RIDER, TenantRole.DRIVER);
-    return cases.findOwn(context.tenantId(), context.accountId());
+    return cases.findOwn(context.tenantId(), context.accountId()).stream()
+        .map(this::withoutInternalMessages).toList();
+  }
+
+  @Transactional(readOnly = true)
+  public SupportCase get(UUID caseId) {
+    TenantContext context = TenantContext.require();
+    SupportCase supportCase = cases.find(context.tenantId(), caseId)
+        .orElseThrow(() -> new NotFoundException("Support case not found"));
+    if (isStaff(context)) {
+      return supportCase;
+    }
+    requireAny(TenantRole.RIDER, TenantRole.DRIVER);
+    if (!supportCase.openedByAccountId().equals(context.accountId())) {
+      throw new NotFoundException("Support case not found");
+    }
+    return withoutInternalMessages(supportCase);
   }
 
   @Transactional
@@ -81,21 +103,32 @@ public class SupportService {
     }
     cases.insertMessage(context.tenantId(), caseId,
         new SupportCase.Message(UUID.randomUUID(), context.accountId(), body, internal, clock.instant()));
-    return cases.find(context.tenantId(), caseId).orElseThrow();
+    SupportCase updated = cases.find(context.tenantId(), caseId).orElseThrow();
+    return isStaff(context) ? updated : withoutInternalMessages(updated);
   }
 
   @Transactional
-  public SupportCase changeState(UUID caseId, String next, String reason) {
+  public SupportCase changeState(
+      UUID caseId, String expectedState, String next, long expectedVersion, String reason) {
     TenantContext context = requireStaff();
-    if (!STATES.contains(next)) {
+    if (!TRANSITIONS.containsKey(expectedState) || !TRANSITIONS.containsKey(next)) {
       throw new InvalidRequestException("Unsupported support case state");
     }
     SupportCase current = cases.find(context.tenantId(), caseId)
         .orElseThrow(() -> new NotFoundException("Support case not found"));
+    if (current.version() != expectedVersion || !current.state().equals(expectedState)) {
+      throw new ConflictException("Support case state or version is stale");
+    }
+    if (!TRANSITIONS.get(current.state()).contains(next)) {
+      throw new ConflictException("Support case cannot transition from " + current.state() + " to " + next);
+    }
     Instant now = clock.instant();
-    cases.updateState(context.tenantId(), caseId, next, now);
+    if (!cases.updateState(
+        context.tenantId(), caseId, expectedState, next, expectedVersion, now)) {
+      throw new ConflictException("Support case changed concurrently");
+    }
     cases.appendState(context.tenantId(), caseId, current.state(), next, context.accountId(), reason, now);
-    outbox.append(context.tenantId(), "support_case", caseId, 1,
+    outbox.append(context.tenantId(), "support_case", caseId, expectedVersion + 1,
         "support.case_state_changed", 1,
         json.valueToTree(new CaseEvent(caseId, current.rideId(), next)), null);
     audit.record(context.tenantId(), context.accountId(), "support_case.state", "support_case",
@@ -104,11 +137,20 @@ public class SupportService {
   }
 
   @Transactional
-  public void assign(UUID caseId, UUID assigneeId) {
+  public void assign(UUID caseId, UUID assigneeId, long expectedVersion) {
     TenantContext context = requireStaff();
-    cases.find(context.tenantId(), caseId)
+    SupportCase supportCase = cases.find(context.tenantId(), caseId)
         .orElseThrow(() -> new NotFoundException("Support case not found"));
-    cases.assign(context.tenantId(), caseId, assigneeId, context.accountId(), clock.instant());
+    if (supportCase.version() != expectedVersion) {
+      throw new ConflictException("Support case changed concurrently");
+    }
+    if (!cases.hasStaffRole(context.tenantId(), assigneeId)) {
+      throw new InvalidRequestException("Assignee must have SUPPORT or TENANT_ADMIN role");
+    }
+    if (!cases.assign(context.tenantId(), caseId, assigneeId, context.accountId(),
+        expectedVersion, clock.instant())) {
+      throw new ConflictException("Support case changed concurrently");
+    }
     audit.record(context.tenantId(), context.accountId(), "support_case.assign", "support_case",
         caseId, "SUCCESS", json.valueToTree(new AssignmentAudit(assigneeId)));
   }
@@ -128,6 +170,13 @@ public class SupportService {
   private boolean isStaff(TenantContext context) {
     return context.roles().contains(TenantRole.SUPPORT)
         || context.roles().contains(TenantRole.TENANT_ADMIN);
+  }
+
+  private SupportCase withoutInternalMessages(SupportCase supportCase) {
+    return new SupportCase(supportCase.id(), supportCase.openedByAccountId(), supportCase.rideId(),
+        supportCase.subject(), supportCase.state(), supportCase.priority(), supportCase.createdAt(),
+        supportCase.updatedAt(), supportCase.version(), supportCase.messages().stream()
+            .filter(message -> !message.internal()).toList());
   }
 
   private record CaseAudit(UUID rideId, String state) {}

--- a/src/main/java/in/rsh/cab/support/internal/persistence/JdbcSupportRepository.java
+++ b/src/main/java/in/rsh/cab/support/internal/persistence/JdbcSupportRepository.java
@@ -15,7 +15,8 @@ import org.springframework.stereotype.Repository;
 public class JdbcSupportRepository implements SupportRepository {
 
   private static final String SELECT = """
-      SELECT id, opened_by_account_id, ride_id, subject, state, priority, created_at, updated_at
+      SELECT id, opened_by_account_id, ride_id, subject, state, priority, created_at, updated_at,
+             version
       FROM support_cases
       """;
   private final JdbcClient jdbc;
@@ -58,19 +59,22 @@ public class JdbcSupportRepository implements SupportRepository {
             WHERE tenant_id = :tenantId AND opened_by_account_id = :accountId
             ORDER BY updated_at DESC, id
             """)
-        .param("tenantId", tenantId).param("accountId", accountId).query(this::map).list();
+        .param("tenantId", tenantId).param("accountId", accountId).query(this::map).list().stream()
+        .map(supportCase -> withMessages(tenantId, supportCase)).toList();
   }
 
   @Override
   public List<SupportCase> findAll(UUID tenantId) {
     return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId ORDER BY updated_at DESC, id")
-        .param("tenantId", tenantId).query(this::map).list();
+        .param("tenantId", tenantId).query(this::map).list().stream()
+        .map(supportCase -> withMessages(tenantId, supportCase)).toList();
   }
 
   @Override
   public Optional<SupportCase> find(UUID tenantId, UUID caseId) {
     return jdbc.sql(SELECT + " WHERE tenant_id = :tenantId AND id = :id")
-        .param("tenantId", tenantId).param("id", caseId).query(this::map).optional();
+        .param("tenantId", tenantId).param("id", caseId).query(this::map).optional()
+        .map(supportCase -> withMessages(tenantId, supportCase));
   }
 
   @Override
@@ -87,13 +91,18 @@ public class JdbcSupportRepository implements SupportRepository {
   }
 
   @Override
-  public boolean updateState(UUID tenantId, UUID caseId, String state, Instant now) {
+  public boolean updateState(
+      UUID tenantId, UUID caseId, String expectedState, String state, long expectedVersion,
+      Instant now) {
     return jdbc.sql("""
-            UPDATE support_cases SET state = :state, updated_at = :now
-            WHERE tenant_id = :tenantId AND id = :id
+            UPDATE support_cases
+            SET state = :state, updated_at = :now, version = version + 1
+            WHERE tenant_id = :tenantId AND id = :id AND state = :expectedState
+              AND version = :expectedVersion
             """)
         .param("state", state).param("now", Timestamp.from(now)).param("tenantId", tenantId)
-        .param("id", caseId).update() == 1;
+        .param("id", caseId).param("expectedState", expectedState)
+        .param("expectedVersion", expectedVersion).update() == 1;
   }
 
   @Override
@@ -110,7 +119,33 @@ public class JdbcSupportRepository implements SupportRepository {
   }
 
   @Override
-  public void assign(UUID tenantId, UUID caseId, UUID assigneeId, UUID actorId, Instant now) {
+  public boolean hasStaffRole(UUID tenantId, UUID accountId) {
+    return jdbc.sql("""
+            SELECT EXISTS (
+              SELECT 1 FROM tenant_memberships membership
+              JOIN tenant_membership_roles role ON role.membership_id = membership.id
+              WHERE membership.tenant_id = :tenantId
+                AND membership.user_account_id = :accountId
+                AND membership.status = 'ACTIVE'
+                AND role.role IN ('SUPPORT', 'TENANT_ADMIN'))
+            """)
+        .param("tenantId", tenantId).param("accountId", accountId)
+        .query(Boolean.class).single();
+  }
+
+  @Override
+  public boolean assign(
+      UUID tenantId, UUID caseId, UUID assigneeId, UUID actorId, long expectedVersion,
+      Instant now) {
+    int claimed = jdbc.sql("""
+            UPDATE support_cases SET updated_at = :now, version = version + 1
+            WHERE tenant_id = :tenantId AND id = :caseId AND version = :expectedVersion
+            """)
+        .param("now", Timestamp.from(now)).param("tenantId", tenantId).param("caseId", caseId)
+        .param("expectedVersion", expectedVersion).update();
+    if (claimed != 1) {
+      return false;
+    }
     jdbc.sql("""
             UPDATE support_assignments SET active = false, ended_at = :now
             WHERE tenant_id = :tenantId AND case_id = :caseId AND active
@@ -126,6 +161,7 @@ public class JdbcSupportRepository implements SupportRepository {
         .param("id", UUID.randomUUID()).param("tenantId", tenantId).param("caseId", caseId)
         .param("assigneeId", assigneeId).param("actorId", actorId)
         .param("now", Timestamp.from(now)).update();
+    return true;
   }
 
   private SupportCase map(ResultSet rs, int row) throws SQLException {
@@ -133,6 +169,23 @@ public class JdbcSupportRepository implements SupportRepository {
     return new SupportCase(id, rs.getObject("opened_by_account_id", UUID.class),
         rs.getObject("ride_id", UUID.class), rs.getString("subject"), rs.getString("state"),
         rs.getString("priority"), rs.getTimestamp("created_at").toInstant(),
-        rs.getTimestamp("updated_at").toInstant(), List.of());
+        rs.getTimestamp("updated_at").toInstant(), rs.getLong("version"), List.of());
+  }
+
+  private SupportCase withMessages(UUID tenantId, SupportCase supportCase) {
+    List<SupportCase.Message> messages = jdbc.sql("""
+            SELECT id, author_account_id, body, internal, created_at
+            FROM support_messages
+            WHERE tenant_id = :tenantId AND case_id = :caseId
+            ORDER BY created_at, id
+            """)
+        .param("tenantId", tenantId).param("caseId", supportCase.id())
+        .query((rs, row) -> new SupportCase.Message(rs.getObject("id", UUID.class),
+            rs.getObject("author_account_id", UUID.class), rs.getString("body"),
+            rs.getBoolean("internal"), rs.getTimestamp("created_at").toInstant()))
+        .list();
+    return new SupportCase(supportCase.id(), supportCase.openedByAccountId(), supportCase.rideId(),
+        supportCase.subject(), supportCase.state(), supportCase.priority(), supportCase.createdAt(),
+        supportCase.updatedAt(), supportCase.version(), messages);
   }
 }

--- a/src/main/java/in/rsh/cab/support/internal/persistence/SupportRepository.java
+++ b/src/main/java/in/rsh/cab/support/internal/persistence/SupportRepository.java
@@ -20,10 +20,15 @@ public interface SupportRepository {
 
   void insertMessage(UUID tenantId, UUID caseId, SupportCase.Message message);
 
-  boolean updateState(UUID tenantId, UUID caseId, String state, Instant now);
+  boolean updateState(
+      UUID tenantId, UUID caseId, String expectedState, String state, long expectedVersion,
+      Instant now);
 
   void appendState(UUID tenantId, UUID caseId, String from, String to, UUID actorId,
       String reason, Instant now);
 
-  void assign(UUID tenantId, UUID caseId, UUID assigneeId, UUID actorId, Instant now);
+  boolean hasStaffRole(UUID tenantId, UUID accountId);
+
+  boolean assign(
+      UUID tenantId, UUID caseId, UUID assigneeId, UUID actorId, long expectedVersion, Instant now);
 }

--- a/src/main/java/in/rsh/cab/support/internal/web/SupportController.java
+++ b/src/main/java/in/rsh/cab/support/internal/web/SupportController.java
@@ -40,6 +40,11 @@ public class SupportController {
     return support.list();
   }
 
+  @GetMapping("/{id}")
+  public SupportCase get(@PathVariable UUID id) {
+    return support.get(id);
+  }
+
   @PostMapping("/{id}/messages")
   public SupportCase message(@PathVariable UUID id, @Valid @RequestBody MessageRequest request) {
     return support.addMessage(id, request.body(), request.internal());
@@ -47,13 +52,14 @@ public class SupportController {
 
   @PostMapping("/{id}/state")
   public SupportCase state(@PathVariable UUID id, @Valid @RequestBody StateRequest request) {
-    return support.changeState(id, request.state(), request.reason());
+    return support.changeState(
+        id, request.expectedState(), request.state(), request.version(), request.reason());
   }
 
   @PostMapping("/{id}/assignments")
   public ResponseEntity<Void> assign(
       @PathVariable UUID id, @Valid @RequestBody AssignmentRequest request) {
-    support.assign(id, request.assigneeAccountId());
+    support.assign(id, request.assigneeAccountId(), request.version());
     return ResponseEntity.noContent().build();
   }
 
@@ -66,8 +72,13 @@ public class SupportController {
       @NotBlank @Size(max = 4000) String body, boolean internal) {}
 
   public record StateRequest(
+      @NotBlank @Pattern(regexp = "OPEN|IN_PROGRESS|WAITING|RESOLVED|CLOSED")
+          String expectedState,
       @NotBlank @Pattern(regexp = "OPEN|IN_PROGRESS|WAITING|RESOLVED|CLOSED") String state,
+      @jakarta.validation.constraints.PositiveOrZero long version,
       @Size(max = 500) String reason) {}
 
-  public record AssignmentRequest(@NotNull UUID assigneeAccountId) {}
+  public record AssignmentRequest(
+      @NotNull UUID assigneeAccountId,
+      @jakarta.validation.constraints.PositiveOrZero long version) {}
 }

--- a/src/main/java/in/rsh/cab/webhook/EnvironmentSecretResolver.java
+++ b/src/main/java/in/rsh/cab/webhook/EnvironmentSecretResolver.java
@@ -14,8 +14,9 @@ public class EnvironmentSecretResolver implements SecretResolver {
 
   @Override
   public String resolve(String reference) {
-    if (reference == null || !reference.matches("^env:[A-Za-z_][A-Za-z0-9_]*$")) {
-      throw new IllegalArgumentException("Only env secret references are supported");
+    if (reference == null || !reference.matches("^env:CAB_WEBHOOK_[A-Z0-9_]+$")) {
+      throw new IllegalArgumentException(
+          "Webhook secret references must use the env:CAB_WEBHOOK_ prefix");
     }
     String secret = environment.getProperty(reference.substring(4));
     if (secret == null || secret.isBlank()) {

--- a/src/main/java/in/rsh/cab/webhook/WebhookService.java
+++ b/src/main/java/in/rsh/cab/webhook/WebhookService.java
@@ -22,6 +22,7 @@ public class WebhookService {
 
   public static final Set<String> EVENT_ALLOWLIST = Set.of(
       "ride.created", "ride.status_changed", "ride.completed", "ride.cancelled",
+      "ride.driver_assigned", "ride.no_driver",
       "rating.created", "support.case_created", "support.case_state_changed");
   private final WebhookRepository subscriptions;
   private final WebhookSecurity security;
@@ -88,8 +89,9 @@ public class WebhookService {
 
   private void validate(String url, String secretReference, Set<String> eventFilters) {
     security.validate(url);
-    if (secretReference == null || !secretReference.matches("^env:[A-Za-z_][A-Za-z0-9_]*$")) {
-      throw new InvalidRequestException("Webhook secret must be an env: reference");
+    if (secretReference == null || !secretReference.matches("^env:CAB_WEBHOOK_[A-Z0-9_]+$")) {
+      throw new InvalidRequestException(
+          "Webhook secret must use an env:CAB_WEBHOOK_ reference");
     }
     if (eventFilters == null || eventFilters.isEmpty()
         || !EVENT_ALLOWLIST.containsAll(eventFilters)) {

--- a/src/main/java/in/rsh/cab/webhook/internal/web/WebhookController.java
+++ b/src/main/java/in/rsh/cab/webhook/internal/web/WebhookController.java
@@ -36,8 +36,8 @@ public class WebhookController {
   public ResponseEntity<WebhookSubscription> create(@Valid @RequestBody SubscriptionRequest request) {
     WebhookSubscription subscription = webhooks.create(request.url(), request.secretReference(),
         request.eventFilters(), request.enabled());
-    return ResponseEntity.created(URI.create("/api/v1/admin/webhook-subscriptions/"
-        + subscription.id())).body(subscription);
+    return ResponseEntity.created(URI.create("/api/v1/admin/webhook-subscriptions"))
+        .body(subscription);
   }
 
   @GetMapping

--- a/src/main/resources/db/migration/V16__validate_driver_document_constraints.sql
+++ b/src/main/resources/db/migration/V16__validate_driver_document_constraints.sql
@@ -1,0 +1,5 @@
+ALTER TABLE driver_documents
+    VALIDATE CONSTRAINT chk_driver_document_type;
+
+ALTER TABLE driver_documents
+    VALIDATE CONSTRAINT chk_driver_document_review;

--- a/src/main/resources/db/migration/V17__domain_api_consistency.sql
+++ b/src/main/resources/db/migration/V17__domain_api_consistency.sql
@@ -1,0 +1,29 @@
+ALTER TABLE support_cases ADD COLUMN version bigint NOT NULL DEFAULT 0;
+ALTER TABLE safety_incidents ADD COLUMN version bigint NOT NULL DEFAULT 0;
+
+ALTER TABLE rides ADD CONSTRAINT chk_ride_status_timestamps_v17 CHECK (
+    (assigned_at IS NULL OR assigned_at >= requested_at)
+    AND (arrived_at IS NULL OR (assigned_at IS NOT NULL AND arrived_at >= assigned_at))
+    AND (started_at IS NULL OR (arrived_at IS NOT NULL AND started_at >= arrived_at))
+    AND (completed_at IS NULL OR (started_at IS NOT NULL AND completed_at >= started_at))
+    AND (cancelled_at IS NULL OR cancelled_at >= requested_at)
+    AND (status NOT IN ('DRIVER_ASSIGNED', 'DRIVER_ARRIVING', 'DRIVER_ARRIVED',
+                        'IN_PROGRESS', 'COMPLETED') OR assigned_at IS NOT NULL)
+    AND (status NOT IN ('DRIVER_ARRIVED', 'IN_PROGRESS', 'COMPLETED') OR arrived_at IS NOT NULL)
+    AND (status NOT IN ('IN_PROGRESS', 'COMPLETED') OR started_at IS NOT NULL)
+    AND ((status = 'COMPLETED') = (completed_at IS NOT NULL))
+) NOT VALID;
+
+ALTER TABLE rides ADD CONSTRAINT chk_ride_status_assignment_v17 CHECK (
+    (status NOT IN ('DRIVER_ASSIGNED', 'DRIVER_ARRIVING', 'DRIVER_ARRIVED',
+                    'IN_PROGRESS', 'COMPLETED')
+     OR (driver_id IS NOT NULL AND vehicle_id IS NOT NULL AND driver_shift_id IS NOT NULL))
+    AND (status NOT IN ('REQUESTED', 'MATCHING', 'NO_DRIVER')
+     OR (driver_id IS NULL AND vehicle_id IS NULL AND driver_shift_id IS NULL))
+) NOT VALID;
+
+ALTER TABLE rides VALIDATE CONSTRAINT chk_ride_status_timestamps_v17;
+ALTER TABLE rides VALIDATE CONSTRAINT chk_ride_status_assignment_v17;
+
+CREATE INDEX idx_driver_location_created_at_v17
+    ON driver_location_checkpoints (tenant_id, created_at, id);

--- a/src/main/resources/db/migration/V9__notifications_ratings_support_safety_webhooks.sql
+++ b/src/main/resources/db/migration/V9__notifications_ratings_support_safety_webhooks.sql
@@ -201,7 +201,8 @@ CREATE TABLE safety_evidence (
     CONSTRAINT fk_safety_evidence_submitter FOREIGN KEY (tenant_id, submitted_by_account_id)
         REFERENCES tenant_memberships (tenant_id, user_account_id),
     CONSTRAINT chk_safety_evidence_key CHECK (
-        object_key ~ '^[A-Za-z0-9][A-Za-z0-9._/-]{0,511}$'
+        length(object_key) BETWEEN 1 AND 512
+        AND object_key ~ '^[A-Za-z0-9][A-Za-z0-9._/-]*$'
         AND object_key !~ '(^|/)\.\.(/|$)' AND object_key !~ '^[a-zA-Z][a-zA-Z0-9+.-]*:'),
     CONSTRAINT chk_safety_evidence_size CHECK (size_bytes IS NULL OR size_bytes >= 0),
     CONSTRAINT chk_safety_evidence_checksum CHECK

--- a/src/test/java/in/rsh/cab/driver/DriverDocumentServiceTest.java
+++ b/src/test/java/in/rsh/cab/driver/DriverDocumentServiceTest.java
@@ -59,6 +59,8 @@ class DriverDocumentServiceTest {
 
     when(documents.findAll(TENANT, DRIVER)).thenReturn(List.of(submitted));
     assertEquals(List.of(submitted), service.listOwn());
+    when(documents.find(TENANT, DRIVER, submitted.id())).thenReturn(Optional.of(submitted));
+    assertEquals(submitted, service.getOwn(submitted.id()));
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/location/LocationRetentionTest.java
+++ b/src/test/java/in/rsh/cab/location/LocationRetentionTest.java
@@ -1,0 +1,46 @@
+package in.rsh.cab.location;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.rsh.cab.location.internal.persistence.LocationCheckpointRepository;
+import in.rsh.cab.tenancy.TenantExecution;
+import in.rsh.cab.tenancy.internal.persistence.TenantRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class LocationRetentionTest {
+
+  @Test
+  void purgesEachActiveTenantAtConfiguredCutoff() {
+    UUID tenant = UUID.randomUUID();
+    Instant now = Instant.parse("2026-08-09T10:00:00Z");
+    TenantRepository tenants = mock(TenantRepository.class);
+    TenantExecution execution = mock(TenantExecution.class);
+    LocationCheckpointRepository checkpoints = mock(LocationCheckpointRepository.class);
+    when(tenants.findActiveIds()).thenReturn(List.of(tenant));
+    when(execution.inTransaction(org.mockito.ArgumentMatchers.eq(tenant),
+        org.mockito.ArgumentMatchers.<java.util.function.Supplier<Integer>>any()))
+        .thenAnswer(invocation -> invocation
+            .getArgument(1, java.util.function.Supplier.class).get());
+
+    new LocationRetention(tenants, execution, checkpoints,
+        Clock.fixed(now, ZoneOffset.UTC), Duration.ofDays(30), 500).purge();
+
+    verify(checkpoints).deleteCreatedBefore(tenant, now.minus(Duration.ofDays(30)), 500);
+  }
+
+  @Test
+  void rejectsNonPositiveRetention() {
+    assertThrows(IllegalArgumentException.class, () -> new LocationRetention(
+        mock(TenantRepository.class), mock(TenantExecution.class),
+        mock(LocationCheckpointRepository.class), Clock.systemUTC(), Duration.ZERO, 1));
+  }
+}

--- a/src/test/java/in/rsh/cab/pricing/PricingServiceTest.java
+++ b/src/test/java/in/rsh/cab/pricing/PricingServiceTest.java
@@ -244,6 +244,20 @@ class PricingServiceTest {
     assertThrows(TenantAccessDeniedException.class, service::listOwnQuotes);
   }
 
+  @Test
+  void derivesExpiredStatusOnGetAndListWithoutChangingStoredSnapshot() {
+    rider();
+    FareQuote stored = new FareQuote(UUID.randomUUID(), PRODUCT_ID, UUID.randomUUID(), 1,
+        PICKUP, DROPOFF, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, "USD",
+        QuoteStatus.ACTIVE, NOW, "fingerprint", NOW.minusSeconds(60), NOW.minusSeconds(60), 0);
+    when(repository.findQuote(TENANT_ID, ACCOUNT_ID, stored.id())).thenReturn(Optional.of(stored));
+    when(repository.findQuotes(TENANT_ID, ACCOUNT_ID)).thenReturn(List.of(stored));
+
+    assertEquals(QuoteStatus.EXPIRED, service.getOwnQuote(stored.id()).status());
+    assertEquals(QuoteStatus.EXPIRED, service.listOwnQuotes().getFirst().status());
+    assertEquals(QuoteStatus.ACTIVE, stored.status());
+  }
+
   private ServiceProduct product(ProductStatus status) {
     return new ServiceProduct(PRODUCT_ID, "standard", "Standard", status, 4, "STANDARD", NOW, NOW);
   }

--- a/src/test/java/in/rsh/cab/rating/RatingServiceTest.java
+++ b/src/test/java/in/rsh/cab/rating/RatingServiceTest.java
@@ -79,6 +79,17 @@ class RatingServiceTest {
     assertThrows(ConflictException.class, () -> service.create(RIDE, 3, null));
   }
 
+  @Test
+  void participantGetsOwnRating() {
+    context(ACCOUNT, TenantRole.RIDER);
+    Rating rating = new Rating(UUID.randomUUID(), RIDE, ACCOUNT, UUID.randomUUID(), "RIDER",
+        "DRIVER", 5, null, "PUBLISHED", NOW);
+    when(repository.findOwn(TENANT, ACCOUNT, rating.id())).thenReturn(Optional.of(rating));
+
+    assertEquals(rating, service.getOwn(rating.id()));
+    assertThrows(NotFoundException.class, () -> service.getOwn(UUID.randomUUID()));
+  }
+
   private void context(UUID account, TenantRole role) {
     TenantContext.set(new TenantContext(TENANT, account, UUID.randomUUID(), Set.of(role)));
   }

--- a/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
@@ -92,6 +92,18 @@ class RideEventStreamTest {
     TransactionSynchronizationManager.setActualTransactionActive(false);
   }
 
+  @Test
+  void resumeSubscriptionAlwaysStartsWithCurrentSnapshot() throws IOException {
+    Ride ride = ride();
+    context(TenantRole.TENANT_ADMIN);
+    when(rides.find(TENANT, ride.id())).thenReturn(Optional.of(ride));
+
+    stream.subscribe(ride.id(), 1L);
+
+    verify(emitter).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+    assertEquals(1, stream.subscriberCount(TENANT, ride.id()));
+  }
+
   private Ride ride() {
     return new Ride(UUID.randomUUID(), ACCOUNT, UUID.randomUUID(), UUID.randomUUID(),
         new GeoPoint(12.95, 77.6), new GeoPoint(13.0, 77.65), 100, "USD",

--- a/src/test/java/in/rsh/cab/safety/SafetyServiceTest.java
+++ b/src/test/java/in/rsh/cab/safety/SafetyServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import in.rsh.cab.audit.AuditService;
 import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.exception.ConflictException;
 import in.rsh.cab.operations.OutboxService;
 import in.rsh.cab.safety.internal.persistence.SafetyRepository;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
@@ -51,8 +52,11 @@ class SafetyServiceTest {
     context(TenantRole.SAFETY);
     when(repository.find(TENANT, incident.id())).thenReturn(Optional.of(incident), Optional.of(
         new SafetyIncident(incident.id(), RIDE, ACCOUNT, incident.category(), incident.description(),
-            "TRIAGED", "HIGH", NOW, NOW, List.of())));
-    assertEquals("TRIAGED", service.action(incident.id(), "TRIAGE", "TRIAGED", "HIGH", null).state());
+            "TRIAGED", "HIGH", NOW, NOW, 1, List.of())));
+    when(repository.update(TENANT, incident.id(), "REPORTED", "TRIAGED", "HIGH", 0, NOW))
+        .thenReturn(true);
+    assertEquals("TRIAGED", service.action(incident.id(), "TRIAGE", "REPORTED", "TRIAGED",
+        "HIGH", 0, null).state());
     when(repository.findAll(TENANT)).thenReturn(List.of(incident));
     assertEquals(1, service.listRestricted().size());
   }
@@ -64,13 +68,30 @@ class SafetyServiceTest {
         () -> service.report(RIDE, "UNSAFE_DRIVING", "hard braking"));
     assertThrows(TenantAccessDeniedException.class, service::listRestricted);
     SafetyIncident incident = new SafetyIncident(UUID.randomUUID(), RIDE, ACCOUNT, "OTHER", "x",
-        "REPORTED", "UNASSESSED", NOW, NOW, List.of());
+        "REPORTED", "UNASSESSED", NOW, NOW, 0, List.of());
     when(repository.find(TENANT, incident.id())).thenReturn(Optional.of(incident));
     assertThrows(InvalidRequestException.class, () -> service.addEvidence(incident.id(),
         "https://objects.example/evidence", "image/jpeg", 10L, null));
     SafetyIncident.Evidence evidence = service.addEvidence(incident.id(),
         "tenant/incidents/photo.jpg", "image/jpeg", 10L, null);
     verify(repository).insertEvidence(TENANT, incident.id(), evidence);
+  }
+
+  @Test
+  void closedIncidentCannotReopenAndParticipantCanGetHydratedIncident() {
+    SafetyIncident.Evidence evidence = new SafetyIncident.Evidence(UUID.randomUUID(), ACCOUNT,
+        "incident/photo.jpg", "image/jpeg", 10L, null, NOW);
+    SafetyIncident closed = new SafetyIncident(UUID.randomUUID(), RIDE, ACCOUNT, "OTHER", "x",
+        "CLOSED", "HIGH", NOW, NOW, 4, List.of(evidence));
+    when(repository.find(TENANT, closed.id())).thenReturn(Optional.of(closed));
+
+    context(TenantRole.SAFETY);
+    assertThrows(ConflictException.class, () -> service.action(closed.id(), "REOPEN", "CLOSED",
+        "INVESTIGATING", "HIGH", 4, null));
+
+    context(TenantRole.RIDER);
+    when(repository.isRideParticipant(TENANT, RIDE, ACCOUNT)).thenReturn(true);
+    assertEquals(List.of(evidence), service.get(closed.id()).evidence());
   }
 
   private void context(TenantRole role) {

--- a/src/test/java/in/rsh/cab/support/SupportServiceTest.java
+++ b/src/test/java/in/rsh/cab/support/SupportServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import in.rsh.cab.audit.AuditService;
 import in.rsh.cab.exception.InvalidRequestException;
+import in.rsh.cab.exception.ConflictException;
 import in.rsh.cab.operations.OutboxService;
 import in.rsh.cab.support.internal.persistence.SupportRepository;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
@@ -53,9 +54,11 @@ class SupportServiceTest {
     assertEquals(1, service.list().size());
     when(repository.find(TENANT, supportCase.id())).thenReturn(Optional.of(supportCase), Optional.of(
         new SupportCase(supportCase.id(), ACCOUNT, RIDE, "Receipt", "IN_PROGRESS", "NORMAL",
-            NOW, NOW, List.of())));
+            NOW, NOW, 1, List.of())));
+    when(repository.updateState(TENANT, supportCase.id(), "OPEN", "IN_PROGRESS", 0, NOW))
+        .thenReturn(true);
     assertEquals("IN_PROGRESS",
-        service.changeState(supportCase.id(), "IN_PROGRESS", "triaged").state());
+        service.changeState(supportCase.id(), "OPEN", "IN_PROGRESS", 0, "triaged").state());
   }
 
   @Test
@@ -64,13 +67,34 @@ class SupportServiceTest {
     assertThrows(TenantAccessDeniedException.class,
         () -> service.create(RIDE, "Receipt", "Question"));
     SupportCase supportCase = new SupportCase(UUID.randomUUID(), ACCOUNT, null, "Receipt", "OPEN",
-        "NORMAL", NOW, NOW, List.of());
+        "NORMAL", NOW, NOW, 0, List.of());
     when(repository.find(TENANT, supportCase.id())).thenReturn(Optional.of(supportCase));
     assertThrows(TenantAccessDeniedException.class,
         () -> service.addMessage(supportCase.id(), "private", true));
     context(TenantRole.TENANT_ADMIN);
     assertThrows(InvalidRequestException.class,
-        () -> service.changeState(supportCase.id(), "INVALID", null));
+        () -> service.changeState(supportCase.id(), "OPEN", "INVALID", 0, null));
+    assertThrows(ConflictException.class,
+        () -> service.changeState(supportCase.id(), "OPEN", "CLOSED", 1, null));
+  }
+
+  @Test
+  void closedCaseCannotReopenAndAssignmentRequiresPersistedStaffRole() {
+    context(TenantRole.SUPPORT);
+    UUID assignee = UUID.randomUUID();
+    SupportCase closed = new SupportCase(UUID.randomUUID(), ACCOUNT, null, "Receipt", "CLOSED",
+        "NORMAL", NOW, NOW, 3, List.of());
+    when(repository.find(TENANT, closed.id())).thenReturn(Optional.of(closed));
+
+    assertThrows(ConflictException.class,
+        () -> service.changeState(closed.id(), "CLOSED", "IN_PROGRESS", 3, null));
+    assertThrows(InvalidRequestException.class, () -> service.assign(closed.id(), assignee, 3));
+    assertThrows(ConflictException.class, () -> service.assign(closed.id(), assignee, 2));
+
+    when(repository.hasStaffRole(TENANT, assignee)).thenReturn(true);
+    when(repository.assign(TENANT, closed.id(), assignee, ACCOUNT, 3, NOW)).thenReturn(true);
+    service.assign(closed.id(), assignee, 3);
+    verify(repository).assign(TENANT, closed.id(), assignee, ACCOUNT, 3, NOW);
   }
 
   private void context(TenantRole role) {

--- a/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
@@ -98,7 +98,11 @@ class MarketplaceHttpIT {
     registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
     registry.add("springdoc.api-docs.enabled", () -> "true");
     registry.add("springdoc.swagger-ui.enabled", () -> "true");
-    registry.add("rate-limit.requests", () -> "70");
+    registry.add("rate-limit.requests", () -> "500");
+    registry.add("rate-limit.pre-tenant-requests", () -> "2000");
+    registry.add("rate-limit.callback-requests", () -> "100");
+    registry.add("request-limits.max-bytes", () -> "4096");
+    registry.add("request-limits.callback-max-bytes", () -> "2048");
     registry.add("outbox.dispatcher.enabled", () -> "false");
     registry.add("routing.osrm.base-url", () -> "http://localhost:" + OSRM.getAddress().getPort());
   }
@@ -168,6 +172,65 @@ class MarketplaceHttpIT {
     String accountId = JSON.readTree(current.body()).get("accountId").asText();
     assertEquals(
         403, getWithTenant("/api/v1/current-tenant", tenantId, "unknown-user").statusCode());
+
+    HttpResponse<String> invitation =
+        postWithTenant(
+            "/api/v1/current-tenant/invitations",
+            tenantId,
+            "{\"email\":\"invited-user@example.com\",\"roles\":[\"RIDER\"]}");
+    assertEquals(201, invitation.statusCode(), invitation.body());
+    JsonNode invitationBody = JSON.readTree(invitation.body());
+    String invitationToken = invitationBody.get("token").asText();
+    assertFalse(invitationToken.isBlank());
+    assertFalse(
+        jdbc.sql("SELECT token_hash FROM tenant_membership_invitations WHERE id = :id")
+            .param("id", UUID.fromString(invitationBody.get("id").asText()))
+            .query(String.class)
+            .single()
+            .contains(invitationToken));
+    HttpResponse<String> invitationAccepted =
+        postWithBearer(
+            "/api/v1/tenant-invitations/accept",
+            "invited-user",
+            "{\"token\":\"" + invitationToken + "\"}");
+    assertEquals(200, invitationAccepted.statusCode(), invitationAccepted.body());
+    JsonNode acceptedMembership = JSON.readTree(invitationAccepted.body());
+    assertEquals(tenantId, acceptedMembership.get("tenantId").asText());
+    assertEquals(
+        200, getWithTenant("/api/v1/current-tenant", tenantId, "invited-user").statusCode());
+    assertEquals(
+        400,
+        postWithTenantBearer("/api/v1/current-tenant/roles/DRIVER", tenantId, "invited-user", "")
+            .statusCode());
+    assertEquals(
+        403,
+        postWithBearer(
+                "/api/v1/tenant-invitations/accept",
+                "different-user",
+                "{\"token\":\"" + invitationToken + "\"}")
+            .statusCode());
+
+    HttpResponse<String> secondTenant =
+        post(
+            "/api/v1/tenants",
+            "{\"slug\":\"second-city\",\"displayName\":\"Second City\",\"defaultCurrency\":\"USD\",\"timezone\":\"UTC\"}");
+    assertEquals(201, secondTenant.statusCode(), secondTenant.body());
+    String secondTenantId = JSON.readTree(secondTenant.body()).get("id").asText();
+    HttpResponse<String> added =
+        postWithTenant(
+            "/api/v1/current-tenant/memberships",
+            secondTenantId,
+            "{\"accountId\":\""
+                + acceptedMembership.get("accountId").asText()
+                + "\",\"roles\":[\"SUPPORT\"]}");
+    assertEquals(201, added.statusCode(), added.body());
+    assertEquals(
+        200, getWithTenant("/api/v1/current-tenant", secondTenantId, "invited-user").statusCode());
+
+    HttpResponse<String> oversized =
+        postWithBearer("/api/v1/tenants", "oversized-user", "x".repeat(4097));
+    assertEquals(413, oversized.statusCode(), oversized.body());
+    assertEquals("payload-too-large", JSON.readTree(oversized.body()).get("code").asText());
 
     assertEquals(
         204, postWithTenant("/api/v1/current-tenant/roles/RIDER", tenantId, "").statusCode());
@@ -503,8 +566,9 @@ class MarketplaceHttpIT {
     HttpResponse<String> firstResult = firstAccept.join();
     HttpResponse<String> secondResult = secondAccept.join();
     assertEquals(Set.of(200, 409), Set.of(firstResult.statusCode(), secondResult.statusCode()));
-    HttpResponse<String> accepted = firstResult.statusCode() == 200 ? firstResult : secondResult;
-    assertEquals("DRIVER_ASSIGNED", JSON.readTree(accepted.body()).get("status").asText());
+    HttpResponse<String> acceptedRide =
+        firstResult.statusCode() == 200 ? firstResult : secondResult;
+    assertEquals("DRIVER_ASSIGNED", JSON.readTree(acceptedRide.body()).get("status").asText());
 
     JsonNode arriving = driverRideAction(tenantId, rideId, "arriving", 2);
     assertEquals("DRIVER_ARRIVING", arriving.get("status").asText());
@@ -525,7 +589,13 @@ class MarketplaceHttpIT {
             tenantId,
             "{\"score\":5,\"comment\":\"Safe and professional\"}");
     assertEquals(201, rating.statusCode(), rating.body());
-    assertEquals(5, JSON.readTree(rating.body()).get("score").asInt());
+    JsonNode ratingBody = JSON.readTree(rating.body());
+    assertEquals(5, ratingBody.get("score").asInt());
+    assertEquals(
+        200,
+        getWithTenant(
+                "/api/v1/ratings/" + ratingBody.get("id").asText(), tenantId, "platform-admin")
+            .statusCode());
     assertEquals(
         409,
         postWithTenant("/api/v1/rides/" + rideId + "/ratings", tenantId, "{\"score\":4}")
@@ -540,10 +610,30 @@ class MarketplaceHttpIT {
                 + "\",\"subject\":\"Receipt question\","
                 + "\"message\":\"Please explain the receipt\"}");
     assertEquals(201, supportCase.statusCode(), supportCase.body());
+    JsonNode supportCaseBody = JSON.readTree(supportCase.body());
+    String supportCaseId = supportCaseBody.get("id").asText();
+    JsonNode supportCases =
+        JSON.readTree(getWithTenant("/api/v1/support/cases", tenantId, "platform-admin").body());
+    assertEquals(1, supportCases.size());
+    assertEquals(1, supportCases.get(0).get("messages").size());
     assertEquals(
-        1,
-        JSON.readTree(getWithTenant("/api/v1/support/cases", tenantId, "platform-admin").body())
-            .size());
+        200,
+        getWithTenant("/api/v1/support/cases/" + supportCaseId, tenantId, "platform-admin")
+            .statusCode());
+    assertEquals(
+        200,
+        postWithTenant(
+                "/api/v1/support/cases/" + supportCaseId + "/state",
+                tenantId,
+                "{\"expectedState\":\"OPEN\",\"state\":\"CLOSED\",\"version\":0}")
+            .statusCode());
+    assertEquals(
+        409,
+        postWithTenant(
+                "/api/v1/support/cases/" + supportCaseId + "/state",
+                tenantId,
+                "{\"expectedState\":\"CLOSED\",\"state\":\"IN_PROGRESS\",\"version\":1}")
+            .statusCode());
 
     HttpResponse<String> incident =
         postWithTenant(
@@ -554,10 +644,39 @@ class MarketplaceHttpIT {
                 + "\",\"category\":\"UNSAFE_DRIVING\","
                 + "\"description\":\"Hard braking near the destination\"}");
     assertEquals(201, incident.statusCode(), incident.body());
+    String incidentId = JSON.readTree(incident.body()).get("id").asText();
+    HttpResponse<String> evidence =
+        postWithTenant(
+            "/api/v1/safety/incidents/" + incidentId + "/evidence",
+            tenantId,
+            "{\"objectKey\":\"incidents/photo.jpg\",\"mediaType\":\"image/jpeg\",\"sizeBytes\":10}");
+    assertEquals(201, evidence.statusCode(), evidence.body());
     assertEquals(
         1,
         JSON.readTree(getWithTenant("/api/v1/safety/incidents", tenantId, "platform-admin").body())
+            .get(0)
+            .get("evidence")
             .size());
+    assertEquals(
+        200,
+        getWithTenant("/api/v1/safety/incidents/" + incidentId, tenantId, "platform-admin")
+            .statusCode());
+    assertEquals(
+        200,
+        postWithTenant(
+                "/api/v1/safety/incidents/" + incidentId + "/actions",
+                tenantId,
+                "{\"action\":\"CLOSE\",\"expectedState\":\"REPORTED\","
+                    + "\"state\":\"CLOSED\",\"severity\":\"HIGH\",\"version\":0}")
+            .statusCode());
+    assertEquals(
+        409,
+        postWithTenant(
+                "/api/v1/safety/incidents/" + incidentId + "/actions",
+                tenantId,
+                "{\"action\":\"REOPEN\",\"expectedState\":\"CLOSED\","
+                    + "\"state\":\"INVESTIGATING\",\"severity\":\"HIGH\",\"version\":1}")
+            .statusCode());
 
     HttpResponse<String> preference =
         putWithTenant(
@@ -571,7 +690,7 @@ class MarketplaceHttpIT {
         postWithTenant(
             "/api/v1/admin/webhook-subscriptions",
             tenantId,
-            "{\"url\":\"https://localhost/hook\",\"secretReference\":\"env:WEBHOOK_SECRET\","
+            "{\"url\":\"https://localhost/hook\",\"secretReference\":\"env:CAB_WEBHOOK_SECRET\","
                 + "\"eventFilters\":[\"ride.completed\"],\"enabled\":true,\"version\":0}");
     assertEquals(400, unsafeWebhook.statusCode(), unsafeWebhook.body());
     assertTrue(unsafeWebhook.body().contains("non-public"));
@@ -728,6 +847,7 @@ class MarketplaceHttpIT {
         JSON.readTree(
             getWithTenant("/api/v1/finance/settlements", tenantId, "platform-admin").body());
     assertEquals("COMPLETED", settlements.get(0).get("state").asText());
+    assertEquals(payoutId, settlements.get(0).get("payouts").get(0).get("id").asText());
   }
 
   @Test
@@ -833,7 +953,7 @@ class MarketplaceHttpIT {
     String tenantId = JSON.readTree(created.body()).get("id").asText();
 
     HttpResponse<String> response = null;
-    for (int request = 0; request <= 70; request++) {
+    for (int request = 0; request <= 500; request++) {
       response = getWithTenant("/api/v1/current-tenant", tenantId, "limited-actor");
     }
 
@@ -887,6 +1007,19 @@ class MarketplaceHttpIT {
       throws Exception {
     return httpClient.send(
         tenantPostRequest(path, tenantId, body), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpResponse<String> postWithTenantBearer(
+      String path, String tenantId, String token, String body) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(uri(path))
+            .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + token)
+            .header("X-Tenant-ID", tenantId)
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
   private HttpRequest tenantPostRequest(String path, String tenantId, String body) {
@@ -1042,7 +1175,8 @@ class MarketplaceHttpIT {
               .subject(token)
               .claim(
                   "scope", token.equals("observability") ? "observability.read" : "platform.admin")
-              .claim("email", "admin@example.com")
+              .claim("email", token + "@example.com")
+              .claim("email_verified", true)
               .claim("name", "Platform Admin")
               .build();
     }

--- a/src/test/java/in/rsh/cab/webhook/EnvironmentSecretResolverTest.java
+++ b/src/test/java/in/rsh/cab/webhook/EnvironmentSecretResolverTest.java
@@ -1,0 +1,21 @@
+package in.rsh.cab.webhook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class EnvironmentSecretResolverTest {
+
+  @Test
+  void resolvesOnlyCabWebhookNamespace() {
+    MockEnvironment environment =
+        new MockEnvironment().withProperty("CAB_WEBHOOK_PARTNER", "secret");
+    EnvironmentSecretResolver resolver = new EnvironmentSecretResolver(environment);
+
+    assertEquals("secret", resolver.resolve("env:CAB_WEBHOOK_PARTNER"));
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolve("env:PATH"));
+    assertThrows(IllegalStateException.class, () -> resolver.resolve("env:CAB_WEBHOOK_MISSING"));
+  }
+}

--- a/src/test/java/in/rsh/cab/webhook/WebhookServiceTest.java
+++ b/src/test/java/in/rsh/cab/webhook/WebhookServiceTest.java
@@ -57,7 +57,7 @@ class WebhookServiceTest {
   @Test
   void createsAndListsTenantSubscriptionsWithAudit() {
     WebhookSubscription created =
-        service.create("https://example.com/hook", "env:WEBHOOK_SECRET", FILTERS, true);
+        service.create("https://example.com/hook", "env:CAB_WEBHOOK_SECRET", FILTERS, true);
 
     assertEquals("https://example.com/hook", created.url());
     assertEquals(NOW, created.createdAt());
@@ -68,6 +68,8 @@ class WebhookServiceTest {
 
     when(repository.findAll(TENANT)).thenReturn(List.of(created));
     assertEquals(List.of(created), service.list());
+    assertTrue(WebhookService.EVENT_ALLOWLIST.contains("ride.driver_assigned"));
+    assertTrue(WebhookService.EVENT_ALLOWLIST.contains("ride.no_driver"));
   }
 
   @Test
@@ -78,7 +80,7 @@ class WebhookServiceTest {
     when(repository.update(eq(TENANT), any(), eq(2L))).thenReturn(true);
 
     WebhookSubscription updated = service.update(
-        id, 2, "https://example.com/updated", "env:UPDATED_SECRET", FILTERS, false);
+        id, 2, "https://example.com/updated", "env:CAB_WEBHOOK_UPDATED_SECRET", FILTERS, false);
 
     assertEquals(3, updated.version());
     assertEquals(current.createdAt(), updated.createdAt());
@@ -94,14 +96,14 @@ class WebhookServiceTest {
         () -> service.create("https://example.com", "secret", FILTERS, true));
     assertThrows(
         InvalidRequestException.class,
-        () -> service.create("https://example.com", "env:SECRET", Set.of("payment.captured"), true));
+        () -> service.create("https://example.com", "env:CAB_WEBHOOK_SECRET", Set.of("payment.captured"), true));
 
     UUID missing = UUID.randomUUID();
     when(repository.find(TENANT, missing)).thenReturn(Optional.empty());
     assertThrows(
         NotFoundException.class,
         () -> service.update(
-            missing, 0, "https://example.com", "env:SECRET", FILTERS, true));
+            missing, 0, "https://example.com", "env:CAB_WEBHOOK_SECRET", FILTERS, true));
     assertThrows(NotFoundException.class, () -> service.delete(missing));
 
     UUID stale = UUID.randomUUID();
@@ -109,7 +111,7 @@ class WebhookServiceTest {
     assertThrows(
         ConflictException.class,
         () -> service.update(
-            stale, 1, "https://example.com", "env:SECRET", FILTERS, true));
+            stale, 1, "https://example.com", "env:CAB_WEBHOOK_SECRET", FILTERS, true));
 
     UUID raced = UUID.randomUUID();
     when(repository.find(TENANT, raced)).thenReturn(Optional.of(subscription(raced, 2)));
@@ -117,7 +119,7 @@ class WebhookServiceTest {
     assertThrows(
         ConflictException.class,
         () -> service.update(
-            raced, 2, "https://example.com", "env:SECRET", FILTERS, true));
+            raced, 2, "https://example.com", "env:CAB_WEBHOOK_SECRET", FILTERS, true));
   }
 
   @Test
@@ -133,7 +135,7 @@ class WebhookServiceTest {
     return new WebhookSubscription(
         id,
         "https://example.com/hook",
-        "env:SECRET",
+        "env:CAB_WEBHOOK_SECRET",
         FILTERS,
         true,
         NOW.minusSeconds(60),


### PR DESCRIPTION
## Summary
- Delivers `fix(platform): enforce domain readiness contracts` as part 21 of 26 in the production marketplace stack.
- Contains 47 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/118`
- Head: `stack/21-readiness`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.