### PR TITLE
fix(platform): harden distributed runtime boundaries

### DIFF
--- a/src/main/java/in/rsh/cab/config/RideStreamRedisConfiguration.java
+++ b/src/main/java/in/rsh/cab/config/RideStreamRedisConfiguration.java
@@ -1,0 +1,26 @@
+package in.rsh.cab.config;
+
+import in.rsh.cab.ride.RideEventStream;
+import java.nio.charset.StandardCharsets;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import tools.jackson.databind.ObjectMapper;
+
+@Configuration
+public class RideStreamRedisConfiguration {
+
+  @Bean
+  RedisMessageListenerContainer rideStreamRedisListeners(
+      RedisConnectionFactory connectionFactory, RideEventStream stream, ObjectMapper json) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    container.addMessageListener(
+        (message, pattern) ->
+            stream.receive(new String(message.getBody(), StandardCharsets.UTF_8), json),
+        new PatternTopic("cab:{*}:ride-events"));
+    return container;
+  }
+}

--- a/src/main/java/in/rsh/cab/dispatch/DispatchService.java
+++ b/src/main/java/in/rsh/cab/dispatch/DispatchService.java
@@ -212,11 +212,11 @@ public class DispatchService {
   }
 
   private void emit(TenantContext context, Ride ride, String event, String action) {
-    outbox.append(context.tenantId(), "ride", ride.id(), ride.version(), event, 1,
+    UUID eventId = outbox.append(context.tenantId(), "ride", ride.id(), ride.version(), event, 1,
         json.valueToTree(new DispatchEvent(ride.id(), ride.status(), ride.driverId())), null);
     audit.record(context.tenantId(), context.accountId(), action, "ride", ride.id(), "SUCCESS",
         json.valueToTree(new DispatchAudit(ride.status())));
-    eventStream.afterCommit(context.tenantId(), ride);
+    eventStream.afterCommit(context.tenantId(), eventId, ride);
   }
 
   private TenantContext requireAny(TenantRole... roles) {

--- a/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/rsh/cab/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package in.rsh.cab.exception;
 
 import in.rsh.cab.operations.IdempotencyConflictException;
 import in.rsh.cab.payment.PaymentSignatureException;
+import in.rsh.cab.ratelimit.PayloadTooLargeException;
 import in.rsh.cab.ratelimit.RateLimitExceededException;
 import in.rsh.cab.routing.RouteProviderException;
 import in.rsh.cab.tenancy.TenantAccessDeniedException;
@@ -102,6 +103,15 @@ public class GlobalExceptionHandler {
                 "Too many requests",
                 exception.getMessage(),
                 "rate-limit-exceeded"));
+  }
+
+  @ExceptionHandler(PayloadTooLargeException.class)
+  public ResponseEntity<ProblemDetail> handlePayloadTooLarge(PayloadTooLargeException exception) {
+    return problem(
+        HttpStatus.PAYLOAD_TOO_LARGE,
+        "Payload too large",
+        exception.getMessage(),
+        "payload-too-large");
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/in/rsh/cab/location/DriverLocationReconciler.java
+++ b/src/main/java/in/rsh/cab/location/DriverLocationReconciler.java
@@ -5,6 +5,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +20,7 @@ public class DriverLocationReconciler {
   private final LiveLocationStore locations;
   private final Clock clock;
   private final Duration maxAge;
+  private final ConcurrentMap<UUID, UUID> cursors = new ConcurrentHashMap<>();
 
   public DriverLocationReconciler(
       LocationCheckpointRepository checkpoints, LiveLocationStore locations, Clock clock,
@@ -30,14 +33,26 @@ public class DriverLocationReconciler {
 
   public void reconcile(UUID tenantId, int limit) {
     var now = clock.instant();
-    for (DriverLocation location : checkpoints.findLatestEligible(
-        tenantId, now.minus(maxAge), LocalDate.now(clock), limit)) {
+    UUID cursor = cursors.get(tenantId);
+    var page = checkpoints.findLatestEligibleAfter(
+        tenantId, now.minus(maxAge), LocalDate.now(clock), cursor, limit);
+    if (page.isEmpty() && cursor != null) {
+      cursors.remove(tenantId, cursor);
+      page = checkpoints.findLatestEligibleAfter(
+          tenantId, now.minus(maxAge), LocalDate.now(clock), null, limit);
+    }
+    for (DriverLocation location : page) {
       try {
-        locations.update(tenantId, location);
+        if (!locations.isCurrent(tenantId, location)) {
+          locations.update(tenantId, location);
+        }
       } catch (RuntimeException exception) {
         log.warn("Live location reconciliation failed tenant={} shift={}", tenantId,
             location.shiftId(), exception);
       }
+    }
+    if (!page.isEmpty()) {
+      cursors.put(tenantId, page.getLast().shiftId());
     }
   }
 }

--- a/src/main/java/in/rsh/cab/location/LiveLocationStore.java
+++ b/src/main/java/in/rsh/cab/location/LiveLocationStore.java
@@ -10,6 +10,8 @@ public interface LiveLocationStore {
 
   boolean update(UUID tenantId, DriverLocation location);
 
+  boolean isCurrent(UUID tenantId, DriverLocation location);
+
   List<UUID> nearby(
       UUID tenantId, GeoPoint point, double radiusMeters, int limit, Instant now, Duration maxAge);
 }

--- a/src/main/java/in/rsh/cab/location/internal/persistence/JdbcLocationCheckpointRepository.java
+++ b/src/main/java/in/rsh/cab/location/internal/persistence/JdbcLocationCheckpointRepository.java
@@ -46,8 +46,8 @@ public class JdbcLocationCheckpointRepository implements LocationCheckpointRepos
   }
 
   @Override
-  public List<DriverLocation> findLatestEligible(
-      UUID tenantId, Instant recordedSince, LocalDate currentDate, int limit) {
+  public List<DriverLocation> findLatestEligibleAfter(
+      UUID tenantId, Instant recordedSince, LocalDate currentDate, UUID afterShiftId, int limit) {
     return jdbc.sql("""
             SELECT DISTINCT ON (c.shift_id) c.shift_id,
               ST_Y(c.point) AS latitude, ST_X(c.point) AS longitude,
@@ -57,6 +57,7 @@ public class JdbcLocationCheckpointRepository implements LocationCheckpointRepos
             JOIN driver_profiles d ON d.tenant_id = s.tenant_id AND d.id = s.driver_id
             JOIN vehicles v ON v.tenant_id = s.tenant_id AND v.id = s.vehicle_id
             WHERE c.tenant_id = :tenantId AND c.recorded_at >= :recordedSince
+              AND (:afterShiftId IS NULL OR c.shift_id > CAST(:afterShiftId AS uuid))
               AND s.status = 'AVAILABLE' AND d.status = 'APPROVED' AND v.status = 'ACTIVE'
               AND EXISTS (
                 SELECT 1 FROM driver_documents document
@@ -69,6 +70,7 @@ public class JdbcLocationCheckpointRepository implements LocationCheckpointRepos
             LIMIT :limit
             """)
         .param("tenantId", tenantId).param("recordedSince", Timestamp.from(recordedSince))
+        .param("afterShiftId", afterShiftId)
         .param("currentDate", currentDate).param("limit", Math.max(1, Math.min(limit, 500)))
         .query((rs, row) -> new DriverLocation(rs.getObject("shift_id", UUID.class),
             new in.rsh.cab.geography.GeoPoint(rs.getDouble("latitude"), rs.getDouble("longitude")),

--- a/src/main/java/in/rsh/cab/location/internal/persistence/LocationCheckpointRepository.java
+++ b/src/main/java/in/rsh/cab/location/internal/persistence/LocationCheckpointRepository.java
@@ -10,8 +10,8 @@ public interface LocationCheckpointRepository {
 
   boolean insertIfNewer(UUID tenantId, DriverLocation location, Instant createdAt);
 
-  List<DriverLocation> findLatestEligible(
-      UUID tenantId, Instant recordedSince, LocalDate currentDate, int limit);
+  List<DriverLocation> findLatestEligibleAfter(
+      UUID tenantId, Instant recordedSince, LocalDate currentDate, UUID afterShiftId, int limit);
 
   int deleteCreatedBefore(UUID tenantId, Instant cutoff, int limit);
 }

--- a/src/main/java/in/rsh/cab/location/internal/redis/RedisLiveLocationStore.java
+++ b/src/main/java/in/rsh/cab/location/internal/redis/RedisLiveLocationStore.java
@@ -54,6 +54,25 @@ public class RedisLiveLocationStore implements LiveLocationStore {
   }
 
   @Override
+  public boolean isCurrent(UUID tenantId, DriverLocation location) {
+    Object marker = redis.opsForHash().get(
+        metadataKey(tenantId), location.shiftId().toString());
+    if (!(marker instanceof String value)) {
+      return false;
+    }
+    try {
+      int separator = value.indexOf(':');
+      long sequence = Long.parseLong(value.substring(0, separator));
+      long recordedAt = Long.parseLong(value.substring(separator + 1));
+      long expectedRecordedAt = location.recordedAt().toEpochMilli();
+      return sequence > location.sequence() || recordedAt > expectedRecordedAt
+          || (sequence == location.sequence() && recordedAt == expectedRecordedAt);
+    } catch (IllegalArgumentException | IndexOutOfBoundsException exception) {
+      return false;
+    }
+  }
+
+  @Override
   public List<UUID> nearby(
       UUID tenantId, GeoPoint point, double radiusMeters, int limit, Instant now, Duration maxAge) {
     int boundedLimit = Math.max(1, Math.min(limit, 100));

--- a/src/main/java/in/rsh/cab/operations/RideStreamOutboxConsumer.java
+++ b/src/main/java/in/rsh/cab/operations/RideStreamOutboxConsumer.java
@@ -1,0 +1,29 @@
+package in.rsh.cab.operations;
+
+import in.rsh.cab.ride.RideEventStream;
+import in.rsh.cab.ride.RideStatus;
+import in.rsh.cab.ride.RideStreamRedisPublisher;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(10)
+public class RideStreamOutboxConsumer implements OutboxConsumer {
+
+  private final RideStreamRedisPublisher publisher;
+
+  public RideStreamOutboxConsumer(RideStreamRedisPublisher publisher) {
+    this.publisher = publisher;
+  }
+
+  @Override
+  public boolean process(OutboxEvent event) {
+    if (!"ride".equals(event.aggregateType()) || !event.payload().hasNonNull("status")) {
+      return false;
+    }
+    RideStatus status = RideStatus.valueOf(event.payload().get("status").asText());
+    publisher.publish(event.tenantId(), new RideEventStream.RideStatusEvent(
+        event.id(), event.aggregateId(), status, event.aggregateVersion(), event.occurredAt()));
+    return true;
+  }
+}

--- a/src/main/java/in/rsh/cab/ratelimit/ApiAbuseProtectionFilter.java
+++ b/src/main/java/in/rsh/cab/ratelimit/ApiAbuseProtectionFilter.java
@@ -83,7 +83,48 @@ public class ApiAbuseProtectionFilter extends OncePerRequestFilter {
         return;
       }
     }
-    chain.doFilter(request, response);
+    try {
+      chain.doFilter(new SizeLimitedHttpServletRequest(request, maximum), response);
+    } catch (ServletException exception) {
+      if (!isPayloadTooLarge(exception)) {
+        throw exception;
+      }
+      writePayloadTooLarge(response);
+    } catch (IOException exception) {
+      if (!isPayloadTooLarge(exception)) {
+        throw exception;
+      }
+      writePayloadTooLarge(response);
+    } catch (RuntimeException exception) {
+      if (!isPayloadTooLarge(exception)) {
+        throw exception;
+      }
+      writePayloadTooLarge(response);
+    }
+  }
+
+  private void writePayloadTooLarge(HttpServletResponse response) throws IOException {
+    if (response.isCommitted()) {
+      throw new PayloadTooLargeException();
+    }
+    response.resetBuffer();
+    writeProblem(
+        response,
+        413,
+        "Payload too large",
+        "Request body exceeds the configured limit",
+        "payload-too-large");
+  }
+
+  private boolean isPayloadTooLarge(Throwable exception) {
+    Throwable cause = exception;
+    while (cause != null) {
+      if (cause instanceof PayloadTooLargeException) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
   }
 
   private boolean consume(HttpServletResponse response, String key, long limit) throws IOException {

--- a/src/main/java/in/rsh/cab/ratelimit/PayloadTooLargeException.java
+++ b/src/main/java/in/rsh/cab/ratelimit/PayloadTooLargeException.java
@@ -1,0 +1,8 @@
+package in.rsh.cab.ratelimit;
+
+public class PayloadTooLargeException extends RuntimeException {
+
+  public PayloadTooLargeException() {
+    super("Request body exceeds the configured limit");
+  }
+}

--- a/src/main/java/in/rsh/cab/ratelimit/SizeLimitedHttpServletRequest.java
+++ b/src/main/java/in/rsh/cab/ratelimit/SizeLimitedHttpServletRequest.java
@@ -1,0 +1,175 @@
+package in.rsh.cab.ratelimit;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+final class SizeLimitedHttpServletRequest extends HttpServletRequestWrapper {
+
+  private final byte[] body;
+  private ServletInputStream inputStream;
+  private BufferedReader reader;
+
+  SizeLimitedHttpServletRequest(HttpServletRequest request, long maximumBytes) throws IOException {
+    super(request);
+    this.body =
+        new SizeLimitedServletInputStream(request.getInputStream(), maximumBytes).readAllBytes();
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    if (reader != null) {
+      throw new IllegalStateException("getReader() has already been called for this request");
+    }
+    if (inputStream == null) {
+      inputStream = new CachedBodyServletInputStream(body);
+    }
+    return inputStream;
+  }
+
+  @Override
+  public BufferedReader getReader() throws IOException {
+    if (reader != null) {
+      return reader;
+    }
+    if (inputStream != null) {
+      throw new IllegalStateException("getInputStream() has already been called for this request");
+    }
+    Charset charset =
+        getCharacterEncoding() == null
+            ? StandardCharsets.ISO_8859_1
+            : Charset.forName(getCharacterEncoding());
+    inputStream = new CachedBodyServletInputStream(body);
+    reader = new BufferedReader(new InputStreamReader(inputStream, charset));
+    return reader;
+  }
+
+  private static final class CachedBodyServletInputStream extends ServletInputStream {
+
+    private final ByteArrayInputStream delegate;
+
+    private CachedBodyServletInputStream(byte[] body) {
+      this.delegate = new ByteArrayInputStream(body);
+    }
+
+    @Override
+    public int read() {
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) {
+      return delegate.read(bytes, offset, length);
+    }
+
+    @Override
+    public int available() {
+      return delegate.available();
+    }
+
+    @Override
+    public boolean isFinished() {
+      return delegate.available() == 0;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener listener) {
+      try {
+        if (!isFinished()) {
+          listener.onDataAvailable();
+        }
+        if (isFinished()) {
+          listener.onAllDataRead();
+        }
+      } catch (IOException exception) {
+        listener.onError(exception);
+      }
+    }
+  }
+
+  private static final class SizeLimitedServletInputStream extends ServletInputStream {
+
+    private final ServletInputStream delegate;
+    private final long maximumBytes;
+    private long bytesRead;
+
+    private SizeLimitedServletInputStream(ServletInputStream delegate, long maximumBytes) {
+      this.delegate = delegate;
+      this.maximumBytes = maximumBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int value = delegate.read();
+      if (value != -1 && ++bytesRead > maximumBytes) {
+        throw new PayloadTooLargeException();
+      }
+      return value;
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+      if (length == 0) {
+        return 0;
+      }
+      long remaining = maximumBytes - bytesRead;
+      int boundedLength = remaining >= length ? length : (int) remaining + 1;
+      int read = delegate.read(bytes, offset, boundedLength);
+      if (read != -1) {
+        bytesRead += read;
+        if (bytesRead > maximumBytes) {
+          throw new PayloadTooLargeException();
+        }
+      }
+      return read;
+    }
+
+    @Override
+    public long skip(long count) throws IOException {
+      long remaining = maximumBytes - bytesRead;
+      long skipped = delegate.skip(remaining >= count ? count : remaining + 1);
+      bytesRead += skipped;
+      if (bytesRead > maximumBytes) {
+        throw new PayloadTooLargeException();
+      }
+      return skipped;
+    }
+
+    @Override
+    public int available() throws IOException {
+      return delegate.available();
+    }
+
+    @Override
+    public boolean isFinished() {
+      return delegate.isFinished();
+    }
+
+    @Override
+    public boolean isReady() {
+      return delegate.isReady();
+    }
+
+    @Override
+    public void setReadListener(ReadListener listener) {
+      delegate.setReadListener(listener);
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}

--- a/src/main/java/in/rsh/cab/ride/RideEventStream.java
+++ b/src/main/java/in/rsh/cab/ride/RideEventStream.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.LongFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,10 +25,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class RideEventStream {
 
+  private static final Logger log = LoggerFactory.getLogger(RideEventStream.class);
   private static final Set<TenantRole> STAFF =
       Set.of(TenantRole.TENANT_ADMIN, TenantRole.DISPATCHER, TenantRole.SUPPORT);
   private final RideRepository rides;
@@ -34,6 +38,7 @@ public class RideEventStream {
   private final int maxPerActor;
   private final int maxPerRide;
   private final LongFunction<SseEmitter> emitterFactory;
+  private final RideStreamRedisPublisher publisher;
   private final Map<ActorKey, Set<Subscription>> byActor = new HashMap<>();
   private final Map<RideKey, Set<Subscription>> byRide = new HashMap<>();
 
@@ -42,18 +47,20 @@ public class RideEventStream {
       RideRepository rides,
       @Value("${rides.events.timeout:PT5M}") Duration timeout,
       @Value("${rides.events.max-per-actor:3}") int maxPerActor,
-      @Value("${rides.events.max-per-ride:20}") int maxPerRide) {
-    this(rides, timeout, maxPerActor, maxPerRide, SseEmitter::new);
+      @Value("${rides.events.max-per-ride:20}") int maxPerRide,
+      RideStreamRedisPublisher publisher) {
+    this(rides, timeout, maxPerActor, maxPerRide, SseEmitter::new, publisher);
   }
 
   RideEventStream(
       RideRepository rides, Duration timeout, int maxPerActor, int maxPerRide,
-      LongFunction<SseEmitter> emitterFactory) {
+      LongFunction<SseEmitter> emitterFactory, RideStreamRedisPublisher publisher) {
     this.rides = rides;
     this.timeoutMillis = timeout.toMillis();
     this.maxPerActor = maxPerActor;
     this.maxPerRide = maxPerRide;
     this.emitterFactory = emitterFactory;
+    this.publisher = publisher;
   }
 
   @Transactional(readOnly = true)
@@ -94,21 +101,31 @@ public class RideEventStream {
     return subscribe(rideId, null);
   }
 
-  public void afterCommit(UUID tenantId, Ride ride) {
+  public void afterCommit(UUID tenantId, UUID eventId, Ride ride) {
     RideStatusEvent event =
-        new RideStatusEvent(ride.id(), ride.status(), ride.version(), ride.updatedAt());
+        new RideStatusEvent(eventId, ride.id(), ride.status(), ride.version(), ride.updatedAt());
     if (!TransactionSynchronizationManager.isActualTransactionActive()
         || !TransactionSynchronizationManager.isSynchronizationActive()) {
-      publish(tenantId, event);
+      publishRedisBestEffort(tenantId, event);
       return;
     }
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
-            publish(tenantId, event);
+            publishRedisBestEffort(tenantId, event);
           }
         });
+  }
+
+  public void receive(String message, ObjectMapper json) {
+    try {
+      RideStreamRedisPublisher.RideStreamMessage decoded =
+          json.readValue(message, RideStreamRedisPublisher.RideStreamMessage.class);
+      publish(decoded.tenantId(), decoded.event());
+    } catch (RuntimeException exception) {
+      log.warn("Discarding invalid ride stream Redis message", exception);
+    }
   }
 
   void publish(UUID tenantId, RideStatusEvent event) {
@@ -162,7 +179,7 @@ public class RideEventStream {
 
   private SseEmitter.SseEventBuilder statusEvent(Ride ride) {
     return statusEvent(new RideStatusEvent(
-        ride.id(), ride.status(), ride.version(), ride.updatedAt()));
+        null, ride.id(), ride.status(), ride.version(), ride.updatedAt()));
   }
 
   private SseEmitter.SseEventBuilder statusEvent(RideStatusEvent event) {
@@ -179,8 +196,17 @@ public class RideEventStream {
     }
   }
 
+  private void publishRedisBestEffort(UUID tenantId, RideStatusEvent event) {
+    try {
+      publisher.publish(tenantId, event);
+    } catch (RuntimeException exception) {
+      log.warn("Immediate ride stream publish failed; outbox will retry event={}", event.eventId(),
+          exception);
+    }
+  }
+
   public record RideStatusEvent(
-      UUID rideId, RideStatus status, long version, Instant occurredAt) {}
+      UUID eventId, UUID rideId, RideStatus status, long version, Instant occurredAt) {}
 
   private record ActorKey(UUID tenantId, UUID accountId) {}
 

--- a/src/main/java/in/rsh/cab/ride/RideService.java
+++ b/src/main/java/in/rsh/cab/ride/RideService.java
@@ -179,11 +179,11 @@ public class RideService {
   }
 
   private void emit(TenantContext context, Ride ride, String event, String action) {
-    outbox.append(context.tenantId(), "ride", ride.id(), ride.version(), event, 1,
+    UUID eventId = outbox.append(context.tenantId(), "ride", ride.id(), ride.version(), event, 1,
         json.valueToTree(new RideEvent(ride.id(), ride.status(), ride.driverId())), null);
     audit.record(context.tenantId(), context.accountId(), action, "ride", ride.id(), "SUCCESS",
         json.valueToTree(new RideAudit(ride.status())));
-    eventStream.afterCommit(context.tenantId(), ride);
+    eventStream.afterCommit(context.tenantId(), eventId, ride);
   }
 
   private TenantContext require(TenantRole role) {

--- a/src/main/java/in/rsh/cab/ride/RideStreamRedisPublisher.java
+++ b/src/main/java/in/rsh/cab/ride/RideStreamRedisPublisher.java
@@ -1,0 +1,34 @@
+package in.rsh.cab.ride;
+
+import java.util.UUID;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+public class RideStreamRedisPublisher {
+
+  private final StringRedisTemplate redis;
+  private final ObjectMapper json;
+
+  public RideStreamRedisPublisher(StringRedisTemplate redis, ObjectMapper json) {
+    this.redis = redis;
+    this.json = json;
+  }
+
+  public void publish(UUID tenantId, RideEventStream.RideStatusEvent event) {
+    try {
+      redis.convertAndSend(channel(tenantId), json.writeValueAsString(
+          new RideStreamMessage(tenantId, event)));
+    } catch (JacksonException exception) {
+      throw new IllegalStateException("Ride stream event cannot be serialized", exception);
+    }
+  }
+
+  static String channel(UUID tenantId) {
+    return "cab:{" + tenantId + "}:ride-events";
+  }
+
+  public record RideStreamMessage(UUID tenantId, RideEventStream.RideStatusEvent event) {}
+}

--- a/src/test/java/in/rsh/cab/dispatch/DispatchServiceTest.java
+++ b/src/test/java/in/rsh/cab/dispatch/DispatchServiceTest.java
@@ -90,7 +90,7 @@ class DispatchServiceTest {
     assertEquals(1, offers.size());
     assertEquals(driver, offers.get(0).driverId());
     verify(dispatch).insertOffer(TENANT, offers.get(0));
-    verify(eventStream).afterCommit(eq(TENANT), any());
+    verify(eventStream).afterCommit(eq(TENANT), any(), any());
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/location/DriverLocationReconcilerTest.java
+++ b/src/test/java/in/rsh/cab/location/DriverLocationReconcilerTest.java
@@ -3,7 +3,9 @@ package in.rsh.cab.location;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import in.rsh.cab.geography.GeoPoint;
@@ -27,15 +29,43 @@ class DriverLocationReconcilerTest {
     LiveLocationStore locations = mock(LiveLocationStore.class);
     DriverLocation first = new DriverLocation(UUID.randomUUID(), new GeoPoint(1, 2), now, 1);
     DriverLocation second = new DriverLocation(UUID.randomUUID(), new GeoPoint(3, 4), now, 2);
-    when(checkpoints.findLatestEligible(tenant, now.minusSeconds(120),
-        LocalDate.of(2026, 8, 8), 20)).thenReturn(List.of(first, second));
+    when(checkpoints.findLatestEligibleAfter(tenant, now.minusSeconds(120),
+        LocalDate.of(2026, 8, 8), null, 20)).thenReturn(List.of(first, second));
+    when(checkpoints.findLatestEligibleAfter(tenant, now.minusSeconds(120),
+        LocalDate.of(2026, 8, 8), second.shiftId(), 20)).thenReturn(List.of());
+    when(locations.isCurrent(tenant, second)).thenReturn(true);
     when(locations.update(tenant, first)).thenThrow(new IllegalStateException("redis unavailable"));
 
     new DriverLocationReconciler(checkpoints, locations, Clock.fixed(now, ZoneOffset.UTC),
         Duration.ofMinutes(2)).reconcile(tenant, 20);
 
-    verify(locations).update(tenant, second);
-    verify(checkpoints).findLatestEligible(eq(tenant), eq(now.minusSeconds(120)),
-        eq(LocalDate.of(2026, 8, 8)), eq(20));
+    verify(locations).update(tenant, first);
+    verify(locations).isCurrent(tenant, second);
+    verify(locations, never()).update(tenant, second);
+  }
+
+  @Test
+  void advancesTenantCursorAndWrapsAfterLastPage() {
+    UUID tenant = UUID.randomUUID();
+    Instant now = Instant.parse("2026-08-08T10:00:00Z");
+    LocationCheckpointRepository checkpoints = mock(LocationCheckpointRepository.class);
+    LiveLocationStore locations = mock(LiveLocationStore.class);
+    DriverLocation location = new DriverLocation(
+        UUID.randomUUID(), new GeoPoint(1, 2), now, 1);
+    when(checkpoints.findLatestEligibleAfter(tenant, now.minusSeconds(120),
+        LocalDate.of(2026, 8, 8), null, 20)).thenReturn(List.of(location));
+    when(checkpoints.findLatestEligibleAfter(tenant, now.minusSeconds(120),
+        LocalDate.of(2026, 8, 8), location.shiftId(), 20)).thenReturn(List.of());
+    DriverLocationReconciler reconciler = new DriverLocationReconciler(
+        checkpoints, locations, Clock.fixed(now, ZoneOffset.UTC), Duration.ofMinutes(2));
+
+    reconciler.reconcile(tenant, 20);
+    reconciler.reconcile(tenant, 20);
+
+    verify(checkpoints).findLatestEligibleAfter(tenant, now.minusSeconds(120),
+        LocalDate.of(2026, 8, 8), location.shiftId(), 20);
+    verify(checkpoints, times(2)).findLatestEligibleAfter(tenant, now.minusSeconds(120),
+        LocalDate.of(2026, 8, 8), null, 20);
+    verify(locations, times(2)).update(tenant, location);
   }
 }

--- a/src/test/java/in/rsh/cab/location/internal/redis/RedisLiveLocationStoreTest.java
+++ b/src/test/java/in/rsh/cab/location/internal/redis/RedisLiveLocationStoreTest.java
@@ -1,6 +1,8 @@
 package in.rsh.cab.location.internal.redis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doReturn;
@@ -9,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import in.rsh.cab.geography.GeoPoint;
+import in.rsh.cab.location.DriverLocation;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -31,6 +34,22 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 class RedisLiveLocationStoreTest {
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void comparesExactSequenceAndTimestampMarker() {
+    UUID tenant = UUID.randomUUID();
+    DriverLocation location = new DriverLocation(UUID.randomUUID(), new GeoPoint(1, 2),
+        Instant.parse("2026-08-08T10:00:00Z"), 7);
+    StringRedisTemplate redis = mock(StringRedisTemplate.class);
+    HashOperations<String, Object, Object> hashes = mock(HashOperations.class);
+    doReturn(hashes).when(redis).opsForHash();
+    when(hashes.get(any(), any())).thenReturn("8:" + location.recordedAt().toEpochMilli(), "6:1");
+    RedisLiveLocationStore store = new RedisLiveLocationStore(redis);
+
+    assertTrue(store.isCurrent(tenant, location));
+    assertFalse(store.isCurrent(tenant, location));
+  }
 
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
+++ b/src/test/java/in/rsh/cab/operations/OutboxConsumerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import in.rsh.cab.notification.NotificationDeliveryWorker;
 import in.rsh.cab.notification.NotificationRecipientResolver;
 import in.rsh.cab.payment.PaymentOperationWorker;
+import in.rsh.cab.ride.RideStreamRedisPublisher;
 import in.rsh.cab.tenancy.TenantExecution;
 import in.rsh.cab.webhook.WebhookDeliveryWorker;
 import java.time.Instant;
@@ -74,6 +75,20 @@ class OutboxConsumerTest {
 
     verify(worker).process(event, recipient, "LOCAL", "safety_incident_reported", 1,
         "A safety incident has an update");
+  }
+
+  @Test
+  void rideStreamConsumerPublishesAggregateVersion() {
+    RideStreamRedisPublisher publisher = mock(RideStreamRedisPublisher.class);
+    var payload = new ObjectMapper().createObjectNode().put("status", "COMPLETED");
+    OutboxEvent event = new OutboxEvent(UUID.randomUUID(), UUID.randomUUID(), "ride",
+        UUID.randomUUID(), 4, "ride.completed", 1, payload,
+        Instant.parse("2026-08-09T10:00:00Z"), null, null, 1, UUID.randomUUID());
+    assertTrue(new RideStreamOutboxConsumer(publisher).process(event));
+    verify(publisher).publish(org.mockito.ArgumentMatchers.eq(event.tenantId()),
+        org.mockito.ArgumentMatchers.argThat(message -> message.eventId().equals(event.id())
+            && message.rideId().equals(event.aggregateId())
+            && message.version() == event.aggregateVersion()));
   }
 
   private OutboxEvent event(String type) {

--- a/src/test/java/in/rsh/cab/ratelimit/ApiAbuseProtectionFilterTest.java
+++ b/src/test/java/in/rsh/cab/ratelimit/ApiAbuseProtectionFilterTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -75,6 +78,47 @@ class ApiAbuseProtectionFilterTest {
       assertTrue(response.getContentAsString().contains("payload-too-large"));
       assertFalse(chain.getRequest() != null);
     }
+  }
+
+  @Test
+  void rejectsUnknownLengthBodyWhileReadingBeforeCallbackProcessing() throws Exception {
+    AtomicInteger processed = new AtomicInteger();
+    MockHttpServletRequest request =
+        request("/api/v1/payment-providers/fake/accounts/id/events", 513);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain =
+        new MockFilterChain(
+            new HttpServlet() {
+              @Override
+              protected void service(
+                  jakarta.servlet.http.HttpServletRequest servletRequest,
+                  jakarta.servlet.http.HttpServletResponse servletResponse)
+                  throws java.io.IOException {
+                ByteArrayOutputStream body = new ByteArrayOutputStream();
+                body.write(servletRequest.getInputStream().readNBytes(2));
+                processed.incrementAndGet();
+              }
+            });
+
+    filter((key, limit, window) -> new RateLimitDecision(true, 1, 1), 1024, 512)
+        .doFilter(
+            new HttpServletRequestWrapper(request) {
+              @Override
+              public long getContentLengthLong() {
+                return -1;
+              }
+
+              @Override
+              public int getContentLength() {
+                return -1;
+              }
+            },
+            response,
+            chain);
+
+    assertEquals(413, response.getStatus());
+    assertEquals(0, processed.get());
+    assertTrue(response.getContentAsString().contains("payload-too-large"));
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import tools.jackson.databind.ObjectMapper;
 
 class RideEventStreamTest {
 
@@ -34,8 +35,9 @@ class RideEventStreamTest {
   private static final Instant NOW = Instant.parse("2026-08-08T10:00:00Z");
   private final RideRepository rides = mock(RideRepository.class);
   private final SseEmitter emitter = mock(SseEmitter.class);
+  private final RideStreamRedisPublisher publisher = mock(RideStreamRedisPublisher.class);
   private final RideEventStream stream =
-      new RideEventStream(rides, Duration.ofMinutes(1), 1, 1, ignored -> emitter);
+      new RideEventStream(rides, Duration.ofMinutes(1), 1, 1, ignored -> emitter, publisher);
 
   @AfterEach
   void tearDown() {
@@ -55,7 +57,8 @@ class RideEventStreamTest {
     assertEquals(1, stream.subscriberCount(TENANT, ride.id()));
 
     stream.publish(TENANT,
-        new RideEventStream.RideStatusEvent(ride.id(), RideStatus.DRIVER_ASSIGNED, 2, NOW));
+        new RideEventStream.RideStatusEvent(
+            UUID.randomUUID(), ride.id(), RideStatus.DRIVER_ASSIGNED, 2, NOW));
     verify(emitter, times(2))
         .send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
     verify(rides, never()).findAssignedToDriver(TENANT, ACCOUNT, ride.id());
@@ -83,12 +86,14 @@ class RideEventStreamTest {
     TransactionSynchronizationManager.initSynchronization();
     TransactionSynchronizationManager.setActualTransactionActive(true);
 
-    stream.afterCommit(TENANT, ride);
+    UUID eventId = UUID.randomUUID();
+    stream.afterCommit(TENANT, eventId, ride);
     verify(emitter, never()).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
     TransactionSynchronization synchronization =
         TransactionSynchronizationManager.getSynchronizations().get(0);
     synchronization.afterCommit();
-    verify(emitter).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+    verify(publisher).publish(org.mockito.ArgumentMatchers.eq(TENANT),
+        org.mockito.ArgumentMatchers.argThat(event -> event.eventId().equals(eventId)));
     TransactionSynchronizationManager.setActualTransactionActive(false);
   }
 
@@ -102,6 +107,24 @@ class RideEventStreamTest {
 
     verify(emitter).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
     assertEquals(1, stream.subscriberCount(TENANT, ride.id()));
+  }
+
+  @Test
+  void redisMessageFansOutToLocalSubscribers() throws Exception {
+    Ride ride = ride();
+    context(TenantRole.TENANT_ADMIN);
+    when(rides.find(TENANT, ride.id())).thenReturn(Optional.of(ride));
+    stream.subscribe(ride.id());
+    org.mockito.Mockito.clearInvocations(emitter);
+    ObjectMapper json = new ObjectMapper();
+    UUID eventId = UUID.randomUUID();
+    String message = json.writeValueAsString(new RideStreamRedisPublisher.RideStreamMessage(
+        TENANT, new RideEventStream.RideStatusEvent(
+            eventId, ride.id(), RideStatus.IN_PROGRESS, 3, NOW)));
+
+    stream.receive(message, json);
+
+    verify(emitter).send(org.mockito.ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
   }
 
   private Ride ride() {

--- a/src/test/java/in/rsh/cab/ride/RideServiceTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideServiceTest.java
@@ -83,7 +83,7 @@ class RideServiceTest {
     Ride cancelled = service.cancelOwn(created.id(), 0, "changed plans");
     assertEquals(RideStatus.CANCELLED, cancelled.status());
     verify(dispatch).cancelRide(TENANT, created.id(), NOW);
-    verify(eventStream).afterCommit(TENANT, cancelled);
+    verify(eventStream).afterCommit(eq(TENANT), any(), eq(cancelled));
   }
 
   @Test

--- a/src/test/java/in/rsh/cab/ride/RideStreamRedisPublisherTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideStreamRedisPublisherTest.java
@@ -1,0 +1,35 @@
+package in.rsh.cab.ride;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import tools.jackson.databind.ObjectMapper;
+
+class RideStreamRedisPublisherTest {
+
+  @Test
+  void serializesSafeEventToTenantChannel() throws Exception {
+    UUID tenant = UUID.randomUUID();
+    UUID eventId = UUID.randomUUID();
+    StringRedisTemplate redis = mock(StringRedisTemplate.class);
+    ObjectMapper json = new ObjectMapper();
+    RideEventStream.RideStatusEvent event = new RideEventStream.RideStatusEvent(eventId,
+        UUID.randomUUID(), RideStatus.IN_PROGRESS, 5, Instant.parse("2026-08-09T10:00:00Z"));
+
+    new RideStreamRedisPublisher(redis, json).publish(tenant, event);
+
+    ArgumentCaptor<String> payload = ArgumentCaptor.forClass(String.class);
+    verify(redis).convertAndSend(eq(RideStreamRedisPublisher.channel(tenant)), payload.capture());
+    RideStreamRedisPublisher.RideStreamMessage decoded = json.readValue(
+        payload.getValue(), RideStreamRedisPublisher.RideStreamMessage.class);
+    assertEquals(tenant, decoded.tenantId());
+    assertEquals(event, decoded.event());
+  }
+}


### PR DESCRIPTION
## Summary
- Delivers `fix(platform): harden distributed runtime boundaries` as part 24 of 26 in the production marketplace stack.
- Contains 23 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/121`
- Head: `stack/24-distributed-runtime`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.