### PR TITLE
fix(trust): make support and safety workflows atomic

### DIFF
--- a/src/main/java/in/rsh/cab/notification/NotificationRecipientResolver.java
+++ b/src/main/java/in/rsh/cab/notification/NotificationRecipientResolver.java
@@ -47,6 +47,23 @@ public class NotificationRecipientResolver {
       return jdbc.sql(sql).param("tenantId", event.tenantId())
           .param("aggregateId", event.aggregateId()).query(UUID.class).list();
     }
+    if (event.eventType().startsWith("safety.")) {
+      return jdbc.sql("""
+              SELECT recipient_id FROM (
+                SELECT membership.user_account_id recipient_id
+                FROM tenant_memberships membership
+                JOIN tenant_membership_roles role ON role.membership_id = membership.id
+                WHERE membership.tenant_id = :tenantId AND membership.status = 'ACTIVE'
+                  AND role.role IN ('SAFETY', 'TENANT_ADMIN')
+                UNION
+                SELECT incident.reported_by_account_id recipient_id
+                FROM safety_incidents incident
+                WHERE incident.tenant_id = :tenantId AND incident.id = :incidentId
+              ) recipients ORDER BY recipient_id
+              """)
+          .param("tenantId", event.tenantId()).param("incidentId", event.aggregateId())
+          .query(UUID.class).list();
+    }
     return List.of();
   }
 }

--- a/src/main/java/in/rsh/cab/operations/NotificationOutboxConsumer.java
+++ b/src/main/java/in/rsh/cab/operations/NotificationOutboxConsumer.java
@@ -29,8 +29,10 @@ public class NotificationOutboxConsumer implements OutboxConsumer {
     List<UUID> routed = tenantExecution.inTransaction(
         event.tenantId(), () -> recipients.resolve(event));
     String template = event.eventType().replace('.', '_');
+    String body = event.eventType().startsWith("safety.")
+        ? "A safety incident has an update" : event.eventType();
     for (UUID recipient : routed) {
-      worker.process(event, recipient, "LOCAL", template, event.eventVersion(), event.eventType());
+      worker.process(event, recipient, "LOCAL", template, event.eventVersion(), body);
     }
     return !routed.isEmpty();
   }

--- a/src/main/java/in/rsh/cab/safety/SafetyService.java
+++ b/src/main/java/in/rsh/cab/safety/SafetyService.java
@@ -64,7 +64,8 @@ public class SafetyService {
     // Safety events deliberately stay off the outbound webhook allowlist.
     outbox.append(context.tenantId(), "safety_incident", incident.id(), 0,
         "safety.incident_reported", 1,
-        json.valueToTree(new SafetyEvent(incident.id(), rideId, category)), null);
+        json.valueToTree(new SafetyEvent(
+            incident.id(), rideId, context.accountId(), category)), null);
     audit.record(context.tenantId(), context.accountId(), "safety_incident.report",
         "safety_incident", incident.id(), "SUCCESS",
         json.valueToTree(new SafetyAudit(rideId, category, "REPORTED")));
@@ -94,7 +95,8 @@ public class SafetyService {
 
   @Transactional
   public SafetyIncident.Evidence addEvidence(
-      UUID incidentId, String objectKey, String mediaType, Long sizeBytes, String checksum) {
+      UUID incidentId, long expectedVersion, String objectKey, String mediaType, Long sizeBytes,
+      String checksum) {
     TenantContext context = TenantContext.require();
     SafetyIncident incident = incidents.find(context.tenantId(), incidentId)
         .orElseThrow(() -> new NotFoundException("Safety incident not found"));
@@ -102,13 +104,22 @@ public class SafetyService {
     if (!staff && !incident.reportedByAccountId().equals(context.accountId())) {
       throw new TenantAccessDeniedException("Safety incident access is restricted");
     }
+    if (incident.version() != expectedVersion || "CLOSED".equals(incident.state())) {
+      throw new ConflictException("Safety incident changed or is closed");
+    }
     if (!OBJECT_KEY.matcher(objectKey).matches() || objectKey.contains("../")
         || objectKey.contains("/..") || objectKey.contains(":")) {
       throw new InvalidRequestException("Evidence must be an external object key, not a URL or path traversal");
     }
     SafetyIncident.Evidence evidence = new SafetyIncident.Evidence(UUID.randomUUID(),
         context.accountId(), objectKey, mediaType, sizeBytes, checksum, clock.instant());
-    incidents.insertEvidence(context.tenantId(), incidentId, evidence);
+    if (!incidents.appendEvidence(
+        context.tenantId(), incidentId, expectedVersion, evidence, evidence.createdAt())) {
+      throw new ConflictException("Safety incident changed or is closed");
+    }
+    outbox.append(context.tenantId(), "safety_incident", incidentId, expectedVersion + 1,
+        "safety.evidence_added", 1,
+        json.valueToTree(new SafetyUpdateEvent(incidentId, incident.rideId())), null);
     audit.record(context.tenantId(), context.accountId(), "safety_evidence.add", "safety_incident",
         incidentId, "SUCCESS", json.valueToTree(new EvidenceAudit(evidence.id(), mediaType)));
     return evidence;
@@ -139,6 +150,9 @@ public class SafetyService {
     }
     incidents.appendAction(context.tenantId(), incidentId, context.accountId(), action,
         current.state(), state, note, now);
+    outbox.append(context.tenantId(), "safety_incident", incidentId, expectedVersion + 1,
+        "safety.incident_updated", 1,
+        json.valueToTree(new SafetyUpdateEvent(incidentId, current.rideId())), null);
     audit.record(context.tenantId(), context.accountId(), "safety_incident.action",
         "safety_incident", incidentId, "SUCCESS",
         json.valueToTree(new ActionAudit(action, state, severity)));
@@ -162,7 +176,10 @@ public class SafetyService {
         || context.roles().contains(TenantRole.TENANT_ADMIN);
   }
 
-  private record SafetyEvent(UUID incidentId, UUID rideId, String category) {}
+  private record SafetyEvent(
+      UUID incidentId, UUID rideId, UUID reporterAccountId, String category) {}
+
+  private record SafetyUpdateEvent(UUID incidentId, UUID rideId) {}
 
   private record SafetyAudit(UUID rideId, String category, String state) {}
 

--- a/src/main/java/in/rsh/cab/safety/internal/persistence/JdbcSafetyRepository.java
+++ b/src/main/java/in/rsh/cab/safety/internal/persistence/JdbcSafetyRepository.java
@@ -67,7 +67,19 @@ public class JdbcSafetyRepository implements SafetyRepository {
   }
 
   @Override
-  public void insertEvidence(UUID tenantId, UUID incidentId, SafetyIncident.Evidence evidence) {
+  public boolean appendEvidence(
+      UUID tenantId, UUID incidentId, long expectedVersion, SafetyIncident.Evidence evidence,
+      Instant now) {
+    int claimed = jdbc.sql("""
+            UPDATE safety_incidents SET updated_at = :now, version = version + 1
+            WHERE tenant_id = :tenantId AND id = :incidentId AND version = :expectedVersion
+              AND state <> 'CLOSED'
+            """)
+        .param("now", Timestamp.from(now)).param("tenantId", tenantId)
+        .param("incidentId", incidentId).param("expectedVersion", expectedVersion).update();
+    if (claimed != 1) {
+      return false;
+    }
     jdbc.sql("""
             INSERT INTO safety_evidence
               (id, tenant_id, incident_id, submitted_by_account_id, object_key,
@@ -80,6 +92,7 @@ public class JdbcSafetyRepository implements SafetyRepository {
         .param("mediaType", evidence.mediaType()).param("sizeBytes", evidence.sizeBytes())
         .param("checksum", evidence.checksumSha256()).param("now", Timestamp.from(evidence.createdAt()))
         .update();
+    return true;
   }
 
   @Override

--- a/src/main/java/in/rsh/cab/safety/internal/persistence/SafetyRepository.java
+++ b/src/main/java/in/rsh/cab/safety/internal/persistence/SafetyRepository.java
@@ -16,7 +16,9 @@ public interface SafetyRepository {
 
   List<SafetyIncident> findAll(UUID tenantId);
 
-  void insertEvidence(UUID tenantId, UUID incidentId, SafetyIncident.Evidence evidence);
+  boolean appendEvidence(
+      UUID tenantId, UUID incidentId, long expectedVersion, SafetyIncident.Evidence evidence,
+      Instant now);
 
   boolean update(
       UUID tenantId, UUID incidentId, String expectedState, String state, String severity,

--- a/src/main/java/in/rsh/cab/safety/internal/web/SafetyController.java
+++ b/src/main/java/in/rsh/cab/safety/internal/web/SafetyController.java
@@ -49,7 +49,7 @@ public class SafetyController {
   @PostMapping("/{id}/evidence")
   public ResponseEntity<SafetyIncident.Evidence> evidence(
       @PathVariable UUID id, @Valid @RequestBody EvidenceRequest request) {
-    SafetyIncident.Evidence evidence = safety.addEvidence(id, request.objectKey(),
+    SafetyIncident.Evidence evidence = safety.addEvidence(id, request.version(), request.objectKey(),
         request.mediaType(), request.sizeBytes(), request.checksumSha256());
     return ResponseEntity.created(URI.create("/api/v1/safety/incidents/" + id)).body(evidence);
   }
@@ -66,6 +66,7 @@ public class SafetyController {
       @NotBlank @Size(max = 2000) String description) {}
 
   public record EvidenceRequest(
+      @NotNull @PositiveOrZero Long version,
       @NotBlank @Size(max = 512) String objectKey,
       @NotBlank @Size(max = 120) String mediaType,
       @PositiveOrZero Long sizeBytes,

--- a/src/main/java/in/rsh/cab/support/SupportService.java
+++ b/src/main/java/in/rsh/cab/support/SupportService.java
@@ -91,7 +91,7 @@ public class SupportService {
   }
 
   @Transactional
-  public SupportCase addMessage(UUID caseId, String body, boolean internal) {
+  public SupportCase addMessage(UUID caseId, long expectedVersion, String body, boolean internal) {
     TenantContext context = TenantContext.require();
     SupportCase supportCase = cases.find(context.tenantId(), caseId)
         .orElseThrow(() -> new NotFoundException("Support case not found"));
@@ -101,8 +101,15 @@ public class SupportService {
     if (!isStaff(context) && !supportCase.openedByAccountId().equals(context.accountId())) {
       throw new NotFoundException("Support case not found");
     }
-    cases.insertMessage(context.tenantId(), caseId,
-        new SupportCase.Message(UUID.randomUUID(), context.accountId(), body, internal, clock.instant()));
+    if (supportCase.version() != expectedVersion
+        || !(supportCase.state().equals("OPEN") || supportCase.state().equals("IN_PROGRESS"))) {
+      throw new ConflictException("Support case changed or does not accept messages");
+    }
+    Instant now = clock.instant();
+    if (!cases.appendMessage(context.tenantId(), caseId, expectedVersion,
+        new SupportCase.Message(UUID.randomUUID(), context.accountId(), body, internal, now), now)) {
+      throw new ConflictException("Support case changed or does not accept messages");
+    }
     SupportCase updated = cases.find(context.tenantId(), caseId).orElseThrow();
     return isStaff(context) ? updated : withoutInternalMessages(updated);
   }

--- a/src/main/java/in/rsh/cab/support/internal/persistence/JdbcSupportRepository.java
+++ b/src/main/java/in/rsh/cab/support/internal/persistence/JdbcSupportRepository.java
@@ -91,6 +91,23 @@ public class JdbcSupportRepository implements SupportRepository {
   }
 
   @Override
+  public boolean appendMessage(
+      UUID tenantId, UUID caseId, long expectedVersion, SupportCase.Message message, Instant now) {
+    int claimed = jdbc.sql("""
+            UPDATE support_cases SET updated_at = :now, version = version + 1
+            WHERE tenant_id = :tenantId AND id = :caseId AND version = :expectedVersion
+              AND state IN ('OPEN', 'IN_PROGRESS')
+            """)
+        .param("now", Timestamp.from(now)).param("tenantId", tenantId).param("caseId", caseId)
+        .param("expectedVersion", expectedVersion).update();
+    if (claimed != 1) {
+      return false;
+    }
+    insertMessage(tenantId, caseId, message);
+    return true;
+  }
+
+  @Override
   public boolean updateState(
       UUID tenantId, UUID caseId, String expectedState, String state, long expectedVersion,
       Instant now) {

--- a/src/main/java/in/rsh/cab/support/internal/persistence/SupportRepository.java
+++ b/src/main/java/in/rsh/cab/support/internal/persistence/SupportRepository.java
@@ -20,6 +20,9 @@ public interface SupportRepository {
 
   void insertMessage(UUID tenantId, UUID caseId, SupportCase.Message message);
 
+  boolean appendMessage(
+      UUID tenantId, UUID caseId, long expectedVersion, SupportCase.Message message, Instant now);
+
   boolean updateState(
       UUID tenantId, UUID caseId, String expectedState, String state, long expectedVersion,
       Instant now);

--- a/src/main/java/in/rsh/cab/support/internal/web/SupportController.java
+++ b/src/main/java/in/rsh/cab/support/internal/web/SupportController.java
@@ -47,7 +47,7 @@ public class SupportController {
 
   @PostMapping("/{id}/messages")
   public SupportCase message(@PathVariable UUID id, @Valid @RequestBody MessageRequest request) {
-    return support.addMessage(id, request.body(), request.internal());
+    return support.addMessage(id, request.version(), request.body(), request.internal());
   }
 
   @PostMapping("/{id}/state")
@@ -69,6 +69,7 @@ public class SupportController {
       @NotBlank @Size(max = 4000) String message) {}
 
   public record MessageRequest(
+      @NotNull @jakarta.validation.constraints.PositiveOrZero Long version,
       @NotBlank @Size(max = 4000) String body, boolean internal) {}
 
   public record StateRequest(

--- a/src/test/java/in/rsh/cab/notification/NotificationRecipientResolverTest.java
+++ b/src/test/java/in/rsh/cab/notification/NotificationRecipientResolverTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import in.rsh.cab.operations.OutboxEvent;
 import java.time.Instant;
@@ -23,5 +24,25 @@ class NotificationRecipientResolverTest {
         UUID.randomUUID(), "quote", UUID.randomUUID(), 1, "quote.created", 1,
         new ObjectMapper().createObjectNode(), Instant.now(), null, null, 1, UUID.randomUUID())));
     verify(jdbc, never()).sql(anyString());
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  void safetyEventsRouteThroughRoleAndReporterQuery() {
+    JdbcClient jdbc = mock(JdbcClient.class);
+    JdbcClient.StatementSpec statement = mock(JdbcClient.StatementSpec.class);
+    JdbcClient.MappedQuerySpec query = mock(JdbcClient.MappedQuerySpec.class);
+    UUID staff = UUID.randomUUID();
+    when(jdbc.sql(org.mockito.ArgumentMatchers.contains("tenant_membership_roles")))
+        .thenReturn(statement);
+    when(statement.param(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(statement);
+    when(statement.query(UUID.class)).thenReturn(query);
+    when(query.list()).thenReturn(java.util.List.of(staff));
+    OutboxEvent event = new OutboxEvent(UUID.randomUUID(), UUID.randomUUID(), "safety_incident",
+        UUID.randomUUID(), 0, "safety.incident_reported", 1,
+        new ObjectMapper().createObjectNode(), Instant.now(), null, null, 1, UUID.randomUUID());
+
+    assertEquals(java.util.List.of(staff), new NotificationRecipientResolver(jdbc).resolve(event));
+    verify(statement).param("incidentId", event.aggregateId());
   }
 }

--- a/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import in.rsh.cab.notification.NotificationDeliveryWorker;
 import in.rsh.cab.notification.NotificationRecipientResolver;
 import in.rsh.cab.payment.PaymentOperationWorker;
-import in.rsh.cab.ride.RideStreamRedisPublisher;
 import in.rsh.cab.tenancy.TenantExecution;
 import in.rsh.cab.webhook.WebhookDeliveryWorker;
 import java.time.Instant;
@@ -75,20 +74,6 @@ class OutboxConsumerTest {
 
     verify(worker).process(event, recipient, "LOCAL", "safety_incident_reported", 1,
         "A safety incident has an update");
-  }
-
-  @Test
-  void rideStreamConsumerPublishesAggregateVersion() {
-    RideStreamRedisPublisher publisher = mock(RideStreamRedisPublisher.class);
-    var payload = new ObjectMapper().createObjectNode().put("status", "COMPLETED");
-    OutboxEvent event = new OutboxEvent(UUID.randomUUID(), UUID.randomUUID(), "ride",
-        UUID.randomUUID(), 4, "ride.completed", 1, payload,
-        Instant.parse("2026-08-09T10:00:00Z"), null, null, 1, UUID.randomUUID());
-    assertTrue(new RideStreamOutboxConsumer(publisher).process(event));
-    verify(publisher).publish(org.mockito.ArgumentMatchers.eq(event.tenantId()),
-        org.mockito.ArgumentMatchers.argThat(message -> message.eventId().equals(event.id())
-            && message.rideId().equals(event.aggregateId())
-            && message.version() == event.aggregateVersion()));
   }
 
   private OutboxEvent event(String type) {

--- a/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import in.rsh.cab.notification.NotificationDeliveryWorker;
 import in.rsh.cab.notification.NotificationRecipientResolver;
 import in.rsh.cab.payment.PaymentOperationWorker;
+import in.rsh.cab.ride.RideStreamRedisPublisher;
 import in.rsh.cab.tenancy.TenantExecution;
 import in.rsh.cab.webhook.WebhookDeliveryWorker;
 import java.time.Instant;
@@ -56,6 +57,38 @@ class OutboxConsumerTest {
     assertTrue(consumer.process(event));
     verify(worker).process(event, first, "LOCAL", "ride_completed", 1, "ride.completed");
     verify(worker).process(event, second, "LOCAL", "ride_completed", 1, "ride.completed");
+  }
+
+  @Test
+  void safetyNotificationUsesGenericBody() {
+    NotificationRecipientResolver resolver = mock(NotificationRecipientResolver.class);
+    NotificationDeliveryWorker worker = mock(NotificationDeliveryWorker.class);
+    TenantExecution execution = mock(TenantExecution.class);
+    when(execution.inTransaction(any(), org.mockito.ArgumentMatchers
+        .<java.util.function.Supplier<List<UUID>>>any())).thenAnswer(invocation ->
+            ((java.util.function.Supplier<?>) invocation.getArgument(1)).get());
+    OutboxEvent event = event("safety.incident_reported");
+    UUID recipient = UUID.randomUUID();
+    when(resolver.resolve(event)).thenReturn(List.of(recipient));
+
+    assertTrue(new NotificationOutboxConsumer(resolver, worker, execution).process(event));
+
+    verify(worker).process(event, recipient, "LOCAL", "safety_incident_reported", 1,
+        "A safety incident has an update");
+  }
+
+  @Test
+  void rideStreamConsumerPublishesAggregateVersion() {
+    RideStreamRedisPublisher publisher = mock(RideStreamRedisPublisher.class);
+    var payload = new ObjectMapper().createObjectNode().put("status", "COMPLETED");
+    OutboxEvent event = new OutboxEvent(UUID.randomUUID(), UUID.randomUUID(), "ride",
+        UUID.randomUUID(), 4, "ride.completed", 1, payload,
+        Instant.parse("2026-08-09T10:00:00Z"), null, null, 1, UUID.randomUUID());
+    assertTrue(new RideStreamOutboxConsumer(publisher).process(event));
+    verify(publisher).publish(org.mockito.ArgumentMatchers.eq(event.tenantId()),
+        org.mockito.ArgumentMatchers.argThat(message -> message.eventId().equals(event.id())
+            && message.rideId().equals(event.aggregateId())
+            && message.version() == event.aggregateVersion()));
   }
 
   private OutboxEvent event(String type) {

--- a/src/test/java/in/rsh/cab/safety/SafetyServiceTest.java
+++ b/src/test/java/in/rsh/cab/safety/SafetyServiceTest.java
@@ -70,11 +70,14 @@ class SafetyServiceTest {
     SafetyIncident incident = new SafetyIncident(UUID.randomUUID(), RIDE, ACCOUNT, "OTHER", "x",
         "REPORTED", "UNASSESSED", NOW, NOW, 0, List.of());
     when(repository.find(TENANT, incident.id())).thenReturn(Optional.of(incident));
-    assertThrows(InvalidRequestException.class, () -> service.addEvidence(incident.id(),
+    assertThrows(InvalidRequestException.class, () -> service.addEvidence(incident.id(), 0,
         "https://objects.example/evidence", "image/jpeg", 10L, null));
-    SafetyIncident.Evidence evidence = service.addEvidence(incident.id(),
+    when(repository.appendEvidence(org.mockito.ArgumentMatchers.eq(TENANT),
+        org.mockito.ArgumentMatchers.eq(incident.id()), org.mockito.ArgumentMatchers.eq(0L),
+        org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(NOW))).thenReturn(true);
+    SafetyIncident.Evidence evidence = service.addEvidence(incident.id(), 0,
         "tenant/incidents/photo.jpg", "image/jpeg", 10L, null);
-    verify(repository).insertEvidence(TENANT, incident.id(), evidence);
+    verify(repository).appendEvidence(TENANT, incident.id(), 0, evidence, NOW);
   }
 
   @Test
@@ -92,6 +95,8 @@ class SafetyServiceTest {
     context(TenantRole.RIDER);
     when(repository.isRideParticipant(TENANT, RIDE, ACCOUNT)).thenReturn(true);
     assertEquals(List.of(evidence), service.get(closed.id()).evidence());
+    assertThrows(ConflictException.class, () -> service.addEvidence(closed.id(), 4,
+        "incident/late.jpg", "image/jpeg", 10L, null));
   }
 
   private void context(TenantRole role) {

--- a/src/test/java/in/rsh/cab/support/SupportServiceTest.java
+++ b/src/test/java/in/rsh/cab/support/SupportServiceTest.java
@@ -70,12 +70,34 @@ class SupportServiceTest {
         "NORMAL", NOW, NOW, 0, List.of());
     when(repository.find(TENANT, supportCase.id())).thenReturn(Optional.of(supportCase));
     assertThrows(TenantAccessDeniedException.class,
-        () -> service.addMessage(supportCase.id(), "private", true));
+        () -> service.addMessage(supportCase.id(), 0, "private", true));
     context(TenantRole.TENANT_ADMIN);
     assertThrows(InvalidRequestException.class,
         () -> service.changeState(supportCase.id(), "OPEN", "INVALID", 0, null));
     assertThrows(ConflictException.class,
         () -> service.changeState(supportCase.id(), "OPEN", "CLOSED", 1, null));
+  }
+
+  @Test
+  void messageRequiresCurrentVersionAndOpenCase() {
+    context(TenantRole.RIDER);
+    SupportCase open = new SupportCase(UUID.randomUUID(), ACCOUNT, null, "Receipt", "OPEN",
+        "NORMAL", NOW, NOW, 2, List.of());
+    when(repository.find(TENANT, open.id())).thenReturn(Optional.of(open), Optional.of(
+        new SupportCase(open.id(), ACCOUNT, null, "Receipt", "OPEN", "NORMAL", NOW, NOW, 3,
+            List.of())));
+    when(repository.appendMessage(org.mockito.ArgumentMatchers.eq(TENANT),
+        org.mockito.ArgumentMatchers.eq(open.id()), org.mockito.ArgumentMatchers.eq(2L),
+        org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(NOW))).thenReturn(true);
+    assertEquals(3, service.addMessage(open.id(), 2, "reply", false).version());
+
+    SupportCase closed = new SupportCase(UUID.randomUUID(), ACCOUNT, null, "Receipt", "CLOSED",
+        "NORMAL", NOW, NOW, 4, List.of());
+    when(repository.find(TENANT, closed.id())).thenReturn(Optional.of(closed));
+    assertThrows(ConflictException.class,
+        () -> service.addMessage(closed.id(), 4, "late reply", false));
+    assertThrows(ConflictException.class,
+        () -> service.addMessage(open.id(), 1, "stale reply", false));
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
@@ -621,18 +621,39 @@ class MarketplaceHttpIT {
         getWithTenant("/api/v1/support/cases/" + supportCaseId, tenantId, "platform-admin")
             .statusCode());
     assertEquals(
+        400,
+        postWithTenant(
+                "/api/v1/support/cases/" + supportCaseId + "/messages",
+                tenantId,
+                "{\"body\":\"missing version\",\"internal\":false}")
+            .statusCode());
+    assertEquals(
+        200,
+        postWithTenant(
+                "/api/v1/support/cases/" + supportCaseId + "/messages",
+                tenantId,
+                "{\"version\":0,\"body\":\"We are reviewing this\",\"internal\":true}")
+            .statusCode());
+    assertEquals(
         200,
         postWithTenant(
                 "/api/v1/support/cases/" + supportCaseId + "/state",
                 tenantId,
-                "{\"expectedState\":\"OPEN\",\"state\":\"CLOSED\",\"version\":0}")
+                "{\"expectedState\":\"OPEN\",\"state\":\"CLOSED\",\"version\":1}")
+            .statusCode());
+    assertEquals(
+        409,
+        postWithTenant(
+                "/api/v1/support/cases/" + supportCaseId + "/messages",
+                tenantId,
+                "{\"version\":2,\"body\":\"late\",\"internal\":true}")
             .statusCode());
     assertEquals(
         409,
         postWithTenant(
                 "/api/v1/support/cases/" + supportCaseId + "/state",
                 tenantId,
-                "{\"expectedState\":\"CLOSED\",\"state\":\"IN_PROGRESS\",\"version\":1}")
+                "{\"expectedState\":\"CLOSED\",\"state\":\"IN_PROGRESS\",\"version\":2}")
             .statusCode());
 
     HttpResponse<String> incident =
@@ -649,7 +670,8 @@ class MarketplaceHttpIT {
         postWithTenant(
             "/api/v1/safety/incidents/" + incidentId + "/evidence",
             tenantId,
-            "{\"objectKey\":\"incidents/photo.jpg\",\"mediaType\":\"image/jpeg\",\"sizeBytes\":10}");
+            "{\"version\":0,\"objectKey\":\"incidents/photo.jpg\","
+                + "\"mediaType\":\"image/jpeg\",\"sizeBytes\":10}");
     assertEquals(201, evidence.statusCode(), evidence.body());
     assertEquals(
         1,
@@ -667,7 +689,15 @@ class MarketplaceHttpIT {
                 "/api/v1/safety/incidents/" + incidentId + "/actions",
                 tenantId,
                 "{\"action\":\"CLOSE\",\"expectedState\":\"REPORTED\","
-                    + "\"state\":\"CLOSED\",\"severity\":\"HIGH\",\"version\":0}")
+                    + "\"state\":\"CLOSED\",\"severity\":\"HIGH\",\"version\":1}")
+            .statusCode());
+    assertEquals(
+        409,
+        postWithTenant(
+                "/api/v1/safety/incidents/" + incidentId + "/evidence",
+                tenantId,
+                "{\"version\":2,\"objectKey\":\"incidents/late.jpg\","
+                    + "\"mediaType\":\"image/jpeg\",\"sizeBytes\":10}")
             .statusCode());
     assertEquals(
         409,
@@ -675,7 +705,7 @@ class MarketplaceHttpIT {
                 "/api/v1/safety/incidents/" + incidentId + "/actions",
                 tenantId,
                 "{\"action\":\"REOPEN\",\"expectedState\":\"CLOSED\","
-                    + "\"state\":\"INVESTIGATING\",\"severity\":\"HIGH\",\"version\":1}")
+                    + "\"state\":\"INVESTIGATING\",\"severity\":\"HIGH\",\"version\":2}")
             .statusCode());
 
     HttpResponse<String> preference =


### PR DESCRIPTION
## Summary
- Delivers `fix(trust): make support and safety workflows atomic` as part 23 of 26 in the production marketplace stack.
- Contains 15 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/120`
- Head: `stack/23-support-safety`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.