### PR TITLE
fix(platform): close final production audit gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,18 +201,19 @@ jobs:
 
       - name: Push scanned release image
         id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
-            ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag }}
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            REVISION=${{ needs.prepare.outputs.commit }}
-            CREATED=${{ steps.source.outputs.created }}
-          cache-from: type=gha
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          docker push "${IMAGE_NAME}:${VERSION}"
+          docker push "${IMAGE_NAME}:${RELEASE_TAG}"
+          version_digest="sha256:$(docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}" --raw | sha256sum | cut -d ' ' -f 1)"
+          release_digest="sha256:$(docker buildx imagetools inspect "${IMAGE_NAME}:${RELEASE_TAG}" --raw | sha256sum | cut -d ' ' -f 1)"
+          if [[ ! "$version_digest" =~ ^sha256:[a-f0-9]{64}$ || "$version_digest" != "$release_digest" ]]; then
+            printf '%s\n' 'Published image tags do not resolve to the same valid digest.'
+            exit 1
+          fi
+          printf 'digest=%s\n' "$version_digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest container image
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/deploy/helm/cab-marketplace/templates/_helpers.tpl
+++ b/deploy/helm/cab-marketplace/templates/_helpers.tpl
@@ -31,8 +31,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "cab-marketplace.image" -}}
-{{- if eq .Values.config.springProfilesActive "prod" -}}
-{{- $_ := required "image.digest is required when config.springProfilesActive=prod" .Values.image.digest -}}
+{{- $production := false -}}
+{{- range (splitList "," .Values.config.springProfilesActive) -}}
+{{- if eq (trim .) "prod" -}}
+{{- $production = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $production -}}
+{{- $_ := required "image.digest is required when config.springProfilesActive includes prod" .Values.image.digest -}}
 {{- end -}}
 {{- if .Values.image.digest -}}
 {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.image.digest) -}}

--- a/src/main/java/in/rsh/cab/ride/RideEventStream.java
+++ b/src/main/java/in/rsh/cab/ride/RideEventStream.java
@@ -79,19 +79,22 @@ public class RideEventStream {
           || byRide.getOrDefault(rideKey, Set.of()).size() >= maxPerRide) {
         throw new ConflictException("Too many active ride event streams");
       }
-      Ride current = visibleRide(context, rideId);
+      byActor.computeIfAbsent(actorKey, ignored -> new HashSet<>()).add(subscription);
+      byRide.computeIfAbsent(rideKey, ignored -> new HashSet<>()).add(subscription);
       try {
+        Ride current = visibleRide(context, rideId);
         // Always establish the stream with a full current snapshot. A newer version than the
         // resume hint therefore also supplies the minimal Last-Event-ID catch-up behavior.
         if (lastEventId != null && current.version() <= lastEventId) {
           emitter.send(SseEmitter.event().comment("current ride version already observed"));
         }
         emitter.send(statusEvent(current));
-        byActor.computeIfAbsent(actorKey, ignored -> new HashSet<>()).add(subscription);
-        byRide.computeIfAbsent(rideKey, ignored -> new HashSet<>()).add(subscription);
       } catch (IOException | IllegalStateException exception) {
         remove(subscription);
         throw new IllegalStateException("Could not open ride event stream", exception);
+      } catch (RuntimeException exception) {
+        remove(subscription);
+        throw exception;
       }
     }
     return emitter;

--- a/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
+++ b/src/test/java/in/rsh/cab/ride/RideEventStreamTest.java
@@ -110,6 +110,35 @@ class RideEventStreamTest {
   }
 
   @Test
+  void registersSubscriberBeforeReadingAuthoritativeSnapshot() {
+    Ride ride = ride();
+    context(TenantRole.TENANT_ADMIN);
+    when(rides.find(TENANT, ride.id()))
+        .thenReturn(Optional.of(ride))
+        .thenAnswer(ignored -> {
+          assertEquals(1, stream.subscriberCount(TENANT, ride.id()));
+          return Optional.of(ride);
+        });
+
+    stream.subscribe(ride.id());
+
+    assertEquals(1, stream.subscriberCount(TENANT, ride.id()));
+  }
+
+  @Test
+  void removesRegisteredSubscriberWhenSnapshotReadFails() {
+    Ride ride = ride();
+    context(TenantRole.TENANT_ADMIN);
+    when(rides.find(TENANT, ride.id()))
+        .thenReturn(Optional.of(ride))
+        .thenThrow(new IllegalStateException("database unavailable"));
+
+    assertThrows(IllegalStateException.class, () -> stream.subscribe(ride.id()));
+
+    assertEquals(0, stream.subscriberCount(TENANT, ride.id()));
+  }
+
+  @Test
   void redisMessageFansOutToLocalSubscribers() throws Exception {
     Ride ride = ride();
     context(TenantRole.TENANT_ADMIN);

--- a/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
+++ b/src/test/java/in/rsh/cab/web/MarketplaceHttpIT.java
@@ -14,6 +14,7 @@ import in.rsh.cab.payment.PaymentAccount;
 import in.rsh.cab.payment.PaymentOperationWorker;
 import in.rsh.cab.payment.internal.persistence.PaymentRepository;
 import in.rsh.cab.tenancy.TenantExecution;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -231,6 +232,18 @@ class MarketplaceHttpIT {
         postWithBearer("/api/v1/tenants", "oversized-user", "x".repeat(4097));
     assertEquals(413, oversized.statusCode(), oversized.body());
     assertEquals("payload-too-large", JSON.readTree(oversized.body()).get("code").asText());
+
+    HttpResponse<String> chunkedOversized =
+        postChunked("/api/v1/tenants", "oversized-user", "x".repeat(4097));
+    assertEquals(413, chunkedOversized.statusCode(), chunkedOversized.body());
+    assertEquals("payload-too-large", JSON.readTree(chunkedOversized.body()).get("code").asText());
+
+    HttpResponse<String> chunkedOversizedCallback =
+        postChunked(
+            "/api/v1/payment-providers/fake/accounts/" + UUID.randomUUID() + "/events",
+            null,
+            "x".repeat(2049));
+    assertEquals(413, chunkedOversizedCallback.statusCode(), chunkedOversizedCallback.body());
 
     assertEquals(
         204, postWithTenant("/api/v1/current-tenant/roles/RIDER", tenantId, "").statusCode());
@@ -785,6 +798,12 @@ class MarketplaceHttpIT {
     assertEquals(201, refundResponse.statusCode(), refundResponse.body());
     assertEquals("false", refundResponse.headers().firstValue("Idempotent-Replayed").orElseThrow());
     String refundId = JSON.readTree(refundResponse.body()).get("id").asText();
+    assertEquals(
+        518,
+        JSON.readTree(getWithTenant("/api/v1/driver/earnings", tenantId, "platform-admin").body())
+            .get(0)
+            .get("availableMinor")
+            .asLong());
     HttpResponse<String> replayedRefund =
         postWithTenantAndIdempotency(
             "/api/v1/finance/payments/" + paymentId + "/refunds",
@@ -862,22 +881,65 @@ class MarketplaceHttpIT {
     assertTrue(paymentWorker.process(payoutRequest));
     payoutEvents.forEach(outboxPoller::published);
     Instant payoutTimestamp = Instant.now();
-    String payoutBody =
-        "{\"eventId\":\"payout-event-1\",\"type\":\"PAYOUT_SUCCEEDED\","
+    String payoutFailureBody =
+        "{\"eventId\":\"payout-event-1\",\"type\":\"PAYOUT_FAILED\","
             + "\"paymentId\":null,\"refundId\":null,\"payoutId\":\""
             + payoutId
             + "\","
             + "\"providerObjectId\":\"fake-payout-"
             + payoutId
             + "\",\"providerVersion\":1,"
+            + "\"amountMinor\":518,\"currency\":\"USD\",\"failureCode\":\"DECLINED\"}";
+    assertEquals(
+        200,
+        providerCallback(paymentAccount.id(), payoutTimestamp, payoutFailureBody).statusCode());
+    JsonNode failedSettlements =
+        JSON.readTree(
+            getWithTenant("/api/v1/finance/settlements", tenantId, "platform-admin").body());
+    assertEquals("FAILED", failedSettlements.get(0).get("payouts").get(0).get("state").asText());
+    assertEquals(
+        0,
+        JSON.readTree(getWithTenant("/api/v1/driver/earnings", tenantId, "platform-admin").body())
+            .get(0)
+            .get("availableMinor")
+            .asLong());
+    HttpResponse<String> releaseResponse =
+        postWithTenant("/api/v1/finance/payouts/" + payoutId + "/release-failed", tenantId, "");
+    assertEquals(200, releaseResponse.statusCode(), releaseResponse.body());
+    assertEquals("RELEASED", JSON.readTree(releaseResponse.body()).get("state").asText());
+    HttpResponse<String> repeatedRelease =
+        postWithTenant("/api/v1/finance/payouts/" + payoutId + "/release-failed", tenantId, "");
+    assertEquals(200, repeatedRelease.statusCode(), repeatedRelease.body());
+    assertEquals(
+        518,
+        JSON.readTree(getWithTenant("/api/v1/driver/earnings", tenantId, "platform-admin").body())
+            .get(0)
+            .get("availableMinor")
+            .asLong());
+    String latePayoutSuccessBody =
+        "{\"eventId\":\"payout-event-2\",\"type\":\"PAYOUT_SUCCEEDED\","
+            + "\"paymentId\":null,\"refundId\":null,\"payoutId\":\""
+            + payoutId
+            + "\",\"providerObjectId\":\"fake-payout-"
+            + payoutId
+            + "\",\"providerVersion\":2,"
             + "\"amountMinor\":518,\"currency\":\"USD\",\"failureCode\":null}";
     assertEquals(
-        200, providerCallback(paymentAccount.id(), payoutTimestamp, payoutBody).statusCode());
+        200,
+        providerCallback(paymentAccount.id(), Instant.now(), latePayoutSuccessBody).statusCode());
     JsonNode settlements =
         JSON.readTree(
             getWithTenant("/api/v1/finance/settlements", tenantId, "platform-admin").body());
-    assertEquals("COMPLETED", settlements.get(0).get("state").asText());
+    assertEquals("FAILED", settlements.get(0).get("state").asText());
     assertEquals(payoutId, settlements.get(0).get("payouts").get(0).get("id").asText());
+    assertEquals(
+        "RECONCILIATION_REQUIRED", settlements.get(0).get("payouts").get(0).get("state").asText());
+    assertEquals(
+        518,
+        JSON.readTree(getWithTenant("/api/v1/driver/earnings", tenantId, "platform-admin").body())
+            .get(0)
+            .get("availableMinor")
+            .asLong());
   }
 
   @Test
@@ -1031,6 +1093,26 @@ class MarketplaceHttpIT {
             .POST(HttpRequest.BodyPublishers.ofString(body))
             .build();
     return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpResponse<String> postChunked(String path, String token, String body)
+      throws Exception {
+    HttpRequest.Builder request =
+        HttpRequest.newBuilder(uri(path))
+            .header("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .header("X-Provider-Timestamp", "0")
+            .header("X-Provider-Signature", "invalid");
+    if (token != null) {
+      request.header("Authorization", "Bearer " + token);
+    }
+    return httpClient.send(
+        request
+            .POST(
+                HttpRequest.BodyPublishers.ofInputStream(
+                    () -> new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8))))
+            .build(),
+        HttpResponse.BodyHandlers.ofString());
   }
 
   private HttpResponse<String> postWithTenant(String path, String tenantId, String body)


### PR DESCRIPTION
## Summary
- Delivers `fix(platform): close final production audit gaps` as part 26 of 26 in the production marketplace stack.
- Contains 5 changed files relative to its immediate base.
- Review and merge this PR only after its dependency.

## Stack
- Base/dependency: `https://github.com/rahilsh/cab/pull/123`
- Head: `stack/26-final-audit`

## Validation
- Required CI gate: `./mvnw --batch-mode --no-transfer-progress clean verify`
- Later deployment layers also validate workflows, Compose, Docker, and Helm assets.